### PR TITLE
fix: query Today feed sessions by user's classes

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -26,7 +26,7 @@ import { subscribeToAuthState } from '@/lib/auth';
 import {
   getLocations,
   getProfilesByIds,
-  getUpcomingSessions,
+  getUpcomingSessionsForClasses,
   getUserProfile,
   joinSession,
   type StudySession,
@@ -242,6 +242,11 @@ export default function HomeScreen() {
     loadUserProfile();
   }, [currentUser]);
 
+  const profileClasses = useMemo(
+    () => (profile?.classes ?? []).map((classCode) => classCode.trim().toUpperCase()),
+    [profile]
+  );
+
   const loadSessions = useCallback(async () => {
     if (!currentUser || !currentUser.emailVerified) {
       return;
@@ -249,8 +254,15 @@ export default function HomeScreen() {
 
     try {
       setSessionsError('');
+      // Query the user's classes directly (plus joined sessions) rather than
+      // scanning the global upcoming list — at scale the first page of that
+      // list may hold none of this user's classes.
       const [loadedSessions, locations] = await Promise.all([
-        getUpcomingSessions({ includeInProgress: true }),
+        getUpcomingSessionsForClasses({
+          classIds: profileClasses,
+          participantId: currentUser.uid,
+          includeInProgress: true,
+        }),
         getLocations(),
       ]);
       const locationsById = new Map(
@@ -268,17 +280,13 @@ export default function HomeScreen() {
         error instanceof Error ? error.message : 'Unable to load sessions right now.';
       setSessionsError(message);
     }
-  }, [currentUser]);
+  }, [currentUser, profileClasses]);
 
   useEffect(() => {
     loadSessions();
   }, [loadSessions]);
 
   const savedName = splitDisplayName(profile?.displayName);
-  const profileClasses = useMemo(
-    () => (profile?.classes ?? []).map((classCode) => classCode.trim().toUpperCase()),
-    [profile]
-  );
 
   // Hero + rows: the board feed is personal — sessions for my classes plus
   // anything I've already joined.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -9,6 +9,14 @@
       ]
     },
     {
+      "collectionGroup": "sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "participantIds", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "startTime", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "conversations",
       "queryScope": "COLLECTION",
       "fields": [

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -14,6 +14,7 @@ import {
   serverTimestamp,
   setDoc,
   Timestamp,
+  type QueryConstraint,
   updateDoc,
   where,
   writeBatch,
@@ -502,6 +503,14 @@ export async function getUpcomingSessions(options?: {
           limit(SESSIONS_PAGE_SIZE),
         ];
 
+  const sessions = await fetchSessionDocs(constraints);
+
+  return filterActiveSessions(sessions, now.toMillis(), options?.includeInProgress);
+}
+
+async function fetchSessionDocs(
+  constraints: QueryConstraint[]
+): Promise<StudySession[]> {
   const snapshot = await getDocs(query(collection(db, COLLECTIONS.sessions), ...constraints));
   const sessions: StudySession[] = [];
 
@@ -514,13 +523,19 @@ export async function getUpcomingSessions(options?: {
     }
   });
 
-  const cutoffMs = now.toMillis();
+  return sessions;
+}
 
+function filterActiveSessions(
+  sessions: StudySession[],
+  cutoffMs: number,
+  includeInProgress?: boolean
+): StudySession[] {
   return sessions.filter((s) => {
     if (s.status === "cancelled") {
       return false;
     }
-    if (!options?.includeInProgress) {
+    if (!includeInProgress) {
       return true;
     }
     // With the widened window, drop sessions that already ended; keep future
@@ -529,6 +544,65 @@ export async function getUpcomingSessions(options?: {
     const stillRunning = !!s.endTime && s.endTime.toMillis() > cutoffMs;
     return startsInFuture || stillRunning;
   });
+}
+
+// Firestore `in` disjunctions cap at 10 values, so class lists are chunked
+// into parallel queries and the pages merged client-side.
+const CLASS_ID_CHUNK_SIZE = 10;
+
+/**
+ * Today feed data path: fetch sessions for the user's enrolled classes
+ * directly (chunked `classId in` queries) plus anything the user already
+ * joined, instead of scanning the global list and filtering client-side.
+ */
+export async function getUpcomingSessionsForClasses(options: {
+  classIds: string[];
+  /** Also include sessions this user already joined, whatever the class. */
+  participantId?: string;
+  includeInProgress?: boolean;
+}): Promise<StudySession[]> {
+  const now = Timestamp.now();
+  const windowStart = options.includeInProgress
+    ? Timestamp.fromMillis(now.toMillis() - IN_PROGRESS_LOOKBACK_MS)
+    : now;
+  const timeConstraints = [
+    where("startTime", ">=", windowStart),
+    orderBy("startTime", "asc"),
+    limit(SESSIONS_PAGE_SIZE),
+  ];
+
+  const classIds = [...new Set(options.classIds)];
+  const chunks: string[][] = [];
+  for (let i = 0; i < classIds.length; i += CLASS_ID_CHUNK_SIZE) {
+    chunks.push(classIds.slice(i, i + CLASS_ID_CHUNK_SIZE));
+  }
+
+  const reads = chunks.map((chunk) =>
+    fetchSessionDocs([where("classId", "in", chunk), ...timeConstraints])
+  );
+  if (options.participantId) {
+    reads.push(
+      fetchSessionDocs([
+        where("participantIds", "array-contains", options.participantId),
+        ...timeConstraints,
+      ])
+    );
+  }
+
+  const pages = await Promise.all(reads);
+
+  // Merge by sessionId: a session can appear in both its class chunk and the
+  // joined-sessions page.
+  const byId = new Map<string, StudySession>();
+  for (const page of pages) {
+    for (const session of page) {
+      byId.set(session.sessionId, session);
+    }
+  }
+
+  return filterActiveSessions([...byId.values()], now.toMillis(), options.includeInProgress)
+    .sort((a, b) => a.startTime.toMillis() - b.startTime.toMillis())
+    .slice(0, SESSIONS_PAGE_SIZE);
 }
 
 export async function getSessionById(sessionId: string) {


### PR DESCRIPTION
## Problem
The Today feed fetched the first 50 global upcoming/in-progress sessions and filtered client-side to the user's classes. At scale, a user's class sessions can fall outside that first page, making Today look empty even when relevant sessions exist.

## Change
- **`lib/firestore.ts`** — new `getUpcomingSessionsForClasses()`: chunks the user's classes into groups of 10 (Firestore `in` cap), runs the chunk queries in parallel over the same 12h in-progress window, plus one `participantIds array-contains uid` query so sessions the user already joined outside their classes stay visible. Results are deduped by `sessionId`, run through the existing cancelled/already-ended filter, sorted by `startTime`, and capped at 50. `getUpcomingSessions` is unchanged, so Sessions/Explore/Profile screens keep their behavior.
- **`app/(tabs)/index.tsx`** — Today feed calls the new function with `profile.classes`; re-fetches when the profile loads. No UI changes.
- **`firestore.indexes.json`** — adds `sessions: participantIds CONTAINS + startTime ASC` composite index required by the joined-sessions query (`classId + startTime` already existed).

No Firestore rules changes.

## Deploy note
The new composite index must be deployed (`firebase deploy --only firestore:indexes`) before/with this change or the joined-sessions query will fail.

## Validation
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run rules:test` — 39 passing
- `npx expo export --platform web` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)