### PR TITLE
[codex] Add in-app privacy and support surface

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -16,6 +16,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { TimeDropdown } from '@/components/time-dropdown';
+import { STUDI_SUPPORT_EMAIL } from '@/constants/app-info';
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { deleteCurrentUserAccount, logOut, subscribeToAuthState } from '@/lib/auth';
@@ -28,7 +29,7 @@ import {
   type AvailabilitySlot,
   type Socials,
 } from '@/lib/firestore';
-import { useRouter } from 'expo-router';
+import { type Href, useRouter } from 'expo-router';
 import type { User } from 'firebase/auth';
 
 function splitDisplayName(displayName: string | undefined) {
@@ -918,6 +919,23 @@ export default function ProfileScreen() {
           <ThemedText lightColor="#ffffff" darkColor="#ffffff" type="defaultSemiBold">
             Save Availability
           </ThemedText>
+        </Pressable>
+      </ThemedView>
+
+      <ThemedView style={[styles.card, { backgroundColor: palette.surface, borderColor: palette.border }]}>
+        <View style={styles.sectionHeader}>
+          <ThemedText style={styles.sectionLabel}>Privacy and support</ThemedText>
+        </View>
+        <ThemedText type="subtitle">Help, policy, and data requests</ThemedText>
+        <ThemedText style={styles.mutedText}>
+          Open the privacy policy, contact {STUDI_SUPPORT_EMAIL}, or find account data request
+          options before using delete account.
+        </ThemedText>
+        <Pressable
+          disabled={isBusy}
+          onPress={() => router.push('/privacy-support' as Href)}
+          style={[styles.secondaryButton, { borderColor: palette.outline, opacity: isBusy ? 0.6 : 1 }]}>
+          <ThemedText type="defaultSemiBold">Privacy & Support</ThemedText>
         </Pressable>
       </ThemedView>
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout() {
         <Stack.Screen name="conversation/[conversationId]" options={{ title: 'Conversation' }} />
         <Stack.Screen name="match/[userId]" options={{ title: 'Match Details' }} />
         <Stack.Screen name="matches" options={{ title: 'Matched Students' }} />
+        <Stack.Screen name="privacy-support" options={{ title: 'Privacy & Support' }} />
         <Stack.Screen name="report-user" options={{ title: 'Report User' }} />
         <Stack.Screen name="session/[sessionId]" options={{ title: 'Session Details' }} />
         <Stack.Screen name="rate-location" options={{ title: 'Rate This Spot' }} />

--- a/app/privacy-support.tsx
+++ b/app/privacy-support.tsx
@@ -1,0 +1,206 @@
+import { useRouter } from 'expo-router';
+import {
+  Alert,
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import {
+  STUDI_APP_NAME,
+  STUDI_PRIVACY_EMAIL,
+  STUDI_PRIVACY_POLICY_URL,
+  STUDI_SUPPORT_EMAIL,
+  STUDI_SUPPORT_URL,
+} from '@/constants/app-info';
+import { Colors } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+async function openExternalUrl(url: string) {
+  try {
+    const canOpen = await Linking.canOpenURL(url);
+
+    if (!canOpen) {
+      throw new Error('Unable to open this link.');
+    }
+
+    await Linking.openURL(url);
+  } catch {
+    Alert.alert('Link Unavailable', 'Please try again later or contact support from this screen.');
+  }
+}
+
+function buildEmailUrl(email: string, subject: string) {
+  return `mailto:${email}?subject=${encodeURIComponent(subject)}`;
+}
+
+export default function PrivacySupportScreen() {
+  const router = useRouter();
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const insets = useSafeAreaInsets();
+
+  return (
+    <ScrollView
+      style={[styles.screen, { backgroundColor: palette.background }]}
+      contentContainerStyle={[styles.content, { paddingTop: insets.top + 12 }]}>
+      <ThemedView style={[styles.hero, { backgroundColor: palette.hero }]}>
+        <ThemedText style={[styles.eyebrow, { color: palette.tint }]}>
+          Privacy and support
+        </ThemedText>
+        <ThemedText type="title">Help with {STUDI_APP_NAME}</ThemedText>
+        <ThemedText style={styles.heroText}>
+          Review privacy details, contact support, and manage account data from one place.
+        </ThemedText>
+      </ThemedView>
+
+      <ThemedView
+        style={[styles.card, { backgroundColor: palette.surface, borderColor: palette.border }]}>
+        <ThemedText style={styles.sectionLabel}>Privacy</ThemedText>
+        <ThemedText type="subtitle">Privacy Policy</ThemedText>
+        <ThemedText style={styles.mutedText}>
+          The policy covers data collection, use, third-party services, retention, consent choices,
+          and deletion requests.
+        </ThemedText>
+        <ThemedText style={styles.linkText}>{STUDI_PRIVACY_POLICY_URL}</ThemedText>
+        <Pressable
+          accessibilityRole="link"
+          onPress={() => openExternalUrl(STUDI_PRIVACY_POLICY_URL)}
+          style={[styles.primaryButton, { backgroundColor: palette.tint }]}>
+          <ThemedText lightColor="#ffffff" darkColor="#ffffff" type="defaultSemiBold">
+            Open Privacy Policy
+          </ThemedText>
+        </Pressable>
+      </ThemedView>
+
+      <ThemedView
+        style={[styles.card, { backgroundColor: palette.surface, borderColor: palette.border }]}>
+        <ThemedText style={styles.sectionLabel}>Support</ThemedText>
+        <ThemedText type="subtitle">Contact Studi</ThemedText>
+        <View style={styles.infoRows}>
+          <View>
+            <ThemedText type="defaultSemiBold">Support email</ThemedText>
+            <ThemedText style={styles.mutedText}>{STUDI_SUPPORT_EMAIL}</ThemedText>
+          </View>
+          <View>
+            <ThemedText type="defaultSemiBold">Support page</ThemedText>
+            <ThemedText style={styles.mutedText}>{STUDI_SUPPORT_URL}</ThemedText>
+          </View>
+        </View>
+        <View style={styles.buttonStack}>
+          <Pressable
+            accessibilityRole="link"
+            onPress={() => openExternalUrl(buildEmailUrl(STUDI_SUPPORT_EMAIL, 'Studi Support'))}
+            style={[styles.secondaryButton, { borderColor: palette.outline }]}>
+            <ThemedText type="defaultSemiBold">Email Support</ThemedText>
+          </Pressable>
+          <Pressable
+            accessibilityRole="link"
+            onPress={() => openExternalUrl(STUDI_SUPPORT_URL)}
+            style={[styles.secondaryButton, { borderColor: palette.outline }]}>
+            <ThemedText type="defaultSemiBold">Open Support Page</ThemedText>
+          </Pressable>
+        </View>
+      </ThemedView>
+
+      <ThemedView
+        style={[styles.card, { backgroundColor: palette.surface, borderColor: palette.border }]}>
+        <ThemedText style={styles.sectionLabel}>Account and data</ThemedText>
+        <ThemedText type="subtitle">Data requests and deletion</ThemedText>
+        <ThemedText style={styles.mutedText}>
+          You can delete your account from Profile. For privacy questions, data access, correction,
+          or consent withdrawal requests, contact the privacy inbox.
+        </ThemedText>
+        <View style={styles.buttonStack}>
+          <Pressable
+            onPress={() => router.push('/profile')}
+            style={[styles.secondaryButton, { borderColor: palette.outline }]}>
+            <ThemedText type="defaultSemiBold">Manage Account</ThemedText>
+          </Pressable>
+          <Pressable
+            accessibilityRole="link"
+            onPress={() =>
+              openExternalUrl(buildEmailUrl(STUDI_PRIVACY_EMAIL, 'Studi Privacy Request'))
+            }
+            style={[styles.secondaryButton, { borderColor: palette.outline }]}>
+            <ThemedText type="defaultSemiBold">Email Privacy Request</ThemedText>
+          </Pressable>
+        </View>
+      </ThemedView>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  content: {
+    gap: 18,
+    padding: 20,
+    paddingBottom: 36,
+  },
+  hero: {
+    borderRadius: 24,
+    gap: 10,
+    padding: 24,
+  },
+  eyebrow: {
+    fontSize: 12,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+  },
+  heroText: {
+    lineHeight: 28,
+    maxWidth: 520,
+  },
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    gap: 12,
+    padding: 20,
+    shadowColor: '#082431',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.06,
+    shadowRadius: 18,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    letterSpacing: 1,
+    opacity: 0.72,
+    textTransform: 'uppercase',
+  },
+  mutedText: {
+    opacity: 0.8,
+  },
+  linkText: {
+    fontSize: 13,
+    opacity: 0.72,
+  },
+  infoRows: {
+    gap: 12,
+  },
+  buttonStack: {
+    gap: 10,
+  },
+  primaryButton: {
+    alignItems: 'center',
+    borderRadius: 14,
+    justifyContent: 'center',
+    minHeight: 54,
+    paddingHorizontal: 16,
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    borderRadius: 14,
+    borderWidth: 1,
+    justifyContent: 'center',
+    minHeight: 54,
+    paddingHorizontal: 16,
+  },
+});

--- a/constants/app-info.ts
+++ b/constants/app-info.ts
@@ -1,0 +1,13 @@
+export const STUDI_APP_NAME = 'Studi';
+
+export const STUDI_PRIVACY_POLICY_URL =
+  process.env.EXPO_PUBLIC_STUDI_PRIVACY_POLICY_URL ?? 'https://studi-app.example.com/privacy';
+
+export const STUDI_SUPPORT_URL =
+  process.env.EXPO_PUBLIC_STUDI_SUPPORT_URL ?? 'https://studi-app.example.com/support';
+
+export const STUDI_SUPPORT_EMAIL =
+  process.env.EXPO_PUBLIC_STUDI_SUPPORT_EMAIL ?? 'support@studi.app';
+
+export const STUDI_PRIVACY_EMAIL =
+  process.env.EXPO_PUBLIC_STUDI_PRIVACY_EMAIL ?? STUDI_SUPPORT_EMAIL;


### PR DESCRIPTION
## Summary

- Add a configurable app info module for privacy policy/support URLs and support/privacy email placeholders.
- Add a dedicated Privacy & Support screen with policy, support, privacy request, and account-management actions.
- Link the new screen from the Profile flow next to existing account actions and delete-account access.

## Why

Apple App Store submission requires a privacy policy to be accessible in-app, plus usable support/contact information. This gives reviewers and users a clear in-app surface while keeping final hosted URLs configurable through Expo public env vars.

## Validation

- `npm run lint` passes.
- `npx tsc --noEmit` remains blocked by the pre-existing unrelated `app/socials.tsx` nullability error (`currentUser` possibly null).
- Local Expo web route `/privacy-support` returned `200 OK` during manual verification.

## Notes

- Final production values should be supplied for `EXPO_PUBLIC_STUDI_PRIVACY_POLICY_URL`, `EXPO_PUBLIC_STUDI_SUPPORT_URL`, `EXPO_PUBLIC_STUDI_SUPPORT_EMAIL`, and optionally `EXPO_PUBLIC_STUDI_PRIVACY_EMAIL` before App Store submission.