### PR TITLE
fix: resolve location alias ids to curated display names everywhere

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -33,6 +33,7 @@ import {
   type StudyLocation,
   type StudySession,
 } from '@/lib/firestore';
+import { canonicalStudyLocationId } from '@/lib/catalog';
 import type { User } from 'firebase/auth';
 
 type MapFilter = 'all' | 'live' | 'next-hour' | 'my-classes' | 'quiet';
@@ -116,9 +117,16 @@ export default function StudyLocationsScreen() {
         getLocationRatingAggregates().catch(() => new Map<string, LocationRatingAggregate>()),
         getUserProfile(currentUser.uid).catch(() => null),
       ]);
+      // Sessions may reference Firestore-only alias ids (e.g. `morgridge`);
+      // the pin list only carries the curated ids, so canonicalize before
+      // grouping or those sessions never show up on the map.
+      const canonicalSessions = loadedSessions.map((session) => ({
+        ...session,
+        locationId: canonicalStudyLocationId(session.locationId),
+      }));
       const counts = new Map<string, number>();
 
-      loadedSessions.forEach((session) => {
+      canonicalSessions.forEach((session) => {
         counts.set(session.locationId, (counts.get(session.locationId) ?? 0) + 1);
       });
 
@@ -128,7 +136,7 @@ export default function StudyLocationsScreen() {
       )[0];
 
       setLocations(loadedLocations);
-      setSessions(loadedSessions);
+      setSessions(canonicalSessions);
       setRatingAggregates(aggregatesResult);
       setProfileClasses(profileResult?.classes ?? []);
       setSelectedLocationId((current) => current ?? firstLocation?.locationId ?? null);

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -32,6 +32,7 @@ import {
   type StudySession,
   type UserProfile,
 } from '@/lib/firestore';
+import { getStudyLocationDisplayName } from '@/lib/catalog';
 import type { User } from 'firebase/auth';
 
 type TodaySession = StudySession & { locationName: string };
@@ -272,7 +273,10 @@ export default function HomeScreen() {
       setSessions(
         loadedSessions.map((session) => ({
           ...session,
-          locationName: locationsById.get(session.locationId)?.name ?? session.locationId,
+          locationName: getStudyLocationDisplayName(
+            session.locationId,
+            locationsById.get(session.locationId)?.name
+          ),
         }))
       );
     } catch (error) {

--- a/app/(tabs)/sessions.tsx
+++ b/app/(tabs)/sessions.tsx
@@ -29,6 +29,7 @@ import {
     joinSession,
     type StudySession,
 } from '@/lib/firestore';
+import { getStudyLocationDisplayName } from '@/lib/catalog';
 import type { User } from 'firebase/auth';
 
 type SessionListEntry = StudySession & {
@@ -141,7 +142,10 @@ export default function SessionsScreen() {
         loadedSessions.map((session) => ({
           ...session,
           hostName: hostsById.get(session.hostId)?.displayName || 'Student',
-          locationName: locationsById.get(session.locationId)?.name ?? session.locationId,
+          locationName: getStudyLocationDisplayName(
+            session.locationId,
+            locationsById.get(session.locationId)?.name
+          ),
         }))
       );
       setStatus(

--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -33,6 +33,7 @@ import {
   type LocationRatingAggregate,
   type StudyLocation,
 } from '@/lib/firestore';
+import { canonicalStudyLocationId } from '@/lib/catalog';
 import {
   MAX_DAYS_IN_FUTURE,
   validateSessionSchedule,
@@ -218,10 +219,15 @@ export default function CreateSessionScreen() {
         normalizedRequestedClass && profileClasses.includes(normalizedRequestedClass)
           ? normalizedRequestedClass
           : profileClasses[0] ?? '';
+      // The picker only lists canonical ids, so resolve alias ids (e.g. a
+      // deep link carrying `morgridge`) before matching.
+      const canonicalRequestedId = requestedLocationId
+        ? canonicalStudyLocationId(requestedLocationId)
+        : '';
       const defaultLocationId = loadedLocations.some(
-        (location) => location.locationId === requestedLocationId
+        (location) => location.locationId === canonicalRequestedId
       )
-        ? requestedLocationId ?? ''
+        ? canonicalRequestedId
         : loadedLocations[0]?.locationId ?? '';
 
       setClasses(profileClasses);

--- a/app/rate-location.tsx
+++ b/app/rate-location.tsx
@@ -17,6 +17,7 @@ import { Brand, Colors, FontFamily, Radius, Space, TypeScale } from '@/constants
 import { LOCATION_RATING_TAG_GROUPS } from '@/data/location-rating-options';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { subscribeToAuthState } from '@/lib/auth';
+import { getStudyLocationDisplayName } from '@/lib/catalog';
 import { getUserLocationRating, submitLocationRating } from '@/lib/firestore';
 import type { User } from 'firebase/auth';
 
@@ -135,7 +136,9 @@ export default function RateLocationScreen() {
       ]}>
       <View style={styles.header}>
         <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>Reviewing</Text>
-        <Text style={[TypeScale.title, { color: palette.text }]}>{locationName}</Text>
+        <Text style={[TypeScale.title, { color: palette.text }]}>
+          {getStudyLocationDisplayName(locationId ?? '', locationName)}
+        </Text>
         {hasExistingRating ? (
           <View style={styles.noticeRow}>
             <BadgeChip label="Already rated" tone="info" />

--- a/app/session/[sessionId].tsx
+++ b/app/session/[sessionId].tsx
@@ -39,6 +39,7 @@ import {
     leaveSession,
     type StudySessionListItem,
 } from '@/lib/firestore';
+import { getStudyLocationDisplayName } from '@/lib/catalog';
 import { FirebaseError } from 'firebase/app';
 import type { User } from 'firebase/auth';
 
@@ -305,6 +306,9 @@ export default function SessionDetailScreen() {
   // The course chip already names the class, so a title like
   // "COMP SCI 400 Study Session" would repeat it — show just the rest
   // ("Study Session"). Custom titles without the class prefix pass through.
+  const locationDisplayName = session
+    ? getStudyLocationDisplayName(session.locationId, session.location?.name)
+    : '';
   const rawTitle = session?.title.trim() ?? '';
   const classPrefix = session ? `${session.classId.trim()} ` : '';
   const heroTitle =
@@ -340,7 +344,7 @@ export default function SessionDetailScreen() {
                 for the banner instead of an empty placeholder block. */}
             <View style={styles.heroBlock}>
               <Text style={[TypeScale.eyebrow, { color: palette.icon }]} numberOfLines={1}>
-                {session.location?.name ?? session.locationId}
+                {locationDisplayName}
                 {session.location?.campusArea ? ` · ${session.location.campusArea}` : ''}
               </Text>
               <View style={styles.heroChipRow}>
@@ -495,7 +499,7 @@ export default function SessionDetailScreen() {
               ]}>
               <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>Where</Text>
               <Text style={[TypeScale.heading, { color: palette.text }]}>
-                {session.location?.name ?? session.locationId}
+                {locationDisplayName}
               </Text>
               <Text style={[TypeScale.body, { color: palette.icon }]}>
                 {session.location?.building ?? 'Campus location'}
@@ -517,7 +521,7 @@ export default function SessionDetailScreen() {
                       pathname: '/rate-location',
                       params: {
                         locationId: session.locationId,
-                        locationName: session.location?.name ?? session.locationId,
+                        locationName: locationDisplayName,
                       },
                     })
                   }

--- a/data/uw-study-locations.ts
+++ b/data/uw-study-locations.ts
@@ -15,6 +15,16 @@ export type OfficialStudyLocation = {
   tags: string[];
 };
 
+// Firestore-only alias ids found on existing session/location docs, mapped to
+// the curated location record they refer to (coordinates match exactly). Lets
+// old sessions resolve to the curated display name without a data migration.
+export const UW_STUDY_LOCATION_ALIASES: Record<string, string> = {
+  morgridge: 'morgridge-hall',
+  'steenbock-lib': 'steenbock-library',
+  'whs-reading-room': 'wisconsin-historical-society',
+  'wsb-library': 'business-learning-commons',
+};
+
 export const UW_STUDY_LOCATION_COORDINATE_OVERRIDES: Record<
   string,
   OfficialStudyLocation['coordinates']

--- a/lib/catalog.ts
+++ b/lib/catalog.ts
@@ -1,5 +1,9 @@
 import rawCourseCatalog from '@/data/uw-course-catalog.json';
-import { UW_STUDY_LOCATIONS, type OfficialStudyLocation } from '@/data/uw-study-locations';
+import {
+  UW_STUDY_LOCATIONS,
+  UW_STUDY_LOCATION_ALIASES,
+  type OfficialStudyLocation,
+} from '@/data/uw-study-locations';
 import * as catalogSearch from './catalog-search.js';
 
 export type CatalogCourse = {
@@ -96,6 +100,36 @@ export function searchStudyLocations(query: string) {
   });
 }
 
+export function canonicalStudyLocationId(locationId: string): string {
+  return UW_STUDY_LOCATION_ALIASES[locationId] ?? locationId;
+}
+
 export function findStudyLocationById(locationId: string): OfficialStudyLocation | null {
-  return UW_STUDY_LOCATIONS.find((location) => location.locationId === locationId) ?? null;
+  const canonicalId = canonicalStudyLocationId(locationId);
+  return UW_STUDY_LOCATIONS.find((location) => location.locationId === canonicalId) ?? null;
+}
+
+// Last-resort label for ids with no curated record and no stored name:
+// "math-library" → "Math Library". Never surfaces the raw slug.
+export function formatStudyLocationLabel(locationId: string): string {
+  const label = locationId
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(' ');
+
+  return label || 'Campus study spot';
+}
+
+export function getStudyLocationDisplayName(
+  locationId: string,
+  preferredName?: string | null
+): string {
+  const trimmedName = preferredName?.trim();
+
+  if (trimmedName && trimmedName !== locationId) {
+    return trimmedName;
+  }
+
+  return findStudyLocationById(locationId)?.name ?? formatStudyLocationLabel(locationId);
 }

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -27,7 +27,7 @@ import {
   UW_STUDY_LOCATIONS,
 } from "@/data/uw-study-locations";
 import { sanitizeLocationRatingTags } from "@/data/location-rating-options";
-import { findStudyLocationById } from "@/lib/catalog";
+import { findStudyLocationById, formatStudyLocationLabel } from "@/lib/catalog";
 import { db } from "../firebaseConfig";
 import { track } from "./analytics";
 export const COLLECTIONS = {
@@ -195,7 +195,12 @@ function normalizeStudyLocation(
       typeof location.mapPosition.yPercent === "number"
         ? location.mapPosition
         : fallback?.mapPosition ?? { xPercent: 50, yPercent: 50 },
-    name: location.name ?? fallback?.name ?? locationId,
+    // A stored name that just repeats the doc id is a slug, not a display
+    // name — prefer the curated name (or a humanized label) instead.
+    name:
+      location.name && location.name.trim() && location.name.trim() !== locationId
+        ? location.name.trim()
+        : fallback?.name ?? formatStudyLocationLabel(locationId),
     notes: location.notes ?? fallback?.notes ?? "Study location on or near campus.",
     tags: Array.isArray(location.tags) ? location.tags : fallback?.tags ?? [],
   };
@@ -646,10 +651,13 @@ export async function getSessionById(sessionId: string) {
       .filter((participant): participant is UserProfile => !!participant),
     hostProfile: profilesById.get(session.hostId) ?? null,
     location: location.exists()
-      ? ({
-          locationId: location.id,
-          ...(location.data() as Omit<StudyLocation, "locationId">),
-        } satisfies StudyLocation)
+      ? // Normalize rather than spreading the raw doc — alias docs (e.g.
+        // `morgridge`) may lack a display name, and normalization backfills
+        // it from the curated record so the UI never shows the id.
+        normalizeStudyLocation(
+          location.id,
+          location.data() as Partial<Omit<StudyLocation, "locationId">>
+        )
       : findStudyLocationById(session.locationId),
   } satisfies StudySessionListItem;
 }


### PR DESCRIPTION
## Problem

The Today screen (and other surfaces) showed raw internal location slugs, e.g.:

> Wed, Jul 15 • 2:00 PM–4:00 PM • **morgridge**

instead of:

> Wed, Jul 15 • 2:00 PM–4:00 PM • **Morgridge Hall**

## Root cause

Existing sessions reference Firestore-only alias location ids (e.g. `morgridge`) while the curated catalog uses `morgridge-hall`. Two paths leaked the slug:

1. `getLocations()` dedupes the merged location list by display name, dropping alias entries — screens' `locationsById` lookups missed and fell back to `?? session.locationId`.
2. `normalizeStudyLocation` fell back to `name: locationId` for alias docs with no stored name, and `findStudyLocationById` didn't know about aliases.

## Fix

- **`data/uw-study-locations.ts`**: new `UW_STUDY_LOCATION_ALIASES` map (`morgridge` → `morgridge-hall`, `steenbock-lib` → `steenbock-library`, `whs-reading-room` → `wisconsin-historical-society`, `wsb-library` → `business-learning-commons`; each verified via identical coordinates in the existing overrides table).
- **`lib/catalog.ts`**: alias-aware `findStudyLocationById`; new `canonicalStudyLocationId`, `formatStudyLocationLabel` (humanized-slug last resort), and `getStudyLocationDisplayName` (stored name → curated name → humanized label — never the raw id, and a stored name that merely repeats the id is treated as missing).
- **`lib/firestore.ts`**: `normalizeStudyLocation` never names a location after its doc id; `getSessionById` normalizes the location doc instead of spreading it raw.
- **Screens**: Today feed, sessions list, Session Details (hero, "Where" card, rate-location params), and rate-location title all resolve through the helper; the map canonicalizes session location ids so alias sessions count toward the right pin; create-session canonicalizes a deep-linked `locationId` before matching the picker.

## Data migration

None — resolution is entirely client-side via the static alias map, so existing session/location docs work as-is.

## Validation

- `npx tsc --noEmit` ✅
- `expo lint` ✅
- `expo export --platform web` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)