### PR TITLE
feat: add unblock conversation UX

### DIFF
--- a/app/conversation/[conversationId].tsx
+++ b/app/conversation/[conversationId].tsx
@@ -23,8 +23,10 @@ import { subscribeToAuthState } from '@/lib/auth';
 import {
   blockUser,
   getBlockedUserIds,
+  isBlockedByUser,
   sendDirectMessage,
   subscribeToConversationMessages,
+  unblockUser,
   type ConversationMessage,
 } from '@/lib/firestore';
 import type { User } from 'firebase/auth';
@@ -88,6 +90,7 @@ export default function ConversationScreen() {
   const isRefreshingRef = useRef(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [blockedUserIds, setBlockedUserIds] = useState<string[]>([]);
+  const [isBlockedByOther, setIsBlockedByOther] = useState(false);
 
   useEffect(() => {
     const unsubscribe = subscribeToAuthState((user) => {
@@ -122,17 +125,22 @@ export default function ConversationScreen() {
     async function loadBlocks() {
       if (!currentUser) {
         setBlockedUserIds([]);
+        setIsBlockedByOther(false);
         isRefreshingRef.current = false;
         setIsRefreshing(false);
         return;
       }
 
-      const loadedBlockedUserIds = await getBlockedUserIds(currentUser.uid);
+      const [loadedBlockedUserIds, blockedByOther] = await Promise.all([
+        getBlockedUserIds(currentUser.uid),
+        otherUserId ? isBlockedByUser(currentUser.uid, otherUserId) : false,
+      ]);
       setBlockedUserIds(loadedBlockedUserIds);
+      setIsBlockedByOther(blockedByOther);
     }
 
     loadBlocks();
-  }, [currentUser, refreshNonce]);
+  }, [currentUser, otherUserId, refreshNonce]);
 
   async function handleSendMessage() {
     if (!currentUser || !conversationId) {
@@ -172,6 +180,21 @@ export default function ConversationScreen() {
     }
   }
 
+  async function handleUnblockUser() {
+    if (!currentUser || !otherUserId) {
+      return;
+    }
+
+    try {
+      await unblockUser(currentUser.uid, otherUserId);
+      track('user_unblocked', { context: 'conversation' });
+      setBlockedUserIds((currentIds) => currentIds.filter((id) => id !== otherUserId));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to unblock this user.';
+      Alert.alert('Unblock Error', message);
+    }
+  }
+
   async function handleRefresh() {
     if (!currentUser || !conversationId) {
       return;
@@ -183,8 +206,9 @@ export default function ConversationScreen() {
     setRefreshNonce((value) => value + 1);
   }
 
-  const isBlocked = !!otherUserId && blockedUserIds.includes(otherUserId);
-  const canSend = !isSending && !isBlocked && draft.trim().length > 0;
+  const hasBlockedOther = !!otherUserId && blockedUserIds.includes(otherUserId);
+  const isMessagingDisabled = hasBlockedOther || isBlockedByOther;
+  const canSend = !isSending && !isMessagingDisabled && draft.trim().length > 0;
 
   return (
     <KeyboardAvoidingView
@@ -217,12 +241,16 @@ export default function ConversationScreen() {
           style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}>
           <Text style={[TypeScale.label, { color: palette.icon }]}>Report</Text>
         </Pressable>
-        <Pressable
-          accessibilityRole="button"
-          onPress={handleBlockUser}
-          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}>
-          <Text style={[TypeScale.label, { color: palette.tint }]}>Block</Text>
-        </Pressable>
+        {!isBlockedByOther ? (
+          <Pressable
+            accessibilityRole="button"
+            onPress={hasBlockedOther ? handleUnblockUser : handleBlockUser}
+            style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}>
+            <Text style={[TypeScale.label, { color: palette.tint }]}>
+              {hasBlockedOther ? 'Unblock' : 'Block'}
+            </Text>
+          </Pressable>
+        ) : null}
       </View>
 
       <ScrollView
@@ -303,13 +331,19 @@ export default function ConversationScreen() {
         <View
           style={[
             styles.composer,
-            { backgroundColor: palette.surfaceMuted, opacity: isBlocked ? 0.55 : 1 },
+            { backgroundColor: palette.surfaceMuted, opacity: isMessagingDisabled ? 0.55 : 1 },
           ]}>
           <TextInput
-            editable={!isSending && !isBlocked}
+            editable={!isSending && !isMessagingDisabled}
             multiline
             onChangeText={setDraft}
-            placeholder={isBlocked ? 'This user is blocked.' : 'Message…'}
+            placeholder={
+              hasBlockedOther
+                ? 'This user is blocked.'
+                : isBlockedByOther
+                  ? 'Messaging unavailable.'
+                  : 'Message…'
+            }
             placeholderTextColor={colorScheme === 'dark' ? '#8A8174' : Brand.textSubtle}
             style={[styles.composerInput, { color: palette.text }]}
             value={draft}

--- a/firestore.rules
+++ b/firestore.rules
@@ -352,7 +352,12 @@ service cloud.firestore {
     // ------------------------------------------------------------------
 
     match /userBlocks/{blockId} {
-      allow read: if isVerifiedUwUser()
+      // Either side of a block may `get` the single doc naming them — the
+      // blocked side needs it to render conversation state — but only the
+      // blocker may list, so nobody can enumerate who blocked them.
+      allow get: if isVerifiedUwUser()
+        && request.auth.uid in blockId.split('__');
+      allow list: if isVerifiedUwUser()
         && resource.data.blockerUserId == request.auth.uid;
       allow create: if isVerifiedUwUser()
         && incoming().keys().hasOnly(['blockerUserId', 'blockedUserId', 'createdAt'])

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -72,6 +72,7 @@ export type AnalyticsEvent =
   | "conversation_started"
   | "report_submitted"
   | "user_blocked"
+  | "user_unblocked"
   | "account_deleted"
   | "screen_view";
 

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -2,6 +2,7 @@ import {
   arrayRemove,
   arrayUnion,
   collection,
+  deleteDoc,
   doc,
   documentId,
   getDoc,
@@ -782,6 +783,19 @@ export async function blockUser(blockerUserId: string, blockedUserId: string) {
     blockedUserId,
     createdAt: serverTimestamp(),
   } satisfies UserBlock);
+}
+
+export async function unblockUser(blockerUserId: string, blockedUserId: string) {
+  const blockId = `${blockerUserId}__${blockedUserId}`;
+
+  await deleteDoc(doc(db, COLLECTIONS.userBlocks, blockId));
+}
+
+export async function isBlockedByUser(userId: string, possibleBlockerUserId: string) {
+  const blockId = `${possibleBlockerUserId}__${userId}`;
+  const snapshot = await getDoc(doc(db, COLLECTIONS.userBlocks, blockId));
+
+  return snapshot.exists();
 }
 
 export async function getBlockedUserIds(blockerUserId: string) {

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -646,17 +646,39 @@ describe('locations (curated public data)', () => {
   });
 });
 
-describe('userBlocks (D5: blocker-only visibility)', () => {
-  it('blocker creates/reads/deletes; blocked party cannot read', async () => {
+describe('userBlocks (D5: involved-party get, blocker-only list)', () => {
+  it('blocker creates/reads/deletes; blocked party can get the doc naming them', async () => {
     await assertSucceeds(setDoc(doc(ctx(ALICE), 'userBlocks', `${ALICE}__${BOB}`), {
       blockerUserId: ALICE, blockedUserId: BOB, createdAt: serverTimestamp(),
     }));
     await assertSucceeds(getDoc(doc(ctx(ALICE), 'userBlocks', `${ALICE}__${BOB}`)));
-    await assertFails(getDoc(doc(ctx(BOB), 'userBlocks', `${ALICE}__${BOB}`)));
+    // Blocked side may probe the single doc that targets them (drives the
+    // conversation screen's "messaging unavailable" state)…
+    await assertSucceeds(getDoc(doc(ctx(BOB), 'userBlocks', `${ALICE}__${BOB}`)));
+    // …but uninvolved users cannot, and nobody can list another's blocks.
+    await assertFails(getDoc(doc(ctx(MALLORY), 'userBlocks', `${ALICE}__${BOB}`)));
+    await assertFails(getDocs(query(
+      collection(ctx(BOB), 'userBlocks'),
+      where('blockedUserId', '==', BOB)
+    )));
     await assertFails(setDoc(doc(ctx(MALLORY), 'userBlocks', `${ALICE}__${BOB}`), {
       blockerUserId: ALICE, blockedUserId: BOB, createdAt: serverTimestamp(),
     }));
+    await assertFails(deleteDoc(doc(ctx(BOB), 'userBlocks', `${ALICE}__${BOB}`)));
     await assertSucceeds(deleteDoc(doc(ctx(ALICE), 'userBlocks', `${ALICE}__${BOB}`)));
+  });
+
+  it('blocker lists own blocks; involved get succeeds even when doc is absent', async () => {
+    await seed(`userBlocks/${ALICE}__${BOB}`, {
+      blockerUserId: ALICE, blockedUserId: BOB, createdAt: Timestamp.now(),
+    });
+    await assertSucceeds(getDocs(query(
+      collection(ctx(ALICE), 'userBlocks'),
+      where('blockerUserId', '==', ALICE)
+    )));
+    // The app probes `other__me` before knowing whether a block exists; the
+    // get must be allowed (returning exists=false) rather than denied.
+    await assertSucceeds(getDoc(doc(ctx(ALICE), 'userBlocks', `${BOB}__${ALICE}`)));
   });
 
   it('cannot block yourself; id must match fields', async () => {


### PR DESCRIPTION
Adds unblock support in conversations.

Changes:
- Shows Unblock instead of Block when the current user has blocked the other participant.
- Hides Block/Unblock if the other participant blocked the current user.
- Disables composer with different messaging for “I blocked them” vs “they blocked me.”
- Adds Firestore helper for unblock/reverse-block lookup.
- Updates userBlocks rules/tests to allow direct involved-party get without enabling list/query enumeration.

Validation:
- npx tsc --noEmit passed
- npm run lint passed
- npm run rules:test passed
- npx expo export --platform web passed