### PR TITLE
fix: remove duplicate create-session setup load

### DIFF
--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -264,10 +264,6 @@ export default function CreateSessionScreen() {
     }, [loadSetupData])
   );
 
-  useEffect(() => {
-    loadSetupData();
-  }, [loadSetupData]);
-
   async function handleRefresh() {
     if (!currentUser) {
       return;


### PR DESCRIPTION
## Summary
- `app/create-session.tsx` triggered `loadSetupData` from both `useFocusEffect` and `useEffect`, double-fetching the profile, locations, and rating aggregates on every mount.
- Removed the redundant `useEffect`; `useFocusEffect` remains the single trigger and still covers initial mount, refocus, and auth/param changes (its callback re-runs when `loadSetupData` changes identity). Pull-to-refresh and session creation are untouched.

## Validation
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run rules:test` — 39 passing
- `npx expo export --platform web` — exports successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)