### PR TITLE
fix: collapse empty session-details banner into compact location eyebrow

### DIFF
--- a/app/session/[sessionId].tsx
+++ b/app/session/[sessionId].tsx
@@ -21,7 +21,6 @@ import { SuccessToast, useSuccessToast } from '@/components/ui/Toast';
 import {
     Brand,
     Colors,
-    deptColorFor,
     Elevation,
     FontFamily,
     Radius,
@@ -303,7 +302,6 @@ export default function SessionDetailScreen() {
         : durationMinutes % 60 === 0
           ? `${durationMinutes / 60} hr`
           : `${Math.floor(durationMinutes / 60)}h ${durationMinutes % 60}m`;
-  const deptTint = session ? deptColorFor(session.classId) ?? palette.text : palette.text;
   // The course chip already names the class, so a title like
   // "COMP SCI 400 Study Session" would repeat it — show just the rest
   // ("Study Session"). Custom titles without the class prefix pass through.
@@ -337,22 +335,14 @@ export default function SessionDetailScreen() {
         contentContainerStyle={[styles.content, { paddingTop: Space.sm }]}>
         {session ? (
           <>
-            {/* 1. HERO — banner, course chip, title, time/location summary.
-                Dept tint stands in for the location imagery the app lacks. */}
-            <View
-              style={[
-                styles.banner,
-                {
-                  backgroundColor:
-                    colorScheme === 'dark' ? `${deptTint}26` : `${deptTint}14`,
-                },
-              ]}>
+            {/* 1. HERO — location eyebrow, course chip, title, time. The app
+                has no location imagery, so a compact eyebrow row stands in
+                for the banner instead of an empty placeholder block. */}
+            <View style={styles.heroBlock}>
               <Text style={[TypeScale.eyebrow, { color: palette.icon }]} numberOfLines={1}>
                 {session.location?.name ?? session.locationId}
                 {session.location?.campusArea ? ` · ${session.location.campusArea}` : ''}
               </Text>
-            </View>
-            <View style={styles.heroBlock}>
               <View style={styles.heroChipRow}>
                 <CourseChip code={session.classId} size="lg" />
                 {isCancelled ? (
@@ -637,12 +627,6 @@ const styles = StyleSheet.create({
     gap: Space.lg,
     padding: Space.lg + 4,
     paddingBottom: Space.xxl,
-  },
-  banner: {
-    borderRadius: Radius.xxl - 4,
-    justifyContent: 'flex-end',
-    minHeight: 96,
-    padding: Space.lg,
   },
   heroBlock: {
     gap: Space.sm + 2,

--- a/data/uw-study-locations.ts
+++ b/data/uw-study-locations.ts
@@ -168,7 +168,7 @@ export const UW_STUDY_LOCATIONS: OfficialStudyLocation[] = [
     locationId: 'parkside',
     mapPosition: { xPercent: 32, yPercent: 56 },
     name: 'DeLuca Forum at Discovery Building',
-    building: 'Discovery Building',
+    building: 'Discovery Building (Morgridge Institute for Research)',
     campusArea: 'West Campus',
     notes: 'Open, bright collaborative area that works well for group meetups and flexible sessions.',
     tags: ['collaborative', 'bright', 'west-campus', 'meetup'],


### PR DESCRIPTION
## Summary

Follow-up to #44 — the Session Details hero still opened with a 96pt tinted banner card that held only a single line of text, pushing real content down the screen.

- Removed the banner block entirely (there is no real location imagery behind it) and moved its `LOCATION · CAMPUS AREA` eyebrow to the top of the hero block. The screen now reads, top to bottom: location eyebrow → course chip → session title → time window.
- No data lost: location name/campus area stay in the hero eyebrow and the full Where card is unchanged. Join/leave/cancel/message behavior untouched.
- Morgridge clarification: the duplicate removed in #44 was confirmed a Firestore alias (`morgridge`) with coordinates identical to the built-in `morgridge-hall` — same building, not a second location. The Morgridge Institute for Research is housed in the Discovery Building, which is already curated as "DeLuca Forum at Discovery Building"; its building label now reads "Discovery Building (Morgridge Institute for Research)" so searching "Morgridge Institute" finds it, with a display name that can't be confused with Morgridge Hall.

## Validation

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx expo export --platform web` — exports successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)