### PR TITLE
fix: keep Firebase auth email flow beta-safe

### DIFF
--- a/docs/firebase-auth-console-checklist.md
+++ b/docs/firebase-auth-console-checklist.md
@@ -1,16 +1,14 @@
 # Firebase Auth console checklist (pre-launch)
 
 These settings live in the Firebase console for project `studi-b02c3` and cannot
-be set from code. The code half of this work (continue URL + iOS bundle ID on
-auth emails) is in `lib/auth.ts` (`ACTION_CODE_SETTINGS`).
+be set from code.
 
-## Required before the continue-URL change ships
-
-- [ ] **Add authorized domains** — Authentication → Settings → Authorized
-      domains → add `www.joinstudi.com` and `joinstudi.com`.
-      Without this, every `sendPasswordResetEmail` / `sendEmailVerification`
-      call fails with `auth/unauthorized-continue-uri` — the reset and
-      verification flows break entirely, not just the redirect.
+> **Note:** Continue-URL action settings (`ACTION_CODE_SETTINGS` in
+> `lib/auth.ts`) are **deferred to post-beta**. The change was reverted because
+> the Firebase hosted flow showed "The operation is not valid." after
+> completing a password reset with the continue URL set. For beta we keep the
+> default Firebase action flow (emails dead-end on the hosted action page).
+> See the "Deferred" section below for what needs to happen before retrying.
 
 ## Required before public launch
 
@@ -29,13 +27,18 @@ auth emails) is in `lib/auth.ts` (`ACTION_CODE_SETTINGS`).
 ## Verify after the console changes
 
 - [ ] Send a password reset to a real `@wisc.edu` inbox (our whole user base is
-      on university Microsoft 365 mail): confirm it arrives, isn't junked, shows
-      "Studi" as sender and app name, and the action page shows a **Continue**
-      button that lands on `https://www.joinstudi.com/sign-in`.
+      on university Microsoft 365 mail): confirm it arrives, isn't junked, and
+      shows "Studi" as sender and app name.
 - [ ] Repeat for the verification email from a fresh sign-up.
 
 ## Deferred (post-beta, tracked in the audit)
 
+- **Continue URL + iOS bundle ID on auth emails** (`ACTION_CODE_SETTINGS`) —
+  reverted for beta; the hosted flow errored with "The operation is not valid."
+  after completing a reset. Before retrying: add `www.joinstudi.com` and
+  `joinstudi.com` under Authentication → Settings → Authorized domains
+  (missing domains fail sends with `auth/unauthorized-continue-uri`), then
+  debug why the hosted action page rejects the continue URL.
 - Custom sender domain (`noreply@joinstudi.com`) with SPF/DKIM — Authentication
   → Templates → customize domain (DNS status currently `NOT_STARTED`).
 - Fully branded email bodies (Admin SDK `generatePasswordResetLink` + email

--- a/docs/firebase-auth-console-checklist.md
+++ b/docs/firebase-auth-console-checklist.md
@@ -1,0 +1,44 @@
+# Firebase Auth console checklist (pre-launch)
+
+These settings live in the Firebase console for project `studi-b02c3` and cannot
+be set from code. The code half of this work (continue URL + iOS bundle ID on
+auth emails) is in `lib/auth.ts` (`ACTION_CODE_SETTINGS`).
+
+## Required before the continue-URL change ships
+
+- [ ] **Add authorized domains** — Authentication → Settings → Authorized
+      domains → add `www.joinstudi.com` and `joinstudi.com`.
+      Without this, every `sendPasswordResetEmail` / `sendEmailVerification`
+      call fails with `auth/unauthorized-continue-uri` — the reset and
+      verification flows break entirely, not just the redirect.
+
+## Required before public launch
+
+- [ ] **Public-facing app name** — Project settings → General → Public settings
+      → set *Public-facing name* to `Studi`. This fills `%APP_NAME%` in every
+      auth email; if unset, users see the raw project number
+      (`project-569084936595`) in subject lines.
+- [ ] **Support email** — same Public settings section → set the support email.
+- [ ] **Sender display name** — Authentication → Templates → each template
+      (Password reset, Email verification, Email address change) → set sender
+      name to `Studi` so inboxes show "Studi" instead of a bare
+      `noreply@studi-b02c3.firebaseapp.com`.
+- [ ] **Reply-to** — in the same template editor, set reply-to to a monitored
+      support address (currently `noreply`, so replies go nowhere).
+
+## Verify after the console changes
+
+- [ ] Send a password reset to a real `@wisc.edu` inbox (our whole user base is
+      on university Microsoft 365 mail): confirm it arrives, isn't junked, shows
+      "Studi" as sender and app name, and the action page shows a **Continue**
+      button that lands on `https://www.joinstudi.com/sign-in`.
+- [ ] Repeat for the verification email from a fresh sign-up.
+
+## Deferred (post-beta, tracked in the audit)
+
+- Custom sender domain (`noreply@joinstudi.com`) with SPF/DKIM — Authentication
+  → Templates → customize domain (DNS status currently `NOT_STARTED`).
+- Fully branded email bodies (Admin SDK `generatePasswordResetLink` + email
+  provider, or Identity Platform upgrade).
+- Custom-branded action handler page replacing
+  `https://studi-b02c3.firebaseapp.com/__/auth/action`.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -18,6 +18,16 @@ import { createOrUpdateUserProfile } from "./firestore";
 
 const UW_EMAIL_DOMAIN = "@wisc.edu";
 
+// Where auth emails send users after they finish on the Firebase action page.
+// The URL's domain must be listed under Auth → Settings → Authorized domains,
+// or send calls fail with auth/unauthorized-continue-uri (see
+// docs/firebase-auth-console-checklist.md). iOS bundle ID lets the
+// hosting-domain mobile link reopen the installed app.
+const ACTION_CODE_SETTINGS = {
+  url: "https://www.joinstudi.com/sign-in",
+  iOS: { bundleId: "com.joinstudi.app" },
+};
+
 function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
 }
@@ -118,7 +128,7 @@ export async function signUp(
     // Name lives on the Auth profile until the email is verified; the Firestore
     // profile is written post-verification (rules require a verified token).
     await updateProfile(credential.user, { displayName });
-    await sendEmailVerification(credential.user);
+    await sendEmailVerification(credential.user, ACTION_CODE_SETTINGS);
     track("sign_up_completed");
 
     return credential.user;
@@ -146,7 +156,7 @@ export async function resendVerificationEmail() {
     throw new Error("Sign in first to resend the verification email.");
   }
 
-  await sendEmailVerification(user);
+  await sendEmailVerification(user, ACTION_CODE_SETTINGS);
 }
 
 /**
@@ -185,7 +195,7 @@ export async function requestPasswordReset(email: string) {
   }
 
   try {
-    await sendPasswordResetEmail(auth, normalizedEmail);
+    await sendPasswordResetEmail(auth, normalizedEmail, ACTION_CODE_SETTINGS);
   } catch (error: unknown) {
     const authError = error as AuthError;
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -18,16 +18,6 @@ import { createOrUpdateUserProfile } from "./firestore";
 
 const UW_EMAIL_DOMAIN = "@wisc.edu";
 
-// Where auth emails send users after they finish on the Firebase action page.
-// The URL's domain must be listed under Auth → Settings → Authorized domains,
-// or send calls fail with auth/unauthorized-continue-uri (see
-// docs/firebase-auth-console-checklist.md). iOS bundle ID lets the
-// hosting-domain mobile link reopen the installed app.
-const ACTION_CODE_SETTINGS = {
-  url: "https://www.joinstudi.com/sign-in",
-  iOS: { bundleId: "com.joinstudi.app" },
-};
-
 function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
 }
@@ -128,7 +118,7 @@ export async function signUp(
     // Name lives on the Auth profile until the email is verified; the Firestore
     // profile is written post-verification (rules require a verified token).
     await updateProfile(credential.user, { displayName });
-    await sendEmailVerification(credential.user, ACTION_CODE_SETTINGS);
+    await sendEmailVerification(credential.user);
     track("sign_up_completed");
 
     return credential.user;
@@ -156,7 +146,7 @@ export async function resendVerificationEmail() {
     throw new Error("Sign in first to resend the verification email.");
   }
 
-  await sendEmailVerification(user, ACTION_CODE_SETTINGS);
+  await sendEmailVerification(user);
 }
 
 /**
@@ -195,7 +185,7 @@ export async function requestPasswordReset(email: string) {
   }
 
   try {
-    await sendPasswordResetEmail(auth, normalizedEmail, ACTION_CODE_SETTINGS);
+    await sendPasswordResetEmail(auth, normalizedEmail);
   } catch (error: unknown) {
     const authError = error as AuthError;
 


### PR DESCRIPTION
## Summary
- Keeps Firebase auth emails on the default hosted action flow for beta: plain `sendPasswordResetEmail(auth, email)` and `sendEmailVerification(user)` with **no** `ACTION_CODE_SETTINGS`.
- The continue-URL + iOS bundle ID change was tried and reverted on this branch — the Firebase hosted flow showed "The operation is not valid." after completing a password reset. Net code diff vs main is zero; only the docs change ships.
- Adds `docs/firebase-auth-console-checklist.md`: the Console branding checklist (public-facing app name, sender name, reply-to) that pairs with the already-applied Console changes, with the continue-URL work explicitly marked **deferred to post-beta**.

## Test plan
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx expo export --platform web` — builds successfully
- Manual: password reset email sends and completes on the default Firebase action page

🤖 Generated with [Claude Code](https://claude.com/claude-code)