### PR TITLE
fix: UX polish for auth, session details, and location picker

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -86,6 +86,8 @@ export default function SignInScreen() {
             label="UW email"
             autoCapitalize="none"
             autoComplete="email"
+            autoCorrect={false}
+            spellCheck={false}
             editable={!isBusy}
             keyboardType="email-address"
             onChangeText={setEmail}

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -98,6 +98,8 @@ export default function SignUpScreen() {
             label="UW email"
             autoCapitalize="none"
             autoComplete="email"
+            autoCorrect={false}
+            spellCheck={false}
             editable={!isBusy}
             keyboardType="email-address"
             onChangeText={setEmail}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -17,6 +17,7 @@ import { ExternalLink } from '@/components/external-link';
 import { Avatar } from '@/components/ui/Avatar';
 import { Button } from '@/components/ui/Button';
 import { CourseChip } from '@/components/ui/CourseChip';
+import { IconSymbol } from '@/components/ui/icon-symbol';
 import { SectionHeader } from '@/components/ui/SectionHeader';
 import {
     STUDI_CONTACT_EMAIL,
@@ -80,6 +81,7 @@ export default function ProfileScreen() {
   const [isReauthenticatingDelete, setIsReauthenticatingDelete] = useState(false);
   const [showDeleteReauthModal, setShowDeleteReauthModal] = useState(false);
   const [deleteReauthPassword, setDeleteReauthPassword] = useState('');
+  const [isDeletePasswordVisible, setIsDeletePasswordVisible] = useState(false);
   const [deleteReauthEmail, setDeleteReauthEmail] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
@@ -279,6 +281,7 @@ export default function ProfileScreen() {
   async function handleDeleteAccount() {
     setDeleteReauthPassword('');
     setDeleteReauthEmail(currentUser?.email ?? '');
+    setIsDeletePasswordVisible(false);
     setShowDeleteReauthModal(true);
   }
 
@@ -289,6 +292,7 @@ export default function ProfileScreen() {
 
     setShowDeleteReauthModal(false);
     setDeleteReauthPassword('');
+    setIsDeletePasswordVisible(false);
   }
 
   async function handleDeleteWithReauthPassword() {
@@ -689,17 +693,31 @@ export default function ProfileScreen() {
             <Text style={[TypeScale.body, { color: palette.icon }]}>
               For security, please re-enter your password for {deleteReauthEmail || 'your account'}.
             </Text>
-            <TextInput
-              autoCapitalize="none"
-              autoCorrect={false}
-              editable={!isReauthenticatingDelete}
-              onChangeText={setDeleteReauthPassword}
-              placeholder="Password"
-              placeholderTextColor={placeholderColor}
-              secureTextEntry
-              style={[styles.input, inputColors]}
-              value={deleteReauthPassword}
-            />
+            <View>
+              <TextInput
+                autoCapitalize="none"
+                autoCorrect={false}
+                editable={!isReauthenticatingDelete}
+                onChangeText={setDeleteReauthPassword}
+                placeholder="Password"
+                placeholderTextColor={placeholderColor}
+                secureTextEntry={!isDeletePasswordVisible}
+                style={[styles.input, styles.secureInput, inputColors]}
+                value={deleteReauthPassword}
+              />
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={isDeletePasswordVisible ? 'Hide password' : 'Show password'}
+                hitSlop={8}
+                onPress={() => setIsDeletePasswordVisible((visible) => !visible)}
+                style={styles.secureToggle}>
+                <IconSymbol
+                  name={isDeletePasswordVisible ? 'eye.slash' : 'eye'}
+                  size={20}
+                  color={palette.icon}
+                />
+              </Pressable>
+            </View>
             <View style={styles.modalActions}>
               <Button
                 label="Cancel"
@@ -874,6 +892,18 @@ const styles = StyleSheet.create({
     minHeight: 52,
     paddingHorizontal: Space.lg,
     paddingVertical: Space.md,
+  },
+  secureInput: {
+    paddingRight: Space.lg + 28,
+  },
+  secureToggle: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: Space.md,
+    top: 0,
+    width: 28,
   },
   searchResults: {
     gap: Space.sm + 2,

--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -421,6 +421,8 @@ export default function CreateSessionScreen() {
           <Text style={[styles.question, { color: palette.text }]}>Where are you studying?</Text>
           <TextInput
             autoCapitalize="words"
+            autoCorrect={false}
+            spellCheck={false}
             onChangeText={setLocationQuery}
             placeholder="Search spots by name, building, or tag"
             placeholderTextColor={placeholderColor}

--- a/app/session/[sessionId].tsx
+++ b/app/session/[sessionId].tsx
@@ -304,6 +304,15 @@ export default function SessionDetailScreen() {
           ? `${durationMinutes / 60} hr`
           : `${Math.floor(durationMinutes / 60)}h ${durationMinutes % 60}m`;
   const deptTint = session ? deptColorFor(session.classId) ?? palette.text : palette.text;
+  // The course chip already names the class, so a title like
+  // "COMP SCI 400 Study Session" would repeat it — show just the rest
+  // ("Study Session"). Custom titles without the class prefix pass through.
+  const rawTitle = session?.title.trim() ?? '';
+  const classPrefix = session ? `${session.classId.trim()} ` : '';
+  const heroTitle =
+    classPrefix.length > 1 && rawTitle.toUpperCase().startsWith(classPrefix.toUpperCase())
+      ? rawTitle.slice(classPrefix.length).trim() || rawTitle
+      : rawTitle;
 
   // Board lists three authored "house rules"; per-session rules are not in the
   // data model, so the spot's own notes + tags (the closest real guidance)
@@ -325,7 +334,7 @@ export default function SessionDetailScreen() {
         refreshControl={
           <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={palette.tint} />
         }
-        contentContainerStyle={[styles.content, { paddingTop: Space.lg }]}>
+        contentContainerStyle={[styles.content, { paddingTop: Space.sm }]}>
         {session ? (
           <>
             {/* 1. HERO — banner, course chip, title, time/location summary.
@@ -352,10 +361,11 @@ export default function SessionDetailScreen() {
                   <BadgeChip label="Full" tone="neutral" />
                 ) : null}
               </View>
-              <Text style={[styles.heroTitle, { color: palette.text }]}>{session.title}</Text>
+              <Text style={[styles.heroTitle, { color: palette.text }]}>{heroTitle}</Text>
+              {/* The banner directly above already names the spot, so the
+                  meta line only carries the time window. */}
               <Text style={[TypeScale.body, { color: palette.icon }]} numberOfLines={1}>
                 {formatSessionWindow(session.startTime, session.endTime)}
-                {session.location?.name ? ` · ${session.location.name}` : ''}
               </Text>
             </View>
 

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import {
+  Pressable,
   StyleSheet,
   Text,
   TextInput,
@@ -9,6 +10,7 @@ import {
   type ViewStyle,
 } from 'react-native';
 
+import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Brand, Colors, FontFamily, Radius, Space, TypeScale } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
@@ -22,12 +24,21 @@ export type InputProps = Omit<TextInputProps, 'style'> & {
 
 /**
  * Labeled text field (handoff §2): 12pt uppercase eyebrow label, 48pt input,
- * stronger border on focus. Errors render below in accent.
+ * stronger border on focus. Errors render below in accent. Secure fields get
+ * a built-in show/hide toggle (hidden by default, iOS-style eye icon).
  */
-export function Input({ label, error, helper, containerStyle, ...inputProps }: InputProps) {
+export function Input({
+  label,
+  error,
+  helper,
+  containerStyle,
+  secureTextEntry,
+  ...inputProps
+}: InputProps) {
   const colorScheme = useColorScheme() ?? 'light';
   const palette = Colors[colorScheme];
   const [focused, setFocused] = useState(false);
+  const [passwordVisible, setPasswordVisible] = useState(false);
 
   const placeholderColor = colorScheme === 'dark' ? '#8A8174' : Brand.textSubtle;
 
@@ -36,26 +47,44 @@ export function Input({ label, error, helper, containerStyle, ...inputProps }: I
       {label ? (
         <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>{label}</Text>
       ) : null}
-      <TextInput
-        placeholderTextColor={placeholderColor}
-        {...inputProps}
-        onFocus={(event) => {
-          setFocused(true);
-          inputProps.onFocus?.(event);
-        }}
-        onBlur={(event) => {
-          setFocused(false);
-          inputProps.onBlur?.(event);
-        }}
-        style={[
-          styles.input,
-          {
-            backgroundColor: palette.surfaceMuted,
-            borderColor: error ? palette.tint : focused ? palette.outline : palette.border,
-            color: palette.text,
-          },
-        ]}
-      />
+      <View>
+        <TextInput
+          placeholderTextColor={placeholderColor}
+          {...inputProps}
+          secureTextEntry={secureTextEntry && !passwordVisible}
+          onFocus={(event) => {
+            setFocused(true);
+            inputProps.onFocus?.(event);
+          }}
+          onBlur={(event) => {
+            setFocused(false);
+            inputProps.onBlur?.(event);
+          }}
+          style={[
+            styles.input,
+            secureTextEntry ? styles.secureInput : null,
+            {
+              backgroundColor: palette.surfaceMuted,
+              borderColor: error ? palette.tint : focused ? palette.outline : palette.border,
+              color: palette.text,
+            },
+          ]}
+        />
+        {secureTextEntry ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={passwordVisible ? 'Hide password' : 'Show password'}
+            hitSlop={8}
+            onPress={() => setPasswordVisible((visible) => !visible)}
+            style={styles.secureToggle}>
+            <IconSymbol
+              name={passwordVisible ? 'eye.slash' : 'eye'}
+              size={20}
+              color={palette.icon}
+            />
+          </Pressable>
+        ) : null}
+      </View>
       {error ? (
         <Text style={[TypeScale.caption, { color: palette.tint }]}>{error}</Text>
       ) : helper ? (
@@ -76,5 +105,17 @@ const styles = StyleSheet.create({
     fontSize: 15,
     minHeight: 48,
     paddingHorizontal: Space.lg,
+  },
+  secureInput: {
+    paddingRight: Space.lg + 28,
+  },
+  secureToggle: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: Space.md,
+    top: 0,
+    width: 28,
   },
 });

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -22,6 +22,8 @@ const MAPPING = {
   'map.fill': 'map',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  eye: 'visibility',
+  'eye.slash': 'visibility-off',
 } as IconMapping;
 
 /**

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -380,7 +380,22 @@ export async function getLocations() {
       mergedLocations.set(location.locationId, withBuiltInLocationFallback(location));
     }
 
-    return [...mergedLocations.values()].sort((firstLocation, secondLocation) =>
+    // Firestore alias docs (e.g. `morgridge`) can carry the same display name
+    // as a built-in spot under a different id, rendering as duplicate rows in
+    // the location picker. Keep one entry per display name — built-ins are
+    // inserted first, so the curated record (real map position, notes, tags)
+    // wins over the alias.
+    const dedupedByName = new Map<string, StudyLocation>();
+
+    for (const location of mergedLocations.values()) {
+      const nameKey = location.name.trim().toLowerCase();
+
+      if (!dedupedByName.has(nameKey)) {
+        dedupedByName.set(nameKey, location);
+      }
+    }
+
+    return [...dedupedByName.values()].sort((firstLocation, secondLocation) =>
       firstLocation.name.localeCompare(secondLocation.name)
     );
   } catch (error) {


### PR DESCRIPTION
## Summary

Focused UX polish pass — no product behavior or business logic changes.

- **Location picker duplicates**: `getLocations()` now dedupes merged locations by display name. Firestore alias docs (e.g. `morgridge`, `steenbock-lib`) no longer render as duplicate rows next to their built-in counterparts (`morgridge-hall`, `steenbock-library`); the curated built-in record (real map position, notes, tags) wins. No built-in dataset entries renamed or removed — all names were already unique.
- **Session details hero**: strips the redundant class prefix from the displayed title (the course chip already names the class, so "COMP SCI 400 Study Session" renders as chip + "Study Session"; custom titles pass through, stored title unchanged), drops the duplicated location name from the meta line (the banner above already shows it; the Where card keeps full details), and tightens top padding above the hero.
- **Show/hide password**: shared `Input` renders an eye toggle on any `secureTextEntry` field (hidden by default, SF Symbols `eye`/`eye.slash` on iOS, MaterialIcons fallback elsewhere) — covers Sign In and Create Account. The delete-account reauth modal's raw `TextInput` gets the same toggle, resetting to hidden on open/close.
- **Email input UX**: `autoCorrect={false}` + `spellCheck={false}` on both email fields (Sign In, Sign Up — the only email inputs in the app) and on the create-session location search field.

Follow-up (not in this PR): the Firestore alias docs themselves could be deleted server-side; needs service-account access.

## Validation

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run rules:test` — 39 passing
- `npx expo export --platform web` — exports successfully

Password-toggle interaction still deserves a quick on-device QA pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)