### PR TITLE
Fix create session and study location bugs

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -29,6 +29,7 @@ export default function StudyLocationsScreen() {
   const [locationQuery, setLocationQuery] = useState('');
   const [status, setStatus] = useState('Loading study locations...');
   const [isLoading, setIsLoading] = useState(true);
+  const hasLocationSearch = locationQuery.trim().length > 0;
   const filteredLocations = useMemo(() => {
     const normalizedQuery = locationQuery.trim().toLowerCase();
 
@@ -42,7 +43,7 @@ export default function StudyLocationsScreen() {
         location.building,
         location.campusArea,
         location.notes,
-        ...location.tags,
+        ...(Array.isArray(location.tags) ? location.tags : []),
       ]
         .join(' ')
         .toLowerCase()
@@ -144,6 +145,36 @@ export default function StudyLocationsScreen() {
           style={[styles.input, { borderColor: palette.outline, color: palette.text }]}
           value={locationQuery}
         />
+        {hasLocationSearch ? (
+          <View style={styles.searchResults}>
+            <ThemedText style={styles.searchHint}>
+              {filteredLocations.length > 0
+                ? `${filteredLocations.length} matching study spot${
+                    filteredLocations.length === 1 ? '' : 's'
+                  }`
+                : 'No matching study spots yet'}
+            </ThemedText>
+            {filteredLocations.slice(0, 4).map((location) => (
+              <Pressable
+                key={`suggestion-${location.locationId}`}
+                onPress={() => setLocationQuery(location.name)}
+                style={[
+                  styles.searchSuggestion,
+                  {
+                    backgroundColor: palette.surfaceMuted,
+                    borderColor: palette.outline,
+                  },
+                ]}>
+                <View style={styles.searchSuggestionText}>
+                  <ThemedText type="defaultSemiBold">{location.name}</ThemedText>
+                  <ThemedText style={styles.locationArea}>
+                    {location.building} • {location.campusArea}
+                  </ThemedText>
+                </View>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
         <Pressable
           onPress={() => router.push('/sessions')}
           style={[
@@ -198,7 +229,7 @@ export default function StudyLocationsScreen() {
             <ThemedText style={styles.notesText}>{location.notes}</ThemedText>
 
             <View style={styles.tagRow}>
-              {location.tags.map((tag) => (
+              {(Array.isArray(location.tags) ? location.tags : []).map((tag) => (
                 <ThemedView
                   key={`${location.locationId}-${tag}`}
                   style={[
@@ -214,7 +245,7 @@ export default function StudyLocationsScreen() {
             </View>
           </ThemedView>
         ))
-      ) : locationQuery.trim() ? (
+      ) : hasLocationSearch ? (
         <ThemedView
           style={[
             styles.card,
@@ -350,6 +381,21 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     minHeight: 48,
     paddingHorizontal: 16,
+  },
+  searchHint: {
+    fontSize: 14,
+    opacity: 0.7,
+  },
+  searchResults: {
+    gap: 8,
+  },
+  searchSuggestion: {
+    borderRadius: 14,
+    borderWidth: 1,
+    padding: 12,
+  },
+  searchSuggestionText: {
+    gap: 2,
   },
   tag: {
     borderRadius: 999,

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -13,6 +13,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
+import { TimeDropdown } from '@/components/time-dropdown';
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { logOut, subscribeToAuthState } from '@/lib/auth';
@@ -284,8 +285,8 @@ export default function ProfileScreen() {
     }
 
     if (startMinutes === null || endMinutes === null) {
-      setAvailabilityStatus('Enter start and end times in HH:MM format.');
-      Alert.alert('Availability Error', 'Use HH:MM for both start and end time.');
+      setAvailabilityStatus('Choose both a start and end time.');
+      Alert.alert('Availability Error', 'Choose both a start and end time.');
       return;
     }
 
@@ -578,7 +579,7 @@ export default function ProfileScreen() {
         <ThemedText type="subtitle">Choose real days and time blocks</ThemedText>
         <ThemedText style={styles.statusCopy}>{availabilityStatus}</ThemedText>
         <ThemedText style={styles.mutedText}>
-          Pick a real day from the calendar, then add a start and end time in `HH:MM` format.
+          Pick a real day from the calendar, then choose a start and end time.
           Studi will block dates in the past and time slots that have already passed.
         </ThemedText>
         <View style={[styles.calendarCard, { borderColor: palette.outline, backgroundColor: palette.background }]}>
@@ -648,24 +649,28 @@ export default function ProfileScreen() {
           Selected day: {formatDateLabel(selectedAvailabilityDate)}
         </ThemedText>
         <View style={styles.inlineRow}>
-          <TextInput
-            autoCapitalize="none"
-            editable={!isSaving}
-            onChangeText={setAvailabilityStartTime}
-            placeholder="Start (HH:MM)"
-            placeholderTextColor={colorScheme === 'dark' ? '#8aa1a8' : '#7a8f97'}
-            style={[styles.input, styles.flexInput, { borderColor: palette.outline, color: palette.text }]}
-            value={availabilityStartTime}
-          />
-          <TextInput
-            autoCapitalize="none"
-            editable={!isSaving}
-            onChangeText={setAvailabilityEndTime}
-            placeholder="End (HH:MM)"
-            placeholderTextColor={colorScheme === 'dark' ? '#8aa1a8' : '#7a8f97'}
-            style={[styles.input, styles.flexInput, { borderColor: palette.outline, color: palette.text }]}
-            value={availabilityEndTime}
-          />
+          <View style={styles.flexInput}>
+            <TimeDropdown
+              disabled={isSaving}
+              label="Start time"
+              onChange={(time) => {
+                setAvailabilityStartTime(time);
+                setAvailabilityEndTime((currentEndTime) =>
+                  currentEndTime && currentEndTime <= time ? '' : currentEndTime
+                );
+              }}
+              value={availabilityStartTime}
+            />
+          </View>
+          <View style={styles.flexInput}>
+            <TimeDropdown
+              disabled={isSaving}
+              disabledOption={(time) => !!availabilityStartTime && time <= availabilityStartTime}
+              label="End time"
+              onChange={setAvailabilityEndTime}
+              value={availabilityEndTime}
+            />
+          </View>
         </View>
         <Pressable
           disabled={isSaving}

--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
+import { formatTimeLabel, TimeDropdown } from '@/components/time-dropdown';
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { subscribeToAuthState } from '@/lib/auth';
@@ -26,13 +27,6 @@ function combineDateAndTime(date: string, time: string) {
 }
 
 const CALENDAR_WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
-
-const TIME_OPTIONS = Array.from({ length: 33 }, (_, index) => {
-  const totalMinutes = 7 * 60 + index * 30;
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
-});
 
 function startOfMonth(date: Date) {
   return new Date(date.getFullYear(), date.getMonth(), 1);
@@ -79,13 +73,6 @@ function formatDateLabel(date: string) {
     day: 'numeric',
     weekday: 'short',
   });
-}
-
-function formatTimeLabel(time: string) {
-  const [hourValue, minuteValue] = time.split(':').map(Number);
-  const period = hourValue >= 12 ? 'PM' : 'AM';
-  const displayHour = hourValue % 12 === 0 ? 12 : hourValue % 12;
-  return `${displayHour}:${minuteValue.toString().padStart(2, '0')} ${period}`;
 }
 
 function isPastCalendarDate(isoDate: string) {
@@ -485,66 +472,27 @@ export default function CreateSessionScreen() {
           Selected date: {sessionDate ? formatDateLabel(sessionDate) : 'Choose a date'}
         </ThemedText>
 
-        <ThemedText style={styles.sectionLabel}>Start time</ThemedText>
-        <View style={styles.timeChipRow}>
-          {TIME_OPTIONS.map((time) => {
-            const isSelected = startTime === time;
-
-            return (
-              <Pressable
-                key={`start-${time}`}
-                onPress={() => {
-                  setStartTime(time);
-                  setEndTime((currentEndTime) =>
-                    currentEndTime && currentEndTime <= time ? '' : currentEndTime
-                  );
-                }}
-                style={[
-                  styles.timeChip,
-                  {
-                    backgroundColor: isSelected ? palette.tint : palette.surfaceMuted,
-                    borderColor: isSelected ? palette.tint : palette.outline,
-                  },
-                ]}>
-                <ThemedText
-                  type="defaultSemiBold"
-                  lightColor={isSelected ? '#ffffff' : undefined}
-                  darkColor={isSelected ? '#ffffff' : undefined}>
-                  {formatTimeLabel(time)}
-                </ThemedText>
-              </Pressable>
-            );
-          })}
-        </View>
-
-        <ThemedText style={styles.sectionLabel}>End time</ThemedText>
-        <View style={styles.timeChipRow}>
-          {TIME_OPTIONS.map((time) => {
-            const isSelected = endTime === time;
-            const isBeforeStart = !!startTime && time <= startTime;
-
-            return (
-              <Pressable
-                disabled={isBeforeStart}
-                key={`end-${time}`}
-                onPress={() => setEndTime(time)}
-                style={[
-                  styles.timeChip,
-                  {
-                    backgroundColor: isSelected ? palette.tint : palette.surfaceMuted,
-                    borderColor: isSelected ? palette.tint : palette.outline,
-                    opacity: isBeforeStart ? 0.35 : 1,
-                  },
-                ]}>
-                <ThemedText
-                  type="defaultSemiBold"
-                  lightColor={isSelected ? '#ffffff' : undefined}
-                  darkColor={isSelected ? '#ffffff' : undefined}>
-                  {formatTimeLabel(time)}
-                </ThemedText>
-              </Pressable>
-            );
-          })}
+        <View style={styles.timeDropdownRow}>
+          <View style={styles.flexInput}>
+            <TimeDropdown
+              label="Start time"
+              onChange={(time) => {
+                setStartTime(time);
+                setEndTime((currentEndTime) =>
+                  currentEndTime && currentEndTime <= time ? '' : currentEndTime
+                );
+              }}
+              value={startTime}
+            />
+          </View>
+          <View style={styles.flexInput}>
+            <TimeDropdown
+              disabledOption={(time) => !!startTime && time <= startTime}
+              label="End time"
+              onChange={setEndTime}
+              value={endTime}
+            />
+          </View>
         </View>
 
         <ThemedText style={styles.statusText}>
@@ -696,16 +644,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 40,
   },
-  timeChip: {
-    borderRadius: 999,
-    borderWidth: 1,
-    minHeight: 40,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+  flexInput: {
+    flex: 1,
   },
-  timeChipRow: {
+  timeDropdownRow: {
     flexDirection: 'row',
-    flexWrap: 'wrap',
     gap: 10,
   },
   weekday: {

--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -25,6 +25,80 @@ function combineDateAndTime(date: string, time: string) {
   return new Date(`${date}T${time}:00`).toISOString();
 }
 
+const CALENDAR_WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+const TIME_OPTIONS = Array.from({ length: 33 }, (_, index) => {
+  const totalMinutes = 7 * 60 + index * 30;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+});
+
+function startOfMonth(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function addMonths(date: Date, monthOffset: number) {
+  return new Date(date.getFullYear(), date.getMonth() + monthOffset, 1);
+}
+
+function toIsoDate(date: Date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function buildMonthGrid(monthStart: Date) {
+  const firstDayOfMonth = startOfMonth(monthStart);
+  const gridStart = new Date(firstDayOfMonth);
+  gridStart.setDate(firstDayOfMonth.getDate() - firstDayOfMonth.getDay());
+
+  return Array.from({ length: 42 }, (_, index) => {
+    const cellDate = new Date(gridStart);
+    cellDate.setDate(gridStart.getDate() + index);
+
+    return {
+      inCurrentMonth: cellDate.getMonth() === monthStart.getMonth(),
+      isoDate: toIsoDate(cellDate),
+      label: cellDate.getDate().toString(),
+    };
+  });
+}
+
+function formatMonthLabel(date: Date) {
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function formatDateLabel(date: string) {
+  return new Date(`${date}T12:00:00`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
+function formatTimeLabel(time: string) {
+  const [hourValue, minuteValue] = time.split(':').map(Number);
+  const period = hourValue >= 12 ? 'PM' : 'AM';
+  const displayHour = hourValue % 12 === 0 ? 12 : hourValue % 12;
+  return `${displayHour}:${minuteValue.toString().padStart(2, '0')} ${period}`;
+}
+
+function isPastCalendarDate(isoDate: string) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const parsedDate = new Date(`${isoDate}T12:00:00`);
+  return parsedDate < today;
+}
+
+function isSessionStartInPast(date: string, time: string) {
+  return new Date(`${date}T${time}:00`) <= new Date();
+}
+
 export default function CreateSessionScreen() {
   const { classId: requestedClassId } = useLocalSearchParams<{ classId?: string }>();
   const colorScheme = useColorScheme() ?? 'light';
@@ -36,8 +110,8 @@ export default function CreateSessionScreen() {
   const [locationQuery, setLocationQuery] = useState('');
   const [selectedClass, setSelectedClass] = useState('');
   const [selectedLocationId, setSelectedLocationId] = useState('');
-  const [title, setTitle] = useState('');
   const [sessionDate, setSessionDate] = useState('');
+  const [selectedCalendarMonth, setSelectedCalendarMonth] = useState(() => startOfMonth(new Date()));
   const [startTime, setStartTime] = useState('');
   const [endTime, setEndTime] = useState('');
   const [status, setStatus] = useState('Sign in to create a study session.');
@@ -63,6 +137,11 @@ export default function CreateSessionScreen() {
         .includes(normalizedQuery)
     );
   }, [locationQuery, locations]);
+  const calendarDays = useMemo(() => buildMonthGrid(selectedCalendarMonth), [selectedCalendarMonth]);
+  const canGoToPreviousMonth = useMemo(() => {
+    const currentMonthStart = startOfMonth(new Date());
+    return selectedCalendarMonth > currentMonthStart;
+  }, [selectedCalendarMonth]);
 
   useEffect(() => {
     const unsubscribe = subscribeToAuthState((user) => {
@@ -114,10 +193,6 @@ export default function CreateSessionScreen() {
           ? currentSelectedLocationId
           : loadedLocations[0]?.locationId ?? ''
       );
-      setTitle((currentTitle) =>
-        currentTitle ||
-        (defaultClass ? `${defaultClass} Study Session` : '')
-      );
       setStatus(
         profileClasses.length > 0 && loadedLocations.length > 0
           ? 'Pick a class, location, and time to create a session.'
@@ -148,8 +223,18 @@ export default function CreateSessionScreen() {
       return;
     }
 
-    if (!selectedClass || !selectedLocationId || !title.trim() || !sessionDate || !startTime || !endTime) {
-      Alert.alert('Missing Info', 'Fill out class, location, title, date, and start/end times.');
+    if (!selectedClass || !selectedLocationId || !sessionDate || !startTime || !endTime) {
+      Alert.alert('Missing Info', 'Fill out class, location, date, and start/end times.');
+      return;
+    }
+
+    if (endTime <= startTime) {
+      Alert.alert('Time Error', 'Choose an end time later than the start time.');
+      return;
+    }
+
+    if (isSessionStartInPast(sessionDate, startTime)) {
+      Alert.alert('Date Error', 'Choose a future date and start time for your session.');
       return;
     }
 
@@ -159,13 +244,12 @@ export default function CreateSessionScreen() {
         classId: selectedClass,
         hostId: currentUser.uid,
         locationId: selectedLocationId,
-        title: title.trim(),
+        title: `${selectedClass} Study Session`,
         startTime: combineDateAndTime(sessionDate, startTime),
         endTime: combineDateAndTime(sessionDate, endTime),
       });
 
       setStatus(`Session created successfully. Session ID: ${sessionId}`);
-      setTitle('');
       setSessionDate('');
       setStartTime('');
       setEndTime('');
@@ -333,70 +417,141 @@ export default function CreateSessionScreen() {
           { backgroundColor: palette.surface, borderColor: palette.border },
         ]}>
         <ThemedText style={styles.sectionLabel}>Step 3</ThemedText>
-        <ThemedText type="subtitle">Session details</ThemedText>
+        <ThemedText type="subtitle">Pick date and time</ThemedText>
+        <ThemedText style={styles.statusText}>
+          Studi will name the session from your selected class.
+        </ThemedText>
 
-        <TextInput
-          onChangeText={setTitle}
-          placeholder="Session title"
-          placeholderTextColor={colorScheme === 'dark' ? '#8aa1a8' : '#7a8f97'}
-          style={[
-            styles.input,
-            {
-              borderColor: palette.outline,
-              color: palette.text,
-            },
-          ]}
-          value={title}
-        />
+        <View style={[styles.calendar, { borderColor: palette.outline }]}>
+          <View style={styles.calendarHeader}>
+            <Pressable
+              disabled={!canGoToPreviousMonth}
+              onPress={() => setSelectedCalendarMonth((currentMonth) => addMonths(currentMonth, -1))}
+              style={[
+                styles.monthButton,
+                {
+                  borderColor: palette.outline,
+                  opacity: canGoToPreviousMonth ? 1 : 0.35,
+                },
+              ]}>
+              <ThemedText type="defaultSemiBold">{'<'}</ThemedText>
+            </Pressable>
+            <ThemedText type="defaultSemiBold">{formatMonthLabel(selectedCalendarMonth)}</ThemedText>
+            <Pressable
+              onPress={() => setSelectedCalendarMonth((currentMonth) => addMonths(currentMonth, 1))}
+              style={[styles.monthButton, { borderColor: palette.outline }]}>
+              <ThemedText type="defaultSemiBold">{'>'}</ThemedText>
+            </Pressable>
+          </View>
 
-        <TextInput
-          autoCapitalize="none"
-          onChangeText={setSessionDate}
-          placeholder="Date (YYYY-MM-DD)"
-          placeholderTextColor={colorScheme === 'dark' ? '#8aa1a8' : '#7a8f97'}
-          style={[
-            styles.input,
-            {
-              borderColor: palette.outline,
-              color: palette.text,
-            },
-          ]}
-          value={sessionDate}
-        />
+          <View style={styles.weekdayRow}>
+            {CALENDAR_WEEKDAYS.map((weekday) => (
+              <ThemedText key={weekday} style={styles.weekday}>
+                {weekday}
+              </ThemedText>
+            ))}
+          </View>
 
-        <View style={styles.timeRow}>
-          <TextInput
-            autoCapitalize="none"
-            onChangeText={setStartTime}
-            placeholder="Start (HH:MM)"
-            placeholderTextColor={colorScheme === 'dark' ? '#8aa1a8' : '#7a8f97'}
-            style={[
-              styles.input,
-              styles.flexInput,
-              {
-                borderColor: palette.outline,
-                color: palette.text,
-              },
-            ]}
-            value={startTime}
-          />
+          <View style={styles.calendarGrid}>
+            {calendarDays.map((calendarDay) => {
+              const isSelected = sessionDate === calendarDay.isoDate;
+              const isPast = isPastCalendarDate(calendarDay.isoDate);
 
-          <TextInput
-            autoCapitalize="none"
-            onChangeText={setEndTime}
-            placeholder="End (HH:MM)"
-            placeholderTextColor={colorScheme === 'dark' ? '#8aa1a8' : '#7a8f97'}
-            style={[
-              styles.input,
-              styles.flexInput,
-              {
-                borderColor: palette.outline,
-                color: palette.text,
-              },
-            ]}
-            value={endTime}
-          />
+              return (
+                <Pressable
+                  disabled={isPast}
+                  key={calendarDay.isoDate}
+                  onPress={() => setSessionDate(calendarDay.isoDate)}
+                  style={[
+                    styles.dateCell,
+                    {
+                      backgroundColor: isSelected ? palette.tint : 'transparent',
+                      opacity: calendarDay.inCurrentMonth && !isPast ? 1 : 0.34,
+                    },
+                  ]}>
+                  <ThemedText
+                    type={isSelected ? 'defaultSemiBold' : 'default'}
+                    lightColor={isSelected ? '#ffffff' : undefined}
+                    darkColor={isSelected ? '#ffffff' : undefined}>
+                    {calendarDay.label}
+                  </ThemedText>
+                </Pressable>
+              );
+            })}
+          </View>
         </View>
+
+        <ThemedText type="defaultSemiBold">
+          Selected date: {sessionDate ? formatDateLabel(sessionDate) : 'Choose a date'}
+        </ThemedText>
+
+        <ThemedText style={styles.sectionLabel}>Start time</ThemedText>
+        <View style={styles.timeChipRow}>
+          {TIME_OPTIONS.map((time) => {
+            const isSelected = startTime === time;
+
+            return (
+              <Pressable
+                key={`start-${time}`}
+                onPress={() => {
+                  setStartTime(time);
+                  setEndTime((currentEndTime) =>
+                    currentEndTime && currentEndTime <= time ? '' : currentEndTime
+                  );
+                }}
+                style={[
+                  styles.timeChip,
+                  {
+                    backgroundColor: isSelected ? palette.tint : palette.surfaceMuted,
+                    borderColor: isSelected ? palette.tint : palette.outline,
+                  },
+                ]}>
+                <ThemedText
+                  type="defaultSemiBold"
+                  lightColor={isSelected ? '#ffffff' : undefined}
+                  darkColor={isSelected ? '#ffffff' : undefined}>
+                  {formatTimeLabel(time)}
+                </ThemedText>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <ThemedText style={styles.sectionLabel}>End time</ThemedText>
+        <View style={styles.timeChipRow}>
+          {TIME_OPTIONS.map((time) => {
+            const isSelected = endTime === time;
+            const isBeforeStart = !!startTime && time <= startTime;
+
+            return (
+              <Pressable
+                disabled={isBeforeStart}
+                key={`end-${time}`}
+                onPress={() => setEndTime(time)}
+                style={[
+                  styles.timeChip,
+                  {
+                    backgroundColor: isSelected ? palette.tint : palette.surfaceMuted,
+                    borderColor: isSelected ? palette.tint : palette.outline,
+                    opacity: isBeforeStart ? 0.35 : 1,
+                  },
+                ]}>
+                <ThemedText
+                  type="defaultSemiBold"
+                  lightColor={isSelected ? '#ffffff' : undefined}
+                  darkColor={isSelected ? '#ffffff' : undefined}>
+                  {formatTimeLabel(time)}
+                </ThemedText>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <ThemedText style={styles.statusText}>
+          {startTime && endTime
+            ? `Selected time: ${formatTimeLabel(startTime)}-${formatTimeLabel(endTime)}`
+            : 'Choose a start and end time.'}
+        </ThemedText>
 
         <Pressable
           disabled={isSaving || isLoading}
@@ -486,8 +641,28 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     gap: 10,
   },
-  flexInput: {
-    flex: 1,
+  calendar: {
+    borderRadius: 18,
+    borderWidth: 1,
+    gap: 12,
+    padding: 14,
+  },
+  calendarGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    rowGap: 8,
+  },
+  calendarHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  dateCell: {
+    alignItems: 'center',
+    borderRadius: 999,
+    height: 40,
+    justifyContent: 'center',
+    width: `${100 / 7}%`,
   },
   input: {
     borderRadius: 14,
@@ -513,8 +688,32 @@ const styles = StyleSheet.create({
     minHeight: 52,
     paddingHorizontal: 16,
   },
-  timeRow: {
+  monthButton: {
+    alignItems: 'center',
+    borderRadius: 999,
+    borderWidth: 1,
+    height: 40,
+    justifyContent: 'center',
+    width: 40,
+  },
+  timeChip: {
+    borderRadius: 999,
+    borderWidth: 1,
+    minHeight: 40,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  timeChipRow: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     gap: 10,
+  },
+  weekday: {
+    opacity: 0.65,
+    textAlign: 'center',
+    width: `${100 / 7}%`,
+  },
+  weekdayRow: {
+    flexDirection: 'row',
   },
 });

--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useLocalSearchParams } from 'expo-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useFocusEffect, useLocalSearchParams } from 'expo-router';
 import {
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -54,7 +56,7 @@ export default function CreateSessionScreen() {
         location.building,
         location.campusArea,
         location.notes,
-        ...location.tags,
+        ...(Array.isArray(location.tags) ? location.tags : []),
       ]
         .join(' ')
         .toLowerCase()
@@ -70,54 +72,75 @@ export default function CreateSessionScreen() {
     return unsubscribe;
   }, []);
 
-  useEffect(() => {
-    async function loadSetupData() {
-      if (!currentUser) {
-        setClasses([]);
-        setLocations([]);
-        setStatus('Sign in to create a study session.');
-        setIsLoading(false);
-        return;
-      }
-
-      try {
-        setIsLoading(true);
-        const [profile, loadedLocations] = await Promise.all([
-          getUserProfile(currentUser.uid),
-          getLocations(),
-        ]);
-
-        const profileClasses = profile?.classes ?? [];
-        const normalizedRequestedClass = requestedClassId?.trim().toUpperCase() ?? '';
-        setClasses(profileClasses);
-        setLocations(loadedLocations);
-        setSelectedClass(
-          normalizedRequestedClass && profileClasses.includes(normalizedRequestedClass)
-            ? normalizedRequestedClass
-            : profileClasses[0] ?? ''
-        );
-        setSelectedLocationId(loadedLocations[0]?.locationId ?? '');
-        setTitle(
-          normalizedRequestedClass && profileClasses.includes(normalizedRequestedClass)
-            ? `${normalizedRequestedClass} Study Session`
-            : ''
-        );
-        setStatus(
-          profileClasses.length > 0 && loadedLocations.length > 0
-            ? 'Pick a class, location, and time to create a session.'
-            : 'Add classes on your Profile and make sure study spots are available before creating sessions.'
-        );
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : 'Unable to load session setup right now.';
-        setStatus(message);
-      } finally {
-        setIsLoading(false);
-      }
+  const loadSetupData = useCallback(async () => {
+    if (!currentUser) {
+      setClasses([]);
+      setLocations([]);
+      setStatus('Sign in to create a study session.');
+      setIsLoading(false);
+      return;
     }
 
-    loadSetupData();
+    try {
+      setIsLoading(true);
+      const [profile, loadedLocations] = await Promise.all([
+        getUserProfile(currentUser.uid),
+        getLocations(),
+      ]);
+
+      const profileClasses = [
+        ...new Set(
+          (profile?.classes ?? [])
+            .map((classCode) => classCode.trim().toUpperCase())
+            .filter(Boolean)
+        ),
+      ];
+      const normalizedRequestedClass = requestedClassId?.trim().toUpperCase() ?? '';
+      const defaultClass =
+        normalizedRequestedClass && profileClasses.includes(normalizedRequestedClass)
+          ? normalizedRequestedClass
+          : profileClasses[0] ?? '';
+
+      setClasses(profileClasses);
+      setLocations(loadedLocations);
+      setSelectedClass((currentSelectedClass) =>
+        currentSelectedClass && profileClasses.includes(currentSelectedClass)
+          ? currentSelectedClass
+          : defaultClass
+      );
+      setSelectedLocationId((currentSelectedLocationId) =>
+        currentSelectedLocationId &&
+        loadedLocations.some((location) => location.locationId === currentSelectedLocationId)
+          ? currentSelectedLocationId
+          : loadedLocations[0]?.locationId ?? ''
+      );
+      setTitle((currentTitle) =>
+        currentTitle ||
+        (defaultClass ? `${defaultClass} Study Session` : '')
+      );
+      setStatus(
+        profileClasses.length > 0 && loadedLocations.length > 0
+          ? 'Pick a class, location, and time to create a session.'
+          : 'Add classes on your Profile and make sure study spots are available before creating sessions.'
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unable to load session setup right now.';
+      setStatus(message);
+    } finally {
+      setIsLoading(false);
+    }
   }, [currentUser, requestedClassId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadSetupData();
+    }, [loadSetupData])
+  );
+
+  useEffect(() => {
+    loadSetupData();
+  }, [loadSetupData]);
 
   async function handleCreateSession() {
     if (!currentUser) {
@@ -158,9 +181,17 @@ export default function CreateSessionScreen() {
   }
 
   return (
-    <ScrollView
-      style={[styles.screen, { backgroundColor: palette.background }]}
-      contentContainerStyle={[styles.content, { paddingTop: insets.top + 12 }]}>
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 12 : 0}
+      style={[styles.screen, { backgroundColor: palette.background }]}>
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        style={styles.screen}
+        contentContainerStyle={[
+          styles.content,
+          { paddingBottom: insets.bottom + 56, paddingTop: insets.top + 12 },
+        ]}>
       <ThemedView
         style={[
           styles.hero,
@@ -383,7 +414,8 @@ export default function CreateSessionScreen() {
           )}
         </Pressable>
       </ThemedView>
-    </ScrollView>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/components/time-dropdown.tsx
+++ b/components/time-dropdown.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+
+import { Colors } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { ThemedText } from './themed-text';
+
+export const TIME_OPTIONS = Array.from({ length: 33 }, (_, index) => {
+  const totalMinutes = 7 * 60 + index * 30;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+});
+
+export function formatTimeLabel(time: string) {
+  const [hourValue, minuteValue] = time.split(':').map(Number);
+  const period = hourValue >= 12 ? 'PM' : 'AM';
+  const displayHour = hourValue % 12 === 0 ? 12 : hourValue % 12;
+  return `${displayHour}:${minuteValue.toString().padStart(2, '0')} ${period}`;
+}
+
+type TimeDropdownProps = {
+  disabled?: boolean;
+  disabledOption?: (time: string) => boolean;
+  label: string;
+  onChange: (time: string) => void;
+  placeholder?: string;
+  value: string;
+};
+
+export function TimeDropdown({
+  disabled = false,
+  disabledOption,
+  label,
+  onChange,
+  placeholder = 'Select time',
+  value,
+}: TimeDropdownProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedLabel = value ? formatTimeLabel(value) : placeholder;
+
+  function handleSelect(time: string) {
+    onChange(time);
+    setIsOpen(false);
+  }
+
+  return (
+    <View style={styles.container}>
+      <ThemedText style={styles.label}>{label}</ThemedText>
+      <Pressable
+        disabled={disabled}
+        onPress={() => setIsOpen((currentValue) => !currentValue)}
+        style={[
+          styles.trigger,
+          {
+            backgroundColor: palette.surface,
+            borderColor: palette.outline,
+            opacity: disabled ? 0.5 : 1,
+          },
+        ]}>
+        <ThemedText type="defaultSemiBold">{selectedLabel}</ThemedText>
+        <ThemedText style={styles.chevron}>{isOpen ? '^' : 'v'}</ThemedText>
+      </Pressable>
+
+      {isOpen ? (
+        <ScrollView
+          nestedScrollEnabled
+          style={[
+            styles.menu,
+            {
+              backgroundColor: palette.surface,
+              borderColor: palette.outline,
+            },
+          ]}>
+          {TIME_OPTIONS.map((time) => {
+            const isSelected = value === time;
+            const isDisabled = disabledOption?.(time) ?? false;
+
+            return (
+              <Pressable
+                disabled={isDisabled}
+                key={time}
+                onPress={() => handleSelect(time)}
+                style={[
+                  styles.option,
+                  {
+                    backgroundColor: isSelected ? palette.tint : 'transparent',
+                    opacity: isDisabled ? 0.35 : 1,
+                  },
+                ]}>
+                <ThemedText
+                  type="defaultSemiBold"
+                  lightColor={isSelected ? '#ffffff' : undefined}
+                  darkColor={isSelected ? '#ffffff' : undefined}>
+                  {formatTimeLabel(time)}
+                </ThemedText>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chevron: {
+    fontSize: 12,
+    opacity: 0.7,
+  },
+  container: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 12,
+    letterSpacing: 1,
+    opacity: 0.72,
+    textTransform: 'uppercase',
+  },
+  menu: {
+    borderRadius: 14,
+    borderWidth: 1,
+    maxHeight: 220,
+  },
+  option: {
+    borderRadius: 12,
+    marginHorizontal: 6,
+    marginVertical: 4,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  trigger: {
+    alignItems: 'center',
+    borderRadius: 14,
+    borderWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    minHeight: 52,
+    paddingHorizontal: 14,
+  },
+});

--- a/components/time-dropdown.tsx
+++ b/components/time-dropdown.tsx
@@ -5,8 +5,11 @@ import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { ThemedText } from './themed-text';
 
-export const TIME_OPTIONS = Array.from({ length: 33 }, (_, index) => {
-  const totalMinutes = 7 * 60 + index * 30;
+const MINUTES_IN_DAY = 24 * 60;
+const TIME_STEP_MINUTES = 30;
+
+export const TIME_OPTIONS = Array.from({ length: MINUTES_IN_DAY / TIME_STEP_MINUTES }, (_, index) => {
+  const totalMinutes = index * TIME_STEP_MINUTES;
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
@@ -67,6 +70,8 @@ export function TimeDropdown({
       {isOpen ? (
         <ScrollView
           nestedScrollEnabled
+          showsVerticalScrollIndicator
+          contentContainerStyle={styles.menuContent}
           style={[
             styles.menu,
             {
@@ -122,7 +127,10 @@ const styles = StyleSheet.create({
   menu: {
     borderRadius: 14,
     borderWidth: 1,
-    maxHeight: 220,
+    maxHeight: 320,
+  },
+  menuContent: {
+    paddingVertical: 4,
   },
   option: {
     borderRadius: 12,

--- a/data/uw-study-locations.ts
+++ b/data/uw-study-locations.ts
@@ -73,6 +73,22 @@ export const UW_STUDY_LOCATIONS: OfficialStudyLocation[] = [
     tags: ['business', 'modern', 'group-study', 'south-campus'],
   },
   {
+    locationId: 'morgridge-hall',
+    name: 'Morgridge Hall',
+    building: 'Morgridge Hall',
+    campusArea: 'South Campus',
+    notes: 'Modern academic building with collaborative study areas and a convenient south-campus location.',
+    tags: ['modern', 'south-campus', 'collaboration', 'study-rooms'],
+  },
+  {
+    locationId: 'college-library-cafe',
+    name: 'College Library Cafe',
+    building: 'Helen C. White Hall',
+    campusArea: 'Central Campus',
+    notes: 'Casual meetup-friendly area near College Library with easy access to Library Mall.',
+    tags: ['central', 'casual', 'coffee', 'meetup'],
+  },
+  {
     locationId: 'merit-library',
     name: 'MERIT Library',
     building: 'Teacher Education Building',

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -15,7 +15,8 @@ import {
   where,
 } from "firebase/firestore";
 
-import { findStudyLocationById, UW_STUDY_LOCATIONS } from "@/lib/catalog";
+import { UW_STUDY_LOCATIONS } from "@/data/uw-study-locations";
+import { findStudyLocationById } from "@/lib/catalog";
 import { db } from "../firebaseConfig";
 
 export const COLLECTIONS = {
@@ -134,13 +135,41 @@ function withBuiltInLocationFallback(location: StudyLocation): StudyLocation {
   const fallback = findStudyLocationById(location.locationId);
 
   if (!fallback) {
-    return location;
+    return {
+      ...location,
+      tags: location.tags ?? [],
+    };
   }
 
   return {
     ...fallback,
     ...location,
+    tags: location.tags ?? fallback.tags,
   };
+}
+
+function normalizeStudyLocation(
+  locationId: string,
+  location: Partial<Omit<StudyLocation, "locationId">>
+): StudyLocation {
+  const fallback = findStudyLocationById(locationId);
+
+  return {
+    building: location.building ?? fallback?.building ?? "UW-Madison",
+    campusArea: location.campusArea ?? fallback?.campusArea ?? "Campus",
+    locationId,
+    name: location.name ?? fallback?.name ?? locationId,
+    notes: location.notes ?? fallback?.notes ?? "Study location on or near campus.",
+    tags: Array.isArray(location.tags) ? location.tags : fallback?.tags ?? [],
+  };
+}
+
+function getBuiltInStudyLocations() {
+  return UW_STUDY_LOCATIONS.map((location) =>
+    normalizeStudyLocation(location.locationId, location)
+  ).sort((firstLocation, secondLocation) =>
+    firstLocation.name.localeCompare(secondLocation.name)
+  );
 }
 
 export async function createOrUpdateUserProfile(
@@ -279,30 +308,37 @@ export async function updateUserDisplayName(userId: string, displayName: string)
 }
 
 export async function getLocations() {
-  const locationsQuery = query(
-    collection(db, COLLECTIONS.locations),
-    orderBy("name")
-  );
-  const snapshot = await getDocs(locationsQuery);
+  try {
+    const locationsQuery = query(
+      collection(db, COLLECTIONS.locations),
+      orderBy("name")
+    );
+    const snapshot = await getDocs(locationsQuery);
 
-  const storedLocations = snapshot.docs.map((locationDoc) => ({
-    locationId: locationDoc.id,
-    ...(locationDoc.data() as Omit<StudyLocation, "locationId">),
-  }));
+    const storedLocations = snapshot.docs.map((locationDoc) =>
+      normalizeStudyLocation(
+        locationDoc.id,
+        locationDoc.data() as Partial<Omit<StudyLocation, "locationId">>
+      )
+    );
 
-  const mergedLocations = new Map<string, StudyLocation>();
+    const mergedLocations = new Map<string, StudyLocation>();
 
-  for (const location of UW_STUDY_LOCATIONS) {
-    mergedLocations.set(location.locationId, location);
+    for (const location of getBuiltInStudyLocations()) {
+      mergedLocations.set(location.locationId, location);
+    }
+
+    for (const location of storedLocations) {
+      mergedLocations.set(location.locationId, withBuiltInLocationFallback(location));
+    }
+
+    return [...mergedLocations.values()].sort((firstLocation, secondLocation) =>
+      firstLocation.name.localeCompare(secondLocation.name)
+    );
+  } catch (error) {
+    console.warn("Unable to load saved locations, using built-in UW study spots.", error);
+    return getBuiltInStudyLocations();
   }
-
-  for (const location of storedLocations) {
-    mergedLocations.set(location.locationId, withBuiltInLocationFallback(location));
-  }
-
-  return [...mergedLocations.values()].sort((firstLocation, secondLocation) =>
-    firstLocation.name.localeCompare(secondLocation.name)
-  );
 }
 
 export async function getSessions() {


### PR DESCRIPTION
## What this fixes
- Prevents the keyboard from blocking fields on the Create Session screen
- Reloads saved profile classes when opening Create Session
- Fixes study location loading/search in Explore and Create Session
- Adds missing built-in UW study spots including Morgridge Hall
- Falls back to built-in UW locations if Firestore location reads fail

## Verified
- Create Session fields remain usable with keyboard open
- Saved profile classes appear in Create Session
- Explore search now finds locations like Union and Morgridge
- npm run lint passes