### PR TITLE
feat: settings + notification preferences

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,7 +2,6 @@ import { useFocusEffect } from '@react-navigation/native';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     Alert,
-    Modal,
     Pressable,
     RefreshControl,
     ScrollView,
@@ -13,21 +12,14 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { ExternalLink } from '@/components/external-link';
 import { Avatar } from '@/components/ui/Avatar';
 import { Button } from '@/components/ui/Button';
 import { CourseChip } from '@/components/ui/CourseChip';
-import { IconSymbol } from '@/components/ui/icon-symbol';
 import { SectionHeader } from '@/components/ui/SectionHeader';
-import {
-    STUDI_CONTACT_EMAIL,
-    STUDI_PRIVACY_POLICY_URL,
-    STUDI_SUPPORT_URL,
-} from '@/constants/app-info';
 import { Brand, Colors, FontFamily, Radius, Space, TypeScale } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { identifyUser, track } from '@/lib/analytics';
-import { deleteCurrentUserAccount, logOut, subscribeToAuthState } from '@/lib/auth';
+import { subscribeToAuthState } from '@/lib/auth';
 import { UW_COURSE_CATALOG, UW_COURSE_COUNT, searchCourses } from '@/lib/catalog';
 import {
     getLocationRatingAggregates,
@@ -47,7 +39,7 @@ import {
     type StudySession,
     type UserYear,
 } from '@/lib/firestore';
-import { type Href } from 'expo-router';
+import { useRouter } from 'expo-router';
 import type { User } from 'firebase/auth';
 
 // How many saved-location rows the board renders (ProfileScreen ~1815).
@@ -89,24 +81,16 @@ function splitDisplayName(displayName: string | undefined) {
   };
 }
 
-function buildMailtoHref(email: string, subject: string) {
-  return `mailto:${email}?subject=${encodeURIComponent(subject)}` as Href & string;
-}
-
 export default function ProfileScreen() {
   const colorScheme = useColorScheme() ?? 'light';
   const palette = Colors[colorScheme];
   const insets = useSafeAreaInsets();
+  const router = useRouter();
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
-  const [isReauthenticatingDelete, setIsReauthenticatingDelete] = useState(false);
-  const [showDeleteReauthModal, setShowDeleteReauthModal] = useState(false);
-  const [deleteReauthPassword, setDeleteReauthPassword] = useState('');
-  const [isDeletePasswordVisible, setIsDeletePasswordVisible] = useState(false);
-  const [deleteReauthEmail, setDeleteReauthEmail] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [major, setMajor] = useState('');
@@ -323,80 +307,6 @@ export default function ProfileScreen() {
     }
   }
 
-  async function handleSignOut() {
-    try {
-      setIsSaving(true);
-      await logOut();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unable to sign out right now.';
-      Alert.alert('Sign Out Error', message);
-    } finally {
-      setIsSaving(false);
-    }
-  }
-
-  function confirmDeleteAccount() {
-    Alert.alert(
-      'Delete Account',
-      'This will permanently delete your Studi profile and account data. This cannot be undone.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete Account',
-          style: 'destructive',
-          onPress: handleDeleteAccount,
-        },
-      ]
-    );
-  }
-
-  async function handleDeleteAccount() {
-    setDeleteReauthPassword('');
-    setDeleteReauthEmail(currentUser?.email ?? '');
-    setIsDeletePasswordVisible(false);
-    setShowDeleteReauthModal(true);
-  }
-
-  function closeDeleteReauthModal() {
-    if (isReauthenticatingDelete) {
-      return;
-    }
-
-    setShowDeleteReauthModal(false);
-    setDeleteReauthPassword('');
-    setIsDeletePasswordVisible(false);
-  }
-
-  async function handleDeleteWithReauthPassword() {
-    if (!deleteReauthPassword.trim()) {
-      Alert.alert('Password Required', 'Enter your password to continue deleting your account.');
-      return;
-    }
-
-    try {
-      setIsReauthenticatingDelete(true);
-      const result = await deleteCurrentUserAccount({ password: deleteReauthPassword });
-
-      if (result.status === 'requires-recent-login') {
-        Alert.alert(
-          'Re-authentication Needed',
-          'Your session is still not recent enough. Please sign out, sign back in, then try again.'
-        );
-        return;
-      }
-
-      setShowDeleteReauthModal(false);
-      setDeleteReauthPassword('');
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Unable to verify your password right now.';
-      Alert.alert('Delete Account Error', message);
-    } finally {
-      setIsReauthenticatingDelete(false);
-    }
-  }
-
-  const isBusy = isSaving || isReauthenticatingDelete;
   const displayName = `${firstName.trim()} ${lastName.trim()}`.trim();
   // "Junior · Computer Science · she/her" — only the fields the user filled in.
   const academicLine = [year, major.trim(), pronouns.trim()]
@@ -787,107 +697,27 @@ export default function ProfileScreen() {
         )}
       </View>
 
-      {/* Account — board defers these behind its top-right Settings entry; with
-          no settings screen they live here so nothing becomes unreachable. */}
-      <View style={[styles.card, { backgroundColor: palette.surface, borderColor: palette.border }]}>
-        <Text style={[TypeScale.heading, { color: palette.text }]}>Privacy and support</Text>
-        <View style={styles.linkList}>
-          <ExternalLink href={STUDI_PRIVACY_POLICY_URL as Href & string} asChild>
-            <Pressable style={({ pressed }) => [styles.linkRow, { opacity: pressed ? 0.6 : 1 }]}>
-              <Text style={[TypeScale.label, { color: palette.text }]}>Privacy Policy</Text>
-              <Text style={[TypeScale.caption, { color: palette.icon }]}>›</Text>
-            </Pressable>
-          </ExternalLink>
-          <View style={[styles.linkDivider, { backgroundColor: palette.border }]} />
-          <ExternalLink href={STUDI_SUPPORT_URL as Href & string} asChild>
-            <Pressable style={({ pressed }) => [styles.linkRow, { opacity: pressed ? 0.6 : 1 }]}>
-              <Text style={[TypeScale.label, { color: palette.text }]}>Support</Text>
-              <Text style={[TypeScale.caption, { color: palette.icon }]}>›</Text>
-            </Pressable>
-          </ExternalLink>
-          <View style={[styles.linkDivider, { backgroundColor: palette.border }]} />
-          <ExternalLink href={buildMailtoHref(STUDI_CONTACT_EMAIL, 'Studi Contact')} asChild>
-            <Pressable style={({ pressed }) => [styles.linkRow, { opacity: pressed ? 0.6 : 1 }]}>
-              <Text style={[TypeScale.label, { color: palette.text }]}>Contact</Text>
-              <Text style={[TypeScale.caption, { color: palette.icon }]} numberOfLines={1}>
-                {STUDI_CONTACT_EMAIL}
-              </Text>
-            </Pressable>
-          </ExternalLink>
+      {/* Settings entry (design spec §3.12 footer Settings link). Privacy,
+          support, sign out, and delete account live there now. */}
+      <Pressable
+        accessibilityRole="button"
+        onPress={() => router.push('/settings')}
+        style={({ pressed }) => [
+          styles.settingsRow,
+          {
+            backgroundColor: palette.surface,
+            borderColor: palette.border,
+            opacity: pressed ? 0.7 : 1,
+          },
+        ]}>
+        <View style={styles.settingsRowBody}>
+          <Text style={[TypeScale.bodyStrong, { color: palette.text }]}>Settings</Text>
+          <Text style={[TypeScale.caption, { color: palette.icon }]}>
+            Notifications, privacy, and account
+          </Text>
         </View>
-      </View>
-
-      <View style={styles.accountActions}>
-        <Button
-          label="Sign out"
-          variant="secondary"
-          fullWidth
-          loading={isBusy}
-          onPress={handleSignOut}
-        />
-        <Pressable
-          disabled={isBusy}
-          onPress={confirmDeleteAccount}
-          style={({ pressed }) => [
-            styles.deleteLink,
-            { opacity: isBusy || pressed ? 0.6 : 1 },
-          ]}>
-          <Text style={[TypeScale.label, { color: palette.tint }]}>Delete account</Text>
-        </Pressable>
-      </View>
-
-      <Modal
-        animationType="fade"
-        onRequestClose={closeDeleteReauthModal}
-        transparent
-        visible={showDeleteReauthModal}>
-        <View style={styles.modalBackdrop}>
-          <View style={[styles.modalCard, { backgroundColor: palette.surface, borderColor: palette.border }]}>
-            <Text style={[TypeScale.heading, { color: palette.text }]}>Confirm with password</Text>
-            <Text style={[TypeScale.body, { color: palette.icon }]}>
-              For security, please re-enter your password for {deleteReauthEmail || 'your account'}.
-            </Text>
-            <View>
-              <TextInput
-                autoCapitalize="none"
-                autoCorrect={false}
-                editable={!isReauthenticatingDelete}
-                onChangeText={setDeleteReauthPassword}
-                placeholder="Password"
-                placeholderTextColor={placeholderColor}
-                secureTextEntry={!isDeletePasswordVisible}
-                style={[styles.input, styles.secureInput, inputColors]}
-                value={deleteReauthPassword}
-              />
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={isDeletePasswordVisible ? 'Hide password' : 'Show password'}
-                hitSlop={8}
-                onPress={() => setIsDeletePasswordVisible((visible) => !visible)}
-                style={styles.secureToggle}>
-                <IconSymbol
-                  name={isDeletePasswordVisible ? 'eye.slash' : 'eye'}
-                  size={20}
-                  color={palette.icon}
-                />
-              </Pressable>
-            </View>
-            <View style={styles.modalActions}>
-              <Button
-                label="Cancel"
-                variant="secondary"
-                disabled={isReauthenticatingDelete}
-                onPress={closeDeleteReauthModal}
-              />
-              <Button
-                label="Delete account"
-                loading={isReauthenticatingDelete}
-                onPress={handleDeleteWithReauthPassword}
-              />
-            </View>
-          </View>
-        </View>
-      </Modal>
+        <Text style={[TypeScale.heading, { color: palette.icon }]}>›</Text>
+      </Pressable>
     </ScrollView>
   );
 }
@@ -1074,18 +904,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: Space.lg,
     paddingVertical: Space.md,
   },
-  secureInput: {
-    paddingRight: Space.lg + 28,
-  },
-  secureToggle: {
-    alignItems: 'center',
-    bottom: 0,
-    justifyContent: 'center',
-    position: 'absolute',
-    right: Space.md,
-    top: 0,
-    width: 28,
-  },
   searchResults: {
     gap: Space.sm + 2,
   },
@@ -1095,45 +913,19 @@ const styles = StyleSheet.create({
     gap: Space.xs,
     padding: Space.md + 2,
   },
-  linkList: {
-    gap: 0,
-  },
-  linkRow: {
+  settingsRow: {
     alignItems: 'center',
+    borderRadius: Radius.lg,
+    borderWidth: StyleSheet.hairlineWidth * 2,
     flexDirection: 'row',
     gap: Space.md,
     justifyContent: 'space-between',
-    minHeight: 48,
+    minHeight: 56,
+    paddingHorizontal: Space.md + 2,
+    paddingVertical: Space.sm,
   },
-  linkDivider: {
-    height: StyleSheet.hairlineWidth,
-  },
-  accountActions: {
-    gap: Space.md,
-  },
-  deleteLink: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 40,
-  },
-  modalBackdrop: {
-    alignItems: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.45)',
-    flex: 1,
-    justifyContent: 'center',
-    padding: Space.lg + 4,
-  },
-  modalCard: {
-    borderRadius: Radius.card,
-    borderWidth: StyleSheet.hairlineWidth * 2,
-    gap: Space.md,
-    maxWidth: 420,
-    padding: Space.lg + 4,
-    width: '100%',
-  },
-  modalActions: {
-    flexDirection: 'row',
-    gap: Space.sm + 2,
-    justifyContent: 'flex-end',
+  settingsRowBody: {
+    flexShrink: 1,
+    gap: 2,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -179,6 +179,7 @@ function RootLayout() {
           <Stack.Screen name="report-user" options={{ title: 'Report User' }} />
           <Stack.Screen name="session/[sessionId]" options={{ title: 'Session Details' }} />
           <Stack.Screen name="rate-location" options={{ title: 'Rate This Spot' }} />
+          <Stack.Screen name="settings" options={{ title: 'Settings' }} />
         </Stack.Protected>
       </Stack>
       <StatusBar style="auto" />

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,531 @@
+import { type Href, useRouter } from 'expo-router';
+import { useCallback, useEffect, useState } from 'react';
+import {
+    Alert,
+    Modal,
+    Pressable,
+    ScrollView,
+    StyleSheet,
+    Switch,
+    Text,
+    TextInput,
+    View,
+} from 'react-native';
+
+import { ExternalLink } from '@/components/external-link';
+import { Button } from '@/components/ui/Button';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { SectionHeader } from '@/components/ui/SectionHeader';
+import {
+    STUDI_CONTACT_EMAIL,
+    STUDI_PRIVACY_POLICY_URL,
+    STUDI_SUPPORT_URL,
+} from '@/constants/app-info';
+import { Brand, Colors, FontFamily, Radius, Space, TypeScale } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { track } from '@/lib/analytics';
+import { deleteCurrentUserAccount, logOut, subscribeToAuthState } from '@/lib/auth';
+import {
+    DEFAULT_NOTIFICATION_PREFS,
+    getNotificationPrefs,
+    getUserProfile,
+    saveNotificationPref,
+    type NotificationPrefKey,
+    type NotificationPrefs,
+    type UserProfile,
+} from '@/lib/firestore';
+import type { User } from 'firebase/auth';
+
+// Every row is a live control (design spec §3.13) — labels here, persistence
+// in users/{uid}/private/settings. The notify() pipeline (later PR) reads them.
+const NOTIFICATION_ROWS: {
+  key: NotificationPrefKey;
+  label: string;
+  description: string;
+}[] = [
+  {
+    key: 'sessionReminders',
+    label: 'Session reminders',
+    description: 'Before study sessions you joined start.',
+  },
+  {
+    key: 'sessionActivity',
+    label: 'Session activity',
+    description: 'Joins, changes, and cancellations for your sessions.',
+  },
+  {
+    key: 'dmMessages',
+    label: 'Direct messages',
+    description: 'New messages sent directly to you.',
+  },
+  {
+    key: 'groupMessages',
+    label: 'Group messages',
+    description: 'New messages in session group chats.',
+  },
+  {
+    key: 'friendRequests',
+    label: 'Friend requests',
+    description: 'New requests and accepted requests.',
+  },
+];
+
+function buildMailtoHref(email: string, subject: string) {
+  return `mailto:${email}?subject=${encodeURIComponent(subject)}` as Href & string;
+}
+
+export default function SettingsScreen() {
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const router = useRouter();
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULT_NOTIFICATION_PREFS);
+  const [prefsState, setPrefsState] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const [isReauthenticatingDelete, setIsReauthenticatingDelete] = useState(false);
+  const [showDeleteReauthModal, setShowDeleteReauthModal] = useState(false);
+  const [deleteReauthPassword, setDeleteReauthPassword] = useState('');
+  const [isDeletePasswordVisible, setIsDeletePasswordVisible] = useState(false);
+  const [deleteReauthEmail, setDeleteReauthEmail] = useState('');
+
+  useEffect(() => {
+    const unsubscribe = subscribeToAuthState((user) => {
+      setCurrentUser(user);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    track('settings_viewed');
+  }, []);
+
+  // One fetch per screen visit — toggles mutate local state and write through,
+  // so nothing refetches on render.
+  const loadSettings = useCallback(async () => {
+    if (!currentUser) {
+      return;
+    }
+
+    setPrefsState('loading');
+    // The academic line degrades to "Not set" if the profile read fails; only
+    // the preferences read decides the section's error state.
+    getUserProfile(currentUser.uid)
+      .then(setProfile)
+      .catch(() => {});
+    try {
+      setPrefs(await getNotificationPrefs(currentUser.uid));
+      setPrefsState('ready');
+    } catch {
+      setPrefsState('error');
+    }
+  }, [currentUser]);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  async function handleTogglePref(key: NotificationPrefKey, enabled: boolean) {
+    if (!currentUser) {
+      return;
+    }
+
+    const previousValue = prefs[key];
+    setPrefs((current) => ({ ...current, [key]: enabled }));
+
+    try {
+      await saveNotificationPref(currentUser.uid, key, enabled);
+      track('notification_pref_toggled', { category: key, enabled });
+    } catch {
+      setPrefs((current) => ({ ...current, [key]: previousValue }));
+      Alert.alert(
+        'Notifications Error',
+        "That preference didn't save. Check your connection and try again."
+      );
+    }
+  }
+
+  async function handleSignOut() {
+    try {
+      setIsSigningOut(true);
+      await logOut();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to sign out right now.';
+      Alert.alert('Sign Out Error', message);
+    } finally {
+      setIsSigningOut(false);
+    }
+  }
+
+  function confirmDeleteAccount() {
+    Alert.alert(
+      'Delete Account',
+      'This will permanently delete your Studi profile and account data. This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete Account',
+          style: 'destructive',
+          onPress: handleDeleteAccount,
+        },
+      ]
+    );
+  }
+
+  async function handleDeleteAccount() {
+    setDeleteReauthPassword('');
+    setDeleteReauthEmail(currentUser?.email ?? '');
+    setIsDeletePasswordVisible(false);
+    setShowDeleteReauthModal(true);
+  }
+
+  function closeDeleteReauthModal() {
+    if (isReauthenticatingDelete) {
+      return;
+    }
+
+    setShowDeleteReauthModal(false);
+    setDeleteReauthPassword('');
+    setIsDeletePasswordVisible(false);
+  }
+
+  async function handleDeleteWithReauthPassword() {
+    if (!deleteReauthPassword.trim()) {
+      Alert.alert('Password Required', 'Enter your password to continue deleting your account.');
+      return;
+    }
+
+    try {
+      setIsReauthenticatingDelete(true);
+      const result = await deleteCurrentUserAccount({ password: deleteReauthPassword });
+
+      if (result.status === 'requires-recent-login') {
+        Alert.alert(
+          'Re-authentication Needed',
+          'Your session is still not recent enough. Please sign out, sign back in, then try again.'
+        );
+        return;
+      }
+
+      setShowDeleteReauthModal(false);
+      setDeleteReauthPassword('');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unable to verify your password right now.';
+      Alert.alert('Delete Account Error', message);
+    } finally {
+      setIsReauthenticatingDelete(false);
+    }
+  }
+
+  const isBusy = isSigningOut || isReauthenticatingDelete;
+  const placeholderColor = colorScheme === 'dark' ? '#8A8174' : Brand.textSubtle;
+  const inputColors = {
+    backgroundColor: palette.surfaceMuted,
+    borderColor: palette.border,
+    color: palette.text,
+  };
+  const academicLine = [profile?.year, profile?.major].filter(Boolean).join(' · ');
+
+  return (
+    <ScrollView
+      style={[styles.screen, { backgroundColor: palette.background }]}
+      contentContainerStyle={styles.content}>
+      {/* Account (design spec §3.13 grouped list). */}
+      <View style={styles.section}>
+        <SectionHeader eyebrow="Account" />
+        <View style={[styles.card, { backgroundColor: palette.surface, borderColor: palette.border }]}>
+          <View style={styles.row}>
+            <Text style={[TypeScale.body, { color: palette.text }]}>UW email</Text>
+            <Text style={[TypeScale.meta, styles.rowValue, { color: palette.icon }]} numberOfLines={1}>
+              {currentUser?.email ?? '—'}
+            </Text>
+          </View>
+          <View style={[styles.rowDivider, { backgroundColor: palette.border }]} />
+          <View style={styles.row}>
+            <Text style={[TypeScale.body, { color: palette.text }]}>Year &amp; major</Text>
+            <Text style={[TypeScale.meta, styles.rowValue, { color: palette.icon }]} numberOfLines={1}>
+              {academicLine || 'Not set'}
+            </Text>
+          </View>
+          <View style={[styles.rowDivider, { backgroundColor: palette.border }]} />
+          <View style={styles.row}>
+            <Text style={[TypeScale.body, { color: palette.text }]}>Status</Text>
+            <View style={styles.verifiedValue}>
+              <View style={[styles.verifiedDot, { backgroundColor: palette.tint }]}>
+                <Text style={styles.verifiedDotMark}>✓</Text>
+              </View>
+              <Text style={[TypeScale.meta, { color: palette.icon }]}>Verified student</Text>
+            </View>
+          </View>
+          <View style={[styles.rowDivider, { backgroundColor: palette.border }]} />
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => router.push('/(tabs)/profile')}
+            style={({ pressed }) => [styles.row, { opacity: pressed ? 0.6 : 1 }]}>
+            <Text style={[TypeScale.bodyStrong, { color: palette.tint }]}>Edit profile</Text>
+            <Text style={[TypeScale.caption, { color: palette.icon }]}>›</Text>
+          </Pressable>
+        </View>
+      </View>
+
+      {/* Notifications — real switches, optimistic saves (design spec §3.13). */}
+      <View style={styles.section}>
+        <SectionHeader eyebrow="Notifications" />
+        <View style={[styles.card, { backgroundColor: palette.surface, borderColor: palette.border }]}>
+          {prefsState === 'error' ? (
+            <View style={styles.errorBody}>
+              <Text style={[TypeScale.body, { color: palette.text }]}>
+                Your notification preferences didn’t load.
+              </Text>
+              <Pressable accessibilityRole="button" onPress={loadSettings}>
+                <Text style={[TypeScale.label, { color: palette.tint }]}>Try again</Text>
+              </Pressable>
+            </View>
+          ) : (
+            NOTIFICATION_ROWS.map((row, index) => (
+              <View key={row.key}>
+                {index > 0 ? (
+                  <View style={[styles.rowDivider, { backgroundColor: palette.border }]} />
+                ) : null}
+                <View style={styles.row}>
+                  <View style={styles.rowBody}>
+                    <Text style={[TypeScale.body, { color: palette.text }]}>{row.label}</Text>
+                    <Text style={[TypeScale.caption, { color: palette.icon }]}>
+                      {row.description}
+                    </Text>
+                  </View>
+                  <Switch
+                    accessibilityLabel={row.label}
+                    disabled={prefsState !== 'ready'}
+                    ios_backgroundColor={palette.surfaceMuted}
+                    onValueChange={(enabled) => handleTogglePref(row.key, enabled)}
+                    thumbColor="#FFFFFF"
+                    trackColor={{ false: palette.surfaceMuted, true: palette.tint }}
+                    value={prefs[row.key]}
+                  />
+                </View>
+              </View>
+            ))
+          )}
+        </View>
+        <Text style={[TypeScale.caption, { color: palette.icon }]}>
+          Push notifications also respect your device settings.
+        </Text>
+      </View>
+
+      {/* Privacy and support (moved from Profile). */}
+      <View style={styles.section}>
+        <SectionHeader eyebrow="Privacy and support" />
+        <View style={[styles.card, { backgroundColor: palette.surface, borderColor: palette.border }]}>
+          <ExternalLink href={STUDI_PRIVACY_POLICY_URL as Href & string} asChild>
+            <Pressable style={({ pressed }) => [styles.row, { opacity: pressed ? 0.6 : 1 }]}>
+              <Text style={[TypeScale.body, { color: palette.text }]}>Privacy Policy</Text>
+              <Text style={[TypeScale.caption, { color: palette.icon }]}>›</Text>
+            </Pressable>
+          </ExternalLink>
+          <View style={[styles.rowDivider, { backgroundColor: palette.border }]} />
+          <ExternalLink href={STUDI_SUPPORT_URL as Href & string} asChild>
+            <Pressable style={({ pressed }) => [styles.row, { opacity: pressed ? 0.6 : 1 }]}>
+              <Text style={[TypeScale.body, { color: palette.text }]}>Support</Text>
+              <Text style={[TypeScale.caption, { color: palette.icon }]}>›</Text>
+            </Pressable>
+          </ExternalLink>
+          <View style={[styles.rowDivider, { backgroundColor: palette.border }]} />
+          <ExternalLink href={buildMailtoHref(STUDI_CONTACT_EMAIL, 'Studi Contact')} asChild>
+            <Pressable style={({ pressed }) => [styles.row, { opacity: pressed ? 0.6 : 1 }]}>
+              <Text style={[TypeScale.body, { color: palette.text }]}>Contact</Text>
+              <Text style={[TypeScale.meta, styles.rowValue, { color: palette.icon }]} numberOfLines={1}>
+                {STUDI_CONTACT_EMAIL}
+              </Text>
+            </Pressable>
+          </ExternalLink>
+        </View>
+      </View>
+
+      {/* Account actions (moved from Profile). */}
+      <View style={styles.accountActions}>
+        <Button
+          label="Sign out"
+          variant="secondary"
+          fullWidth
+          loading={isBusy}
+          onPress={handleSignOut}
+        />
+        <Pressable
+          disabled={isBusy}
+          onPress={confirmDeleteAccount}
+          style={({ pressed }) => [
+            styles.deleteLink,
+            { opacity: isBusy || pressed ? 0.6 : 1 },
+          ]}>
+          <Text style={[TypeScale.label, { color: palette.tint }]}>Delete account</Text>
+        </Pressable>
+      </View>
+
+      <Modal
+        animationType="fade"
+        onRequestClose={closeDeleteReauthModal}
+        transparent
+        visible={showDeleteReauthModal}>
+        <View style={styles.modalBackdrop}>
+          <View style={[styles.modalCard, { backgroundColor: palette.surface, borderColor: palette.border }]}>
+            <Text style={[TypeScale.heading, { color: palette.text }]}>Confirm with password</Text>
+            <Text style={[TypeScale.body, { color: palette.icon }]}>
+              For security, please re-enter your password for {deleteReauthEmail || 'your account'}.
+            </Text>
+            <View>
+              <TextInput
+                autoCapitalize="none"
+                autoCorrect={false}
+                editable={!isReauthenticatingDelete}
+                onChangeText={setDeleteReauthPassword}
+                placeholder="Password"
+                placeholderTextColor={placeholderColor}
+                secureTextEntry={!isDeletePasswordVisible}
+                style={[styles.input, styles.secureInput, inputColors]}
+                value={deleteReauthPassword}
+              />
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={isDeletePasswordVisible ? 'Hide password' : 'Show password'}
+                hitSlop={8}
+                onPress={() => setIsDeletePasswordVisible((visible) => !visible)}
+                style={styles.secureToggle}>
+                <IconSymbol
+                  name={isDeletePasswordVisible ? 'eye.slash' : 'eye'}
+                  size={20}
+                  color={palette.icon}
+                />
+              </Pressable>
+            </View>
+            <View style={styles.modalActions}>
+              <Button
+                label="Cancel"
+                variant="secondary"
+                disabled={isReauthenticatingDelete}
+                onPress={closeDeleteReauthModal}
+              />
+              <Button
+                label="Delete account"
+                loading={isReauthenticatingDelete}
+                onPress={handleDeleteWithReauthPassword}
+              />
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  content: {
+    gap: Space.xl,
+    padding: Space.lg + 4,
+    paddingBottom: Space.xxl + 4,
+  },
+  section: {
+    gap: Space.md,
+  },
+  card: {
+    borderRadius: Radius.card,
+    borderWidth: StyleSheet.hairlineWidth * 2,
+    paddingHorizontal: Space.lg + 4,
+    paddingVertical: Space.xs,
+  },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: Space.md,
+    justifyContent: 'space-between',
+    minHeight: 56,
+    paddingVertical: Space.sm,
+  },
+  rowBody: {
+    flex: 1,
+    gap: 2,
+  },
+  rowValue: {
+    flexShrink: 1,
+  },
+  rowDivider: {
+    height: StyleSheet.hairlineWidth,
+  },
+  verifiedValue: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: Space.sm - 2,
+  },
+  verifiedDot: {
+    alignItems: 'center',
+    borderRadius: Radius.pill,
+    height: 16,
+    justifyContent: 'center',
+    width: 16,
+  },
+  verifiedDotMark: {
+    color: '#FFFFFF',
+    fontFamily: FontFamily.bodySemiBold,
+    fontSize: 9,
+    lineHeight: 11,
+  },
+  errorBody: {
+    alignItems: 'flex-start',
+    gap: Space.sm,
+    paddingVertical: Space.md,
+  },
+  accountActions: {
+    gap: Space.md,
+  },
+  deleteLink: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 40,
+  },
+  input: {
+    borderRadius: Radius.chip + 4,
+    borderWidth: StyleSheet.hairlineWidth * 2,
+    fontFamily: FontFamily.body,
+    fontSize: 15,
+    minHeight: 52,
+    paddingHorizontal: Space.lg,
+    paddingVertical: Space.md,
+  },
+  secureInput: {
+    paddingRight: Space.lg + 28,
+  },
+  secureToggle: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: Space.md,
+    top: 0,
+    width: 28,
+  },
+  modalBackdrop: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: Space.lg + 4,
+  },
+  modalCard: {
+    borderRadius: Radius.card,
+    borderWidth: StyleSheet.hairlineWidth * 2,
+    gap: Space.md,
+    maxWidth: 420,
+    padding: Space.lg + 4,
+    width: '100%',
+  },
+  modalActions: {
+    flexDirection: 'row',
+    gap: Space.sm + 2,
+    justifyContent: 'flex-end',
+  },
+});

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,4 +1,4 @@
-import { type Href, useRouter } from 'expo-router';
+import { type Href, useFocusEffect, useRouter } from 'expo-router';
 import { useCallback, useEffect, useState } from 'react';
 import {
     Alert,
@@ -97,9 +97,13 @@ export default function SettingsScreen() {
     return unsubscribe;
   }, []);
 
-  useEffect(() => {
-    track('settings_viewed');
-  }, []);
+  // Fires on every focus, not just mount — coming back from Edit profile
+  // counts as a fresh view.
+  useFocusEffect(
+    useCallback(() => {
+      track('settings_viewed');
+    }, [])
+  );
 
   // One fetch per screen visit — toggles mutate local state and write through,
   // so nothing refetches on render.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -13,6 +13,8 @@ from them. If a number ends up on a slide or a resume, its definition lives here
 | `sign_in_completed` | `signIn()` succeeds | — |
 | `classes_saved` | Profile classes save succeeds | `count` |
 | `profile_updated` | Profile edit save succeeds (name/year/major/pronouns/bio) | `fieldsChanged` (count, never values) |
+| `settings_viewed` | Settings screen opened | — |
+| `notification_pref_toggled` | Notification preference save succeeds | `category` (pref key), `enabled` |
 | `session_create_started` | Create-session screen opened | `fromClassId?`, `fromLocationId?` |
 | `session_created` | `createSession()` succeeds | `classId`, `hoursUntilStart`, `capacity` |
 | `session_joined` | `joinSession()` performs a real join | `classId`, `participantCountAfter` |

--- a/firestore.rules
+++ b/firestore.rules
@@ -104,6 +104,31 @@ service cloud.firestore {
                && incoming().bio.size() <= 140));
     }
 
+    // Notification preferences (users/{uid}/private/settings, PR: settings).
+    // A partial map is valid — a missing doc or missing key means the
+    // preference is enabled — but every present value must be a real boolean
+    // and updatedAt is pinned to the server clock. No public profile data
+    // belongs here.
+    function isValidUserSettings() {
+      return incoming().keys().hasOnly(['notificationPrefs', 'updatedAt'])
+        && incoming().updatedAt == request.time
+        && incoming().notificationPrefs is map
+        && incoming().notificationPrefs.keys().hasOnly([
+             'sessionReminders', 'sessionActivity', 'dmMessages',
+             'groupMessages', 'friendRequests'
+           ])
+        && (!('sessionReminders' in incoming().notificationPrefs)
+              || incoming().notificationPrefs.sessionReminders is bool)
+        && (!('sessionActivity' in incoming().notificationPrefs)
+              || incoming().notificationPrefs.sessionActivity is bool)
+        && (!('dmMessages' in incoming().notificationPrefs)
+              || incoming().notificationPrefs.dmMessages is bool)
+        && (!('groupMessages' in incoming().notificationPrefs)
+              || incoming().notificationPrefs.groupMessages is bool)
+        && (!('friendRequests' in incoming().notificationPrefs)
+              || incoming().notificationPrefs.friendRequests is bool);
+    }
+
     match /users/{userId} {
       allow read: if isVerifiedUwUser();
       allow create: if isOwner(userId)
@@ -114,14 +139,19 @@ service cloud.firestore {
         && incoming().createdAt == resource.data.createdAt;
       allow delete: if false; // deletion handled by the deleteUserAccount Cloud Function
 
-      // Private profile: owner-only. Email must match the auth token.
+      // Private subcollection: owner-only. Two client-writable docs:
+      //  - profile:  email mirror (must match the auth token)
+      //  - settings: notification preferences
       match /private/{docId} {
         allow read: if isOwner(userId);
         allow write: if isOwner(userId)
-          && docId == 'profile'
-          && incoming().keys().hasOnly(['email', 'updatedAt'])
-          && incoming().email is string
-          && incoming().email == request.auth.token.email;
+          && (
+            (docId == 'profile'
+              && incoming().keys().hasOnly(['email', 'updatedAt'])
+              && incoming().email is string
+              && incoming().email == request.auth.token.email)
+            || (docId == 'settings' && isValidUserSettings())
+          );
         allow delete: if false;
 
         match /tokens/{tokenId} {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -61,6 +61,8 @@ export type AnalyticsEvent =
   | "onboarding_complete"
   | "profile_completed"
   | "profile_updated"
+  | "settings_viewed"
+  | "notification_pref_toggled"
   | "session_create_started"
   | "session_created"
   | "session_joined"

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -442,6 +442,74 @@ export async function updateUserProfileDetails(userId: string, details: UserProf
   });
 }
 
+// ---------------------------------------------------------------------------
+// Settings — users/{uid}/private/settings (PR: settings + notification prefs).
+// Owner-only. The doc only exists once the user flips a switch; a missing doc
+// or missing key means the preference is enabled. The notify() pipeline
+// (later PR) consults these before sending anything.
+// ---------------------------------------------------------------------------
+
+export const NOTIFICATION_PREF_KEYS = [
+  "sessionReminders",
+  "sessionActivity",
+  "dmMessages",
+  "groupMessages",
+  "friendRequests",
+] as const;
+
+export type NotificationPrefKey = (typeof NOTIFICATION_PREF_KEYS)[number];
+
+export type NotificationPrefs = Record<NotificationPrefKey, boolean>;
+
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
+  sessionReminders: true,
+  sessionActivity: true,
+  dmMessages: true,
+  groupMessages: true,
+  friendRequests: true,
+};
+
+function settingsDoc(userId: string) {
+  return doc(db, COLLECTIONS.users, userId, "private", "settings");
+}
+
+/** Missing doc, missing keys, and non-boolean junk all fall back to enabled. */
+export async function getNotificationPrefs(userId: string): Promise<NotificationPrefs> {
+  const snapshot = await getDoc(settingsDoc(userId));
+  const stored = snapshot.data()?.notificationPrefs as Record<string, unknown> | undefined;
+  const prefs = { ...DEFAULT_NOTIFICATION_PREFS };
+
+  if (stored && typeof stored === "object") {
+    for (const key of NOTIFICATION_PREF_KEYS) {
+      if (typeof stored[key] === "boolean") {
+        prefs[key] = stored[key];
+      }
+    }
+  }
+
+  return prefs;
+}
+
+/**
+ * Persists one preference. Merge keeps the write minimal (only the toggled
+ * key travels), creates the doc on first toggle, and can't clobber a
+ * concurrent toggle of a different preference.
+ */
+export async function saveNotificationPref(
+  userId: string,
+  key: NotificationPrefKey,
+  enabled: boolean
+) {
+  await setDoc(
+    settingsDoc(userId),
+    {
+      notificationPrefs: { [key]: enabled },
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true }
+  );
+}
+
 export async function getLocations() {
   try {
     const locationsQuery = query(

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -315,6 +315,94 @@ describe('users', () => {
   });
 });
 
+// --------------------------------------------------------- user settings
+describe('user settings (users/{uid}/private/settings)', () => {
+  const settingsRef = (db, uid) => doc(db, 'users', uid, 'private', 'settings');
+  const allPrefs = (overrides = {}) => ({
+    sessionReminders: true,
+    sessionActivity: true,
+    dmMessages: true,
+    groupMessages: true,
+    friendRequests: true,
+    ...overrides,
+  });
+
+  it('owner creates valid settings (full and partial pref maps)', async () => {
+    await assertSucceeds(setDoc(settingsRef(ctx(ALICE), ALICE), {
+      notificationPrefs: allPrefs(), updatedAt: serverTimestamp(),
+    }));
+    // Partial map is valid — a missing key means enabled.
+    await assertSucceeds(setDoc(settingsRef(ctx(ALICE), ALICE), {
+      notificationPrefs: { dmMessages: false }, updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('owner updates a single preference in place', async () => {
+    await seed(`users/${ALICE}/private/settings`, {
+      notificationPrefs: allPrefs(), updatedAt: Timestamp.now(),
+    });
+    await assertSucceeds(updateDoc(settingsRef(ctx(ALICE), ALICE), {
+      'notificationPrefs.dmMessages': false,
+      updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('another user cannot read or write settings', async () => {
+    await seed(`users/${ALICE}/private/settings`, {
+      notificationPrefs: allPrefs(), updatedAt: Timestamp.now(),
+    });
+    await assertFails(getDoc(settingsRef(ctx(BOB), ALICE)));
+    await assertFails(setDoc(settingsRef(ctx(BOB), ALICE), {
+      notificationPrefs: allPrefs({ dmMessages: false }),
+      updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('rejects unknown keys at both levels', async () => {
+    await assertFails(setDoc(settingsRef(ctx(ALICE), ALICE), {
+      notificationPrefs: allPrefs(),
+      marketingOptIn: true,
+      updatedAt: serverTimestamp(),
+    }));
+    await assertFails(setDoc(settingsRef(ctx(ALICE), ALICE), {
+      notificationPrefs: allPrefs({ emailDigest: true }),
+      updatedAt: serverTimestamp(),
+    }));
+    // No public/private-profile data in the settings doc:
+    await assertFails(setDoc(settingsRef(ctx(ALICE), ALICE), {
+      email: `${ALICE}@wisc.edu`, updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('rejects non-boolean preference values', async () => {
+    await assertFails(setDoc(settingsRef(ctx(ALICE), ALICE), {
+      notificationPrefs: allPrefs({ dmMessages: 'yes' }),
+      updatedAt: serverTimestamp(),
+    }));
+    await assertFails(setDoc(settingsRef(ctx(ALICE), ALICE), {
+      notificationPrefs: allPrefs({ sessionReminders: 1 }),
+      updatedAt: serverTimestamp(),
+    }));
+  });
+
+  it('rejects arbitrary updatedAt values', async () => {
+    await assertFails(setDoc(settingsRef(ctx(ALICE), ALICE), {
+      notificationPrefs: allPrefs(), updatedAt: Timestamp.fromMillis(0),
+    }));
+    // Updates must re-pin updatedAt to the server clock too:
+    await seed(`users/${ALICE}/private/settings`, {
+      notificationPrefs: allPrefs(), updatedAt: Timestamp.now(),
+    });
+    await assertFails(updateDoc(settingsRef(ctx(ALICE), ALICE), {
+      'notificationPrefs.dmMessages': false,
+    }));
+  });
+
+  it('owner can read a missing settings doc (client falls back to enabled defaults)', async () => {
+    await assertSucceeds(getDoc(settingsRef(ctx(ALICE), ALICE)));
+  });
+});
+
 // ---------------------------------------------------------------- sessions
 describe('sessions', () => {
   it('valid create succeeds', async () => {


### PR DESCRIPTION
## What

Real Settings screen (`/settings`, protected stack route) modeled on the Lovable design spec §3.13, plus persisted notification preferences.

### Screen
- **Account** — UW email, year & major, verified-student status, Edit profile link back to the Profile tab.
- **Notifications** — five real switches (session reminders, session activity, direct messages, group messages, friend requests). Optimistic saves; a failed save reverts the switch and shows an error. Loading disables the switches; a failed load shows an inline retry.
- **Privacy and support** — Privacy Policy, Support, Contact rows moved from Profile (same targets, no duplicate implementations).
- **Account actions** — Sign out and Delete account (with the password re-auth modal) moved from Profile.
- Profile now ends with a single Settings entry row; nothing became unreachable.

### Schema
`users/{uid}/private/settings`: `notificationPrefs` map of five booleans + `updatedAt`. Doc is created on first toggle via merge-write of just the toggled key. **Missing doc or missing key = enabled** — no migration needed.

### Rules
New `isValidUserSettings()`: owner-only read/write, strict key allowlist at both levels, boolean-only preference values, `updatedAt` pinned to `request.time`. Private subcollection write rule now branches per doc (`profile` | `settings`).

### Analytics (docs/metrics.md first)
- `settings_viewed` — screen opened
- `notification_pref_toggled` — `category` (pref key), `enabled`; no PII

### Out of scope (later PRs)
Notifications Center, group chat, friends, notify() pipeline (it will consult these prefs), who-can-message controls, data export, appearance settings.

## Validation
- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npm run rules:test` ✅ 60 passing (7 new: valid create incl. partial map, single-pref update, non-owner denied, unknown keys rejected, non-boolean rejected, arbitrary updatedAt rejected, missing-doc read allowed)
- `npx expo export --platform web` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)