### PR TITLE
feat: session capacity with transactional joins and rules enforcement

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -28,7 +28,9 @@ import {
   getProfilesByIds,
   getUpcomingSessionsForClasses,
   getUserProfile,
+  isSessionAtCapacity,
   joinSession,
+  SessionFullError,
   type StudySession,
   type UserProfile,
 } from '@/lib/firestore';
@@ -95,7 +97,10 @@ function HeroCard({
   const colorScheme = useColorScheme() ?? 'light';
   const palette = Colors[colorScheme];
   const going = session.participantIds.length;
-  const isFull = session.status === 'full';
+  const isFull = session.status === 'full' || isSessionAtCapacity(session);
+  // "3 of 8 going" once capacity exists; pre-capacity sessions keep the count.
+  const goingLabel =
+    typeof session.capacity === 'number' ? `${going} of ${session.capacity} going` : `${going} going`;
 
   const eyebrow =
     kind === 'live' ? 'Happening now' : kind === 'joined' ? 'Your next session' : 'Up next';
@@ -135,7 +140,7 @@ function HeroCard({
           </Text>
         </View>
         <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>
-          {going} going
+          {goingLabel}
         </Text>
       </View>
       <CourseChip code={session.classId} size="lg" />
@@ -156,12 +161,21 @@ function HeroCard({
 /**
  * Board upcoming row (index.tsx ~247-269): standalone card, course chip +
  * title + "location · time" left, big accent count + tiny uppercase label
- * right. Board's number is seats-left; without capacity data it is the
- * going count.
+ * right. The board's number is seats-left — now real via capacity;
+ * pre-capacity sessions fall back to the going count.
  */
 function UpcomingRow({ session, onPress }: { session: TodaySession; onPress: () => void }) {
   const colorScheme = useColorScheme() ?? 'light';
   const palette = Colors[colorScheme];
+  const isFull = session.status === 'full' || isSessionAtCapacity(session);
+  const spotsLeft =
+    typeof session.capacity === 'number'
+      ? Math.max(session.capacity - session.participantIds.length, 0)
+      : undefined;
+  const count =
+    spotsLeft !== undefined
+      ? { number: String(spotsLeft), label: 'left' }
+      : { number: String(session.participantIds.length), label: 'going' };
 
   return (
     <Pressable
@@ -172,7 +186,7 @@ function UpcomingRow({ session, onPress }: { session: TodaySession; onPress: () 
         {
           backgroundColor: palette.surface,
           borderColor: palette.border,
-          opacity: pressed ? 0.85 : session.status === 'full' ? 0.6 : 1,
+          opacity: pressed ? 0.85 : isFull ? 0.6 : 1,
         },
       ]}>
       <View style={styles.upcomingBody}>
@@ -186,12 +200,14 @@ function UpcomingRow({ session, onPress }: { session: TodaySession; onPress: () 
           {session.locationName} · {formatSessionStart(session.startTime)}
         </Text>
       </View>
-      <View style={styles.upcomingCount}>
-        <Text style={[styles.upcomingNumber, { color: palette.tint }]}>
-          {session.participantIds.length}
-        </Text>
-        <Text style={[styles.upcomingNumberLabel, { color: palette.icon }]}>going</Text>
-      </View>
+      {isFull ? (
+        <BadgeChip label="Full" tone="neutral" />
+      ) : (
+        <View style={styles.upcomingCount}>
+          <Text style={[styles.upcomingNumber, { color: palette.tint }]}>{count.number}</Text>
+          <Text style={[styles.upcomingNumberLabel, { color: palette.icon }]}>{count.label}</Text>
+        </View>
+      )}
     </Pressable>
   );
 }
@@ -376,6 +392,13 @@ export default function HomeScreen() {
         showToast('You’re in.', hero.title || 'See you at the table.');
       }
     } catch (error) {
+      // Lost the last-seat race — refresh so the hero flips to Full.
+      if (error instanceof SessionFullError) {
+        track('session_join_blocked_full', { classId: hero.classId });
+        await loadSessions();
+        Alert.alert('Session Full', error.message);
+        return;
+      }
       const message =
         error instanceof Error ? error.message : 'Unable to join this session right now.';
       Alert.alert('Join Session Error', message);

--- a/app/(tabs)/sessions.tsx
+++ b/app/(tabs)/sessions.tsx
@@ -26,7 +26,9 @@ import {
     getProfilesByIds,
     getUpcomingSessions,
     getUserProfile,
+    isSessionAtCapacity,
     joinSession,
+    SessionFullError,
     type StudySession,
 } from '@/lib/firestore';
 import { getStudyLocationDisplayName } from '@/lib/catalog';
@@ -197,6 +199,18 @@ export default function SessionsScreen() {
         showToast('You’re in.', joinedSession?.title ?? 'See you at the table.');
       }
     } catch (error) {
+      // Final seat went to someone else moments earlier — refresh so the
+      // card flips to Full, and tell the user what happened.
+      if (error instanceof SessionFullError) {
+        const fullSession = sessions.find((session) => session.sessionId === sessionId);
+        if (fullSession) {
+          track('session_join_blocked_full', { classId: fullSession.classId });
+        }
+        await loadSessions();
+        setStatus(error.message);
+        Alert.alert('Session Full', error.message);
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Unable to join this session right now.';
       setStatus(message);
       Alert.alert('Join Session Error', message);
@@ -332,7 +346,7 @@ export default function SessionsScreen() {
             const isParticipant = currentUser
               ? session.participantIds.includes(currentUser.uid)
               : false;
-            const isFull = session.status === 'full';
+            const isFull = session.status === 'full' || isSessionAtCapacity(session);
 
             return (
               <SessionCard

--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -30,6 +30,7 @@ import {
   getLocationRatingAggregates,
   getLocations,
   getUserProfile,
+  SESSION_CAPACITY_DEFAULT,
   type LocationRatingAggregate,
   type StudyLocation,
 } from '@/lib/firestore';
@@ -110,6 +111,13 @@ const DURATION_PRESETS = [
   { label: '3 hr', minutes: 180 },
 ] as const;
 
+/**
+ * Board CreateCapacityScreen seat grid — preset tiles in a 4-column grid.
+ * The board shows 2–12; 16 and 20 extend the row to cover the full allowed
+ * range (2–20) without a slider.
+ */
+const CAPACITY_PRESETS = [2, 4, 6, 8, 10, 12, 16, 20];
+
 /** "HH:MM" + minutes, or null when it would cross midnight (end must be same-day). */
 function addMinutesToTime(time: string, minutes: number): string | null {
   const [hours, mins] = time.split(':').map(Number);
@@ -141,6 +149,7 @@ export default function CreateSessionScreen() {
   const [selectedCalendarMonth, setSelectedCalendarMonth] = useState(() => startOfMonth(new Date()));
   const [startTime, setStartTime] = useState('');
   const [endTime, setEndTime] = useState('');
+  const [capacity, setCapacity] = useState(SESSION_CAPACITY_DEFAULT);
   const [focusText, setFocusText] = useState('');
   const { toast, show: showToast } = useSuccessToast();
   const [status, setStatus] = useState('Sign in to create a study session.');
@@ -325,11 +334,13 @@ export default function CreateSessionScreen() {
         title: sessionTitle,
         startTime: new Date(validatedSchedule.startTimeIso),
         endTime: new Date(validatedSchedule.endTimeIso),
+        capacity,
       });
 
       track('session_created', {
         classId: selectedClass,
         locationId: selectedLocationId,
+        capacity,
         hoursUntilStart: Math.round(
           (new Date(validatedSchedule.startTimeIso).getTime() - Date.now()) / 3_600_000
         ),
@@ -339,6 +350,7 @@ export default function CreateSessionScreen() {
       setSessionDate('');
       setStartTime('');
       setEndTime('');
+      setCapacity(SESSION_CAPACITY_DEFAULT);
       setFocusText('');
       showToast('Session posted', sessionTitle);
     } catch (error) {
@@ -372,8 +384,9 @@ export default function CreateSessionScreen() {
       endTime: Timestamp.fromDate(end),
       status: 'open' as const,
       participantIds: currentUser ? [currentUser.uid] : [],
+      capacity,
     };
-  }, [currentUser, endTime, focusText, selectedClass, sessionDate, startTime]);
+  }, [capacity, currentUser, endTime, focusText, selectedClass, sessionDate, startTime]);
 
   const selectedLocation = locations.find(
     (location) => location.locationId === selectedLocationId
@@ -685,6 +698,48 @@ export default function CreateSessionScreen() {
           </Text>
         </View>
 
+        {/* Board CreateCapacityScreen: "How many seats?" — eyebrow row with an
+            "Including you" hint, then a 4-column grid of square seat tiles;
+            the selected tile is solid accent with white text. */}
+        <View style={styles.section}>
+          <Text style={[styles.question, { color: palette.text }]}>How many seats?</Text>
+          <View style={styles.capacityLabelRow}>
+            <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>Capacity</Text>
+            <Text style={[TypeScale.caption, { color: palette.icon }]}>Including you</Text>
+          </View>
+          <View style={styles.capacityGrid}>
+            {CAPACITY_PRESETS.map((seatCount) => {
+              const isSelected = capacity === seatCount;
+
+              return (
+                <Pressable
+                  key={seatCount}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${seatCount} seats`}
+                  accessibilityState={{ selected: isSelected }}
+                  onPress={() => setCapacity(seatCount)}
+                  style={[
+                    styles.capacityTile,
+                    isSelected
+                      ? { backgroundColor: palette.tint, borderColor: palette.tint }
+                      : { backgroundColor: palette.surface, borderColor: palette.border },
+                  ]}>
+                  <Text
+                    style={[
+                      styles.capacityTileNumber,
+                      { color: isSelected ? '#FFFFFF' : palette.text },
+                    ]}>
+                    {seatCount}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <Text style={[TypeScale.caption, { color: palette.icon }]}>
+            {`Join closes at ${capacity} — you hold the first seat.`}
+          </Text>
+        </View>
+
         <View style={styles.section}>
           <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>Focus (optional)</Text>
           <TextInput
@@ -838,6 +893,31 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: Space.sm,
+  },
+  capacityLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+    gap: Space.sm,
+  },
+  capacityGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Space.sm + 2,
+  },
+  capacityTile: {
+    alignItems: 'center',
+    aspectRatio: 1,
+    borderRadius: Radius.xl,
+    borderWidth: StyleSheet.hairlineWidth * 2,
+    flexBasis: '21%',
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+  capacityTileNumber: {
+    fontFamily: FontFamily.bodySemiBold,
+    fontSize: 18,
+    lineHeight: 22,
   },
   durationPill: {
     alignItems: 'center',

--- a/app/session/[sessionId].tsx
+++ b/app/session/[sessionId].tsx
@@ -35,8 +35,10 @@ import {
     getBlockedUserIds,
     getOrCreateDirectConversation,
     getSessionById,
+    isSessionAtCapacity,
     joinSession,
     leaveSession,
+    SessionFullError,
     type StudySessionListItem,
 } from '@/lib/firestore';
 import { getStudyLocationDisplayName } from '@/lib/catalog';
@@ -153,6 +155,17 @@ export default function SessionDetailScreen() {
         showToast('You’re in.', session?.title ?? 'See you at the table.');
       }
     } catch (error) {
+      // Lost the race for the last seat: reload so the Full state renders,
+      // and report it as a fact rather than a failure.
+      if (error instanceof SessionFullError) {
+        if (session) {
+          track('session_join_blocked_full', { classId: session.classId });
+        }
+        await loadSession();
+        setStatus(error.message);
+        Alert.alert('Session Full', error.message);
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Unable to join this session.';
       setStatus(message);
       Alert.alert('Join Session Error', message);
@@ -265,20 +278,29 @@ export default function SessionDetailScreen() {
   const visibleAttendees = session
     ? session.attendeeProfiles.filter((attendee) => !blockedUserIds.includes(attendee.uid))
     : [];
-  const isFull = session?.status === 'full';
+  // Full is derived from capacity (host included); the legacy manual
+  // status === 'full' still counts for pre-capacity sessions.
+  const isFull =
+    session?.status === 'full' || (!!session && isSessionAtCapacity(session));
   const isCancelled = session?.status === 'cancelled';
   const hostName = formatDisplayName(session?.hostProfile?.displayName);
-  // Capacity is not in the data model (no seat count). The board's
-  // "Going (3 of 5)" / "2 left" collapses to the real going count plus the
-  // open/full/cancelled status — same substitution used on Today.
-  const goingCount = visibleAttendees.length || session?.participantIds.length || 0;
+  // Seat math uses the true participant count — blocked users still occupy
+  // seats even though they're hidden from the attendee list below.
+  const goingCount = session?.participantIds.length ?? 0;
+  const capacity = session?.capacity;
+  const spotsLeft =
+    typeof capacity === 'number' ? Math.max(capacity - goingCount, 0) : undefined;
+  const goingHeading =
+    typeof capacity === 'number' ? `Going (${goingCount} of ${capacity})` : `Going (${goingCount})`;
   const joinStatusLabel = isParticipant
     ? 'You’re going'
     : isCancelled
       ? 'Session cancelled'
       : isFull
-        ? 'Session is full'
-        : 'A seat is open';
+        ? 'Full'
+        : spotsLeft !== undefined
+          ? `${spotsLeft} ${spotsLeft === 1 ? 'spot' : 'spots'} left`
+          : 'A seat is open';
 
   const startDate = session?.startTime.toDate();
   const endDate = session?.endTime.toDate();
@@ -402,7 +424,7 @@ export default function SessionDetailScreen() {
               ]}>
               <View style={styles.attendanceHeader}>
                 <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>
-                  Going ({goingCount})
+                  {goingHeading}
                 </Text>
                 <BadgeChip
                   label={joinStatusLabel}
@@ -476,7 +498,11 @@ export default function SessionDetailScreen() {
               {[
                 { label: dateTileLabel, value: timeTileValue },
                 { label: 'Duration', value: durationLabel },
-                { label: 'Going', value: `${goingCount}` },
+                {
+                  label: 'Going',
+                  value:
+                    typeof capacity === 'number' ? `${goingCount} of ${capacity}` : `${goingCount}`,
+                },
               ].map((tile) => (
                 <View
                   key={tile.label}

--- a/components/session-card.tsx
+++ b/components/session-card.tsx
@@ -24,14 +24,21 @@ import type { StudySession } from '@/lib/firestore';
  */
 export type SessionCardSession = Pick<
   StudySession,
-  'sessionId' | 'classId' | 'title' | 'startTime' | 'endTime' | 'status' | 'participantIds'
+  | 'sessionId'
+  | 'classId'
+  | 'title'
+  | 'startTime'
+  | 'endTime'
+  | 'status'
+  | 'participantIds'
+  | 'capacity'
 >;
 
 export type SessionCardProps = {
   session: SessionCardSession;
   /** Resolved display name of the location; falls back to nothing shown. */
   locationName?: string;
-  /** Not in the data model yet — pips render without hollow seats when omitted. */
+  /** Overrides session.capacity when provided; pre-capacity sessions have neither. */
   capacity?: number;
   /** Location rating aggregate, when the caller has loaded it. */
   locationRating?: number;
@@ -137,7 +144,7 @@ function formatAttendees(names: string[]) {
 export function SessionCard({
   session,
   locationName,
-  capacity,
+  capacity: capacityProp,
   locationRating,
   isOnline = false,
   hostName,
@@ -154,6 +161,7 @@ export function SessionCard({
   const palette = Colors[colorScheme];
   const isDark = colorScheme === 'dark';
 
+  const capacity = capacityProp ?? session.capacity;
   const going = session.participantIds.length;
   const isFull =
     session.status === 'full' || (capacity !== undefined && going >= capacity);
@@ -180,6 +188,10 @@ export function SessionCard({
 
   const dept = deptColorFor(session.classId) ?? palette.text;
   const hostFirstName = hostName?.trim().split(' ')[0];
+  const spotsLeft = capacity !== undefined ? Math.max(capacity - going, 0) : undefined;
+  // "3 of 8 going" with capacity, "Full" when no seats remain, plain count otherwise.
+  const goingLabel =
+    spotsLeft === 0 ? 'Full' : capacity !== undefined ? `${going} of ${capacity} going` : `${going} going`;
 
   const dimmed = isFull || isCancelled;
 
@@ -234,7 +246,7 @@ export function SessionCard({
             {metaLine}
           </Text>
         </View>
-        <Text style={[TypeScale.meta, { color: palette.icon }]}>{going} going</Text>
+        <Text style={[TypeScale.meta, { color: palette.icon }]}>{goingLabel}</Text>
       </Pressable>
     );
   }
@@ -322,7 +334,7 @@ export function SessionCard({
               <SeatPips going={going} capacity={capacity} />
             )}
             {joinAction ?? (
-              <Text style={[TypeScale.meta, { color: palette.icon }]}>{going} going</Text>
+              <Text style={[TypeScale.meta, { color: palette.icon }]}>{goingLabel}</Text>
             )}
           </View>
         </View>

--- a/components/ui/SeatPips.tsx
+++ b/components/ui/SeatPips.tsx
@@ -30,7 +30,8 @@ export function SeatPips({ going, capacity, showLabel = true, style }: SeatPipsP
   const spotsLeft = capacity !== undefined ? Math.max(capacity - going, 0) : undefined;
   const showPips = total > 0 && total <= MAX_PIPS;
 
-  const countLabel = `${going} going`;
+  // With a capacity: "3 of 8 going · 5 spots left" / "8 of 8 going · Full".
+  const countLabel = capacity !== undefined ? `${going} of ${capacity} going` : `${going} going`;
   const suffix =
     spotsLeft === undefined
       ? ''

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -13,8 +13,9 @@ from them. If a number ends up on a slide or a resume, its definition lives here
 | `sign_in_completed` | `signIn()` succeeds | — |
 | `classes_saved` | Profile classes save succeeds | `count` |
 | `session_create_started` | Create-session screen opened | `fromClassId?`, `fromLocationId?` |
-| `session_created` | `createSession()` succeeds | `classId`, `hoursUntilStart` |
+| `session_created` | `createSession()` succeeds | `classId`, `hoursUntilStart`, `capacity` |
 | `session_joined` | `joinSession()` performs a real join | `classId`, `participantCountAfter` |
+| `session_join_blocked_full` | Join attempt lost the race for the last seat (SessionFullError) | `classId` |
 | `session_viewed` | Session detail opened | `classId`, `isHost` |
 | `session_left` | `leaveSession()` succeeds | `classId` |
 | `map_directions_opened` | Directions tapped from the study map | `locationId` |

--- a/firestore.rules
+++ b/firestore.rules
@@ -116,12 +116,22 @@ service cloud.firestore {
     // Times are Firestore Timestamps (PR 5 client migration).
     // ------------------------------------------------------------------
 
+    // Capacity counts the host (PR: session capacity). Optional so sessions
+    // created before the field existed stay valid — absent means unlimited.
+    function hasValidCapacity(data) {
+      return !('capacity' in data)
+        || (data.capacity is int
+            && data.capacity >= 2
+            && data.capacity <= 20);
+    }
+
     function isValidNewSession() {
       return incoming().keys().hasOnly([
           'classId', 'hostId', 'locationId', 'title',
           'startTime', 'endTime', 'participantIds', 'status',
-          'createdAt', 'updatedAt'
+          'capacity', 'createdAt', 'updatedAt'
         ])
+        && hasValidCapacity(incoming())
         && incoming().hostId == request.auth.uid
         && incoming().participantIds == [request.auth.uid]
         && incoming().status == 'open'
@@ -151,7 +161,12 @@ service cloud.firestore {
       return request.auth.uid == resource.data.hostId
         && sessionIdentityPinned()
         && affectedKeys().hasOnly(['title', 'locationId', 'startTime', 'endTime',
-                                   'status', 'participantIds', 'updatedAt'])
+                                   'status', 'participantIds', 'capacity', 'updatedAt'])
+        && hasValidCapacity(incoming())
+        // Host may loosen but never shrink below the people already seated
+        // (post-state count, so a simultaneous kick + reduce is judged fairly):
+        && (!('capacity' in incoming())
+            || incoming().capacity >= incoming().participantIds.size())
         && incoming().status in ['open', 'full', 'cancelled']
         && incoming().title is string && incoming().title.size() >= 1
         && incoming().title.size() <= 80
@@ -183,6 +198,11 @@ service cloud.firestore {
         && incoming().participantIds.toSet().intersection(
              resource.data.participantIds.toSet()
            ) == resource.data.participantIds.toSet()
+        // Capacity is the seat ceiling (host included). Legacy sessions
+        // without the field stay unlimited. This is the final enforcement
+        // layer behind the client's transactional join.
+        && (!('capacity' in resource.data)
+            || incoming().participantIds.size() <= resource.data.capacity)
         && !isBlockedEitherWay(request.auth.uid, resource.data.hostId);
     }
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -63,6 +63,7 @@ export type AnalyticsEvent =
   | "session_create_started"
   | "session_created"
   | "session_joined"
+  | "session_join_blocked_full"
   | "session_viewed"
   | "session_left"
   | "session_cancelled"

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -11,6 +11,7 @@ import {
   onSnapshot,
   orderBy,
   query,
+  runTransaction,
   serverTimestamp,
   setDoc,
   Timestamp,
@@ -69,6 +70,8 @@ export type StudySessionStatus = "cancelled" | "full" | "open";
 
 // Session times are Firestore Timestamps (D4).
 export type StudySession = {
+  /** Seat ceiling including the host (2–20). Absent on pre-capacity sessions = unlimited. */
+  capacity?: number;
   classId: string;
   endTime: Timestamp;
   hostId: string;
@@ -79,6 +82,30 @@ export type StudySession = {
   status: StudySessionStatus;
   title: string;
 };
+
+export const SESSION_CAPACITY_MIN = 2;
+export const SESSION_CAPACITY_MAX = 20;
+export const SESSION_CAPACITY_DEFAULT = 8;
+
+/** A session is full when a capacity exists and every seat (host included) is taken. */
+export function isSessionAtCapacity(session: Pick<StudySession, "capacity" | "participantIds">) {
+  return (
+    typeof session.capacity === "number" &&
+    session.participantIds.length >= session.capacity
+  );
+}
+
+/**
+ * Thrown when a join loses the race for the last seat — the transaction
+ * re-read the session and found it full. Callers show a friendly message and
+ * refresh instead of treating it as an unexpected failure.
+ */
+export class SessionFullError extends Error {
+  constructor() {
+    super("This session just filled up — someone grabbed the last seat.");
+    this.name = "SessionFullError";
+  }
+}
 
 export type StudyLocation = {
   building: string;
@@ -481,6 +508,10 @@ function normalizeSessionDoc(
       ? data.participantIds.filter((id): id is string => typeof id === "string")
       : [],
     status: (data.status as StudySessionStatus) ?? "open",
+    // Pre-capacity docs have no field — leave undefined (unlimited).
+    ...(typeof data.capacity === "number" && Number.isInteger(data.capacity)
+      ? { capacity: data.capacity }
+      : {}),
   };
 }
 
@@ -662,41 +693,54 @@ export async function getSessionById(sessionId: string) {
   } satisfies StudySessionListItem;
 }
 
+/**
+ * Joins inside a transaction so the read (seat count) and the write (seat
+ * claim) are atomic: when two users race for the last seat the loser's
+ * transaction re-reads the now-full session and throws SessionFullError
+ * instead of over-filling. Rules re-enforce the same ceiling server-side.
+ */
 export async function joinSession(
   sessionId: string,
   userId: string
 ): Promise<"joined" | "already-joined"> {
   const sessionRef = doc(db, COLLECTIONS.sessions, sessionId);
-  const snapshot = await getDoc(sessionRef);
 
-  if (!snapshot.exists()) {
-    throw new Error("This session no longer exists.");
-  }
+  return runTransaction(db, async (transaction) => {
+    const snapshot = await transaction.get(sessionRef);
 
-  const data = snapshot.data();
-  const participantIds: string[] = Array.isArray(data.participantIds)
-    ? data.participantIds
-    : [];
+    if (!snapshot.exists()) {
+      throw new Error("This session no longer exists.");
+    }
 
-  if (participantIds.includes(userId)) {
-    return "already-joined"; // already in — silent no-op instead of a scary error
-  }
+    const data = snapshot.data();
+    const participantIds: string[] = Array.isArray(data.participantIds)
+      ? data.participantIds
+      : [];
 
-  if (data.status !== "open") {
-    throw new Error("This session is no longer open.");
-  }
+    if (participantIds.includes(userId)) {
+      return "already-joined"; // already in — silent no-op instead of a scary error
+    }
 
-  const startTime = normalizeSessionTimestamp(data.startTime);
-  if (startTime && startTime.toMillis() < Date.now()) {
-    throw new Error("This session has already started.");
-  }
+    if (data.status !== "open") {
+      throw new Error("This session is no longer open.");
+    }
 
-  await updateDoc(sessionRef, {
-    participantIds: arrayUnion(userId),
-    updatedAt: serverTimestamp(),
+    const startTime = normalizeSessionTimestamp(data.startTime);
+    if (startTime && startTime.toMillis() < Date.now()) {
+      throw new Error("This session has already started.");
+    }
+
+    if (isSessionAtCapacity({ capacity: data.capacity, participantIds })) {
+      throw new SessionFullError();
+    }
+
+    transaction.update(sessionRef, {
+      participantIds: arrayUnion(userId),
+      updatedAt: serverTimestamp(),
+    });
+
+    return "joined";
   });
-
-  return "joined";
 }
 
 export async function leaveSession(sessionId: string, userId: string) {
@@ -725,7 +769,19 @@ export async function createSession(input: {
   title: string;
   startTime: Date;
   endTime: Date;
+  /** Seats including the host, 2–20. */
+  capacity: number;
 }): Promise<string> {
+  if (
+    !Number.isInteger(input.capacity) ||
+    input.capacity < SESSION_CAPACITY_MIN ||
+    input.capacity > SESSION_CAPACITY_MAX
+  ) {
+    throw new Error(
+      `Choose a capacity between ${SESSION_CAPACITY_MIN} and ${SESSION_CAPACITY_MAX} seats.`
+    );
+  }
+
   const sessionRef = doc(collection(db, COLLECTIONS.sessions));
   const batch = writeBatch(db);
 
@@ -738,6 +794,7 @@ export async function createSession(input: {
     endTime: Timestamp.fromDate(input.endTime),
     participantIds: [input.hostId],
     status: "open",
+    capacity: input.capacity,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   });

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -11,12 +11,15 @@ import {
   initializeTestEnvironment,
 } from '@firebase/rules-unit-testing';
 import {
+  arrayUnion,
   collection,
   deleteDoc,
+  deleteField,
   doc,
   getDoc,
   getDocs,
   query,
+  runTransaction,
   serverTimestamp,
   setDoc,
   Timestamp,
@@ -417,6 +420,155 @@ describe('sessions', () => {
     }));
     await assertFails(deleteDoc(doc(ctx(BOB), 'sessions', 's1')));
     await assertSucceeds(deleteDoc(doc(ctx(ALICE), 'sessions', 's1')));
+  });
+});
+
+// --------------------------------------------------------- session capacity
+describe('session capacity', () => {
+  const seededSession = (host, overrides = {}) =>
+    validSession(host, {
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+      ...overrides,
+    });
+
+  it('create accepts capacity at and inside the 2–20 bounds', async () => {
+    await assertSucceeds(createSessionWithRateLimit(ctx(ALICE), ALICE, 'c2',
+      validSession(ALICE, { capacity: 2 })));
+    await env.clearFirestore();
+    await assertSucceeds(createSessionWithRateLimit(ctx(ALICE), ALICE, 'c8',
+      validSession(ALICE, { capacity: 8 })));
+    await env.clearFirestore();
+    await assertSucceeds(createSessionWithRateLimit(ctx(ALICE), ALICE, 'c20',
+      validSession(ALICE, { capacity: 20 })));
+  });
+
+  it('create without capacity stays valid (legacy unlimited shape)', async () => {
+    await assertSucceeds(createSessionWithRateLimit(ctx(ALICE), ALICE, 's1',
+      validSession(ALICE)));
+  });
+
+  it('create rejects out-of-range and non-int capacity', async () => {
+    await assertFails(createSessionWithRateLimit(ctx(ALICE), ALICE, 'bad1',
+      validSession(ALICE, { capacity: 1 })));
+    await assertFails(createSessionWithRateLimit(ctx(ALICE), ALICE, 'bad2',
+      validSession(ALICE, { capacity: 21 })));
+    await assertFails(createSessionWithRateLimit(ctx(ALICE), ALICE, 'bad3',
+      validSession(ALICE, { capacity: 2.5 })));
+    await assertFails(createSessionWithRateLimit(ctx(ALICE), ALICE, 'bad4',
+      validSession(ALICE, { capacity: 'eight' })));
+    await assertFails(createSessionWithRateLimit(ctx(ALICE), ALICE, 'bad5',
+      validSession(ALICE, { capacity: null })));
+  });
+
+  it('join succeeds below capacity, is denied at capacity', async () => {
+    await seed('sessions/s1', seededSession(ALICE, { capacity: 3 }));
+    await assertSucceeds(updateDoc(doc(ctx(BOB), 'sessions', 's1'), {
+      participantIds: [ALICE, BOB], updatedAt: serverTimestamp(),
+    }));
+    // Bob took seat 2 of 3; Mallory takes the last one:
+    await assertSucceeds(updateDoc(doc(ctx(MALLORY), 'sessions', 's1'), {
+      participantIds: [ALICE, BOB, MALLORY], updatedAt: serverTimestamp(),
+    }));
+    // 3 of 3 seated — a fourth join must be rejected by rules alone:
+    await assertFails(updateDoc(doc(ctx('daveUid'), 'sessions', 's1'), {
+      participantIds: [ALICE, BOB, MALLORY, 'daveUid'], updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('legacy session without capacity keeps unlimited joins', async () => {
+    await seed('sessions/s1', seededSession(ALICE, {
+      participantIds: [ALICE, BOB, MALLORY],
+    }));
+    await assertSucceeds(updateDoc(doc(ctx('daveUid'), 'sessions', 's1'), {
+      participantIds: [ALICE, BOB, MALLORY, 'daveUid'], updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('host can raise capacity or match the current count, never go below it', async () => {
+    await seed('sessions/s1', seededSession(ALICE, {
+      capacity: 4, participantIds: [ALICE, BOB, MALLORY],
+    }));
+    await assertSucceeds(updateDoc(doc(ctx(ALICE), 'sessions', 's1'), {
+      capacity: 10, updatedAt: serverTimestamp(),
+    }));
+    await assertSucceeds(updateDoc(doc(ctx(ALICE), 'sessions', 's1'), {
+      capacity: 3, updatedAt: serverTimestamp(), // == current participant count
+    }));
+    await assertFails(updateDoc(doc(ctx(ALICE), 'sessions', 's1'), {
+      capacity: 2, updatedAt: serverTimestamp(), // below the 3 already seated
+    }));
+    await assertFails(updateDoc(doc(ctx(ALICE), 'sessions', 's1'), {
+      capacity: 21, updatedAt: serverTimestamp(),
+    }));
+    await assertFails(updateDoc(doc(ctx(ALICE), 'sessions', 's1'), {
+      capacity: 1, updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('host kick + reduce in one update is judged on the post-state count', async () => {
+    await seed('sessions/s1', seededSession(ALICE, {
+      capacity: 4, participantIds: [ALICE, BOB, MALLORY],
+    }));
+    await assertSucceeds(updateDoc(doc(ctx(ALICE), 'sessions', 's1'), {
+      participantIds: [ALICE, BOB], capacity: 2, updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('host may drop the capacity field entirely (back to unlimited)', async () => {
+    await seed('sessions/s1', seededSession(ALICE, { capacity: 2 }));
+    await assertSucceeds(updateDoc(doc(ctx(ALICE), 'sessions', 's1'), {
+      capacity: deleteField(), updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('non-host cannot touch capacity', async () => {
+    await seed('sessions/s1', seededSession(ALICE, {
+      capacity: 4, participantIds: [ALICE, BOB],
+    }));
+    await assertFails(updateDoc(doc(ctx(BOB), 'sessions', 's1'), {
+      capacity: 20, updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('two users competing for the final seat: exactly one transaction wins', async () => {
+    await seed('sessions/s1', seededSession(ALICE, { capacity: 2 }));
+
+    // Mirrors lib/firestore.ts joinSession: read, check the seat count,
+    // claim atomically. The loser's retry re-reads a full session and aborts.
+    const joinTx = (db, uid) =>
+      runTransaction(db, async (tx) => {
+        const snap = await tx.get(doc(db, 'sessions', 's1'));
+        const data = snap.data();
+        if (
+          typeof data.capacity === 'number' &&
+          data.participantIds.length >= data.capacity
+        ) {
+          throw new Error('session-full');
+        }
+        tx.update(doc(db, 'sessions', 's1'), {
+          participantIds: arrayUnion(uid),
+          updatedAt: serverTimestamp(),
+        });
+        return 'joined';
+      });
+
+    const [bobResult, malloryResult] = await Promise.allSettled([
+      joinTx(ctx(BOB), BOB),
+      joinTx(ctx(MALLORY), MALLORY),
+    ]);
+
+    const outcomes = [bobResult, malloryResult];
+    const winners = outcomes.filter((r) => r.status === 'fulfilled');
+    const losers = outcomes.filter((r) => r.status === 'rejected');
+    assert.equal(winners.length, 1, 'exactly one join should win the last seat');
+    assert.equal(losers.length, 1, 'the other join must be rejected');
+
+    // The stored doc holds exactly capacity participants — never over-filled.
+    await env.withSecurityRulesDisabled(async (c) => {
+      const snap = await getDoc(doc(c.firestore(), 'sessions', 's1'));
+      assert.equal(snap.data().participantIds.length, 2);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

PR 1 of the beta feature sequence: adds an optional `capacity` field to study sessions (2–20 seats, **host included**, default 8), per the Lovable `CreateCapacityScreen` board.

- **Create Session** gains a "How many seats?" preset grid (2, 4, 6, 8, 10, 12, 16, 20 — default 8); capacity persists on new session docs and shows in the live preview card.
- **Transactional join**: `joinSession` runs in a Firestore transaction so the seat-count read and seat claim are atomic. The loser of a last-seat race gets a friendly "just filled up" alert + refresh (`SessionFullError`), never an over-filled session.
- **Rules enforce independently**: create/host-edit validate capacity (int, 2–20); self-join is denied once seats are taken; host can never reduce capacity below the current participant count (post-state, so kick+reduce in one update works).
- **Backward compatible**: pre-capacity sessions have no field and remain unlimited — no migration, no new indexes, old clients unaffected.
- **Capacity rendered** on Today (hero "3 of 8 going", upcoming rows show seats left / Full), Sessions cards (SeatPips "3 of 8 going · 5 spots left / Full"), and Session Details ("Going (3 of 8)", spots-left badge, Join disabled when full).
- **Analytics**: `session_created` now carries `capacity`; new `session_join_blocked_full` event (docs/metrics.md updated first, per convention).
- Join, leave, kick, cancel, block, report, and push behavior preserved.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run rules:test` — 49 passing (9 new capacity cases: bounds, legacy docs, host edits, and two users competing for the final seat via concurrent transactions)
- [x] `npx expo export --platform web` — exports
- [ ] Manual QA: create a 2-seat session with a second account, verify the third join is blocked and the Full states render on Today / Sessions / Details

## Deploy note

⚠️ `firestore.rules` changed — requires `firebase deploy --only firestore:rules` at release time. **Not deployed yet**; do not merge until QA'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)