### PR TITLE
fix: launch-relevant fixes from security review

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -234,6 +234,12 @@ service cloud.firestore {
         && conversationId == incoming().participantKey
         && incoming().lastMessagePreview is string
         && incoming().lastMessagePreview.size() <= 200
+        // Pin all timestamps to the server clock (matches the update branch);
+        // otherwise a forged lastMessageAt can park a thread atop the
+        // counterpart's inbox forever.
+        && incoming().lastMessageAt == request.time
+        && incoming().createdAt == request.time
+        && incoming().updatedAt == request.time
         && !isBlockedEitherWay(incoming().participantIds[0], incoming().participantIds[1]);
     }
 

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -293,7 +293,9 @@ export async function getProfilesByIds(
       const profile: UserProfile = {
         uid: docSnap.id,
         displayName: typeof data.displayName === "string" ? data.displayName : "",
-        classes: Array.isArray(data.classes) ? data.classes : [],
+        classes: Array.isArray(data.classes)
+          ? data.classes.filter((c) => typeof c === "string")
+          : [],
       };
       profileCache.set(docSnap.id, { profile, fetchedAt: now });
       result.set(docSnap.id, profile);
@@ -463,9 +465,11 @@ function normalizeSessionDoc(
 
 const SESSIONS_PAGE_SIZE = 50;
 
-// How far back to scan for sessions that are still running (longest hostable
-// session is 3h; 6h leaves margin without meaningfully widening the query).
-const IN_PROGRESS_LOOKBACK_MS = 6 * 60 * 60 * 1000;
+// How far back to scan for sessions that are still running. Rules allow
+// sessions up to 12h (endTime < startTime + 12h), and manual end-time entry
+// lets hosts exceed the 3h preset — scan the full window so no in-progress
+// session drops off the "happening now" view.
+const IN_PROGRESS_LOOKBACK_MS = 12 * 60 * 60 * 1000;
 
 export async function getUpcomingSessions(options?: {
   classIds?: string[];

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -452,6 +452,19 @@ describe('conversations + messages', () => {
     );
   });
 
+  it('rejects forged timestamps on create', async () => {
+    const future = Timestamp.fromMillis(Date.now() + 365 * 24 * 60 * 60 * 1000);
+    await assertFails(setDoc(doc(ctx(ALICE), 'conversations', convoId(ALICE, BOB)), {
+      ...validConversation(ALICE, BOB), lastMessageAt: future,
+    }));
+    await assertFails(setDoc(doc(ctx(ALICE), 'conversations', convoId(ALICE, BOB)), {
+      ...validConversation(ALICE, BOB), createdAt: future,
+    }));
+    await assertFails(setDoc(doc(ctx(ALICE), 'conversations', convoId(ALICE, BOB)), {
+      ...validConversation(ALICE, BOB), updatedAt: Timestamp.fromMillis(0),
+    }));
+  });
+
   it('rejects wrong id, >2 people, third-party creation, blocked pairs', async () => {
     await assertFails(setDoc(doc(ctx(ALICE), 'conversations', 'randomId'),
       validConversation(ALICE, BOB)));


### PR DESCRIPTION
## Summary

Three launch-relevant fixes from the full-codebase security/bug review. Minimal, targeted changes only — no low-priority findings included.

### 1. `getProfilesByIds` classes sanitization (crash vector)
`lib/firestore.ts` — the batch profile fetch copied `data.classes` without the per-element `typeof === "string"` filter that `getUserProfile` applies. A malformed/malicious profile doc (rules only validate list size, not element types) could crash every other user's session list when rendered. Now filtered identically in both paths.

### 2. DM create timestamp validation (rules gap)
`firestore.rules` — `isValidNewConversation` never pinned `createdAt` / `updatedAt` / `lastMessageAt`, so a raw SDK client could create a thread with a far-future `lastMessageAt` and pin itself atop the counterpart's inbox permanently. All three now require `== request.time`, matching the update branch. The client already writes `serverTimestamp()` for all three, so no client change needed. Regression test added.

### 3. Session duration mismatch (audit + fix)
Audit: duration presets cap at 3h, but the free-text end-time input allows any same-day duration and rules allow up to 12h — while the "happening now" lookback scanned only 6h (with a comment claiming 3h max). Sessions longer than 6h silently vanished mid-session. Lookback aligned to the 12h rules cap with a corrected comment.

## Validation

- `npm run rules:test` — 39 passing (includes new "rejects forged timestamps on create" test)
- `npx mocha tests/catalog-search.test.mjs` — 6 passing
- `npx tsc --noEmit` — clean
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)