### PR TITLE
fix: update profile privacy and support links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Public web origin used by native builds and App Store review links.
-EXPO_PUBLIC_STUDI_WEB_BASE_URL=https://studi-b02c3.web.app
+EXPO_PUBLIC_STUDI_WEB_BASE_URL=https://www.joinstudi.com
 
 # Swap this to the final public support alias before App Store submission.
 EXPO_PUBLIC_STUDI_SUPPORT_EMAIL=isp.studi@gmail.com

--- a/constants/app-info.ts
+++ b/constants/app-info.ts
@@ -1,6 +1,6 @@
 export const STUDI_APP_NAME = 'Studi';
 
-const STUDI_FIREBASE_HOSTING_URL = 'https://studi-b02c3.web.app';
+const STUDI_WEB_BASE_URL = 'https://www.joinstudi.com';
 const STUDI_DEFAULT_SUPPORT_EMAIL = 'isp.studi@gmail.com';
 
 const configuredWebBaseUrl = process.env.EXPO_PUBLIC_STUDI_WEB_BASE_URL?.replace(/\/$/, '');
@@ -14,7 +14,7 @@ function buildStudiWebUrl(path: `/${string}`) {
     return path;
   }
 
-  return `${STUDI_FIREBASE_HOSTING_URL}${path}`;
+  return `${STUDI_WEB_BASE_URL}${path}`;
 }
 
 export const STUDI_PRIVACY_POLICY_URL =


### PR DESCRIPTION
## Summary
- Profile > Privacy Policy and Support links pointed at the dead Firebase Hosting origin `https://studi-b02c3.web.app` ("Site Not Found")
- Replace the native fallback base URL in `constants/app-info.ts` with the canonical `https://www.joinstudi.com`, so Privacy Policy opens `/privacy` and Support opens `/support`
- Update `.env.example` so the documented `EXPO_PUBLIC_STUDI_WEB_BASE_URL` no longer references the dead host

Env-var overrides and the web-build relative-path behavior (in-app `/privacy` and `/support` routes) are unchanged. No Profile UI changes.

## Validation
- `npx tsc --noEmit` clean
- `npm run lint` clean
- `npx expo export --platform web` exports successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)