### PR TITLE
PR 5: Session group chat

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -179,6 +179,7 @@ function RootLayout() {
           <Stack.Screen name="conversation/[conversationId]" options={{ title: 'Conversation' }} />
           <Stack.Screen name="report-user" options={{ title: 'Report User' }} />
           <Stack.Screen name="session/[sessionId]" options={{ title: 'Session Details' }} />
+          <Stack.Screen name="session-chat/[sessionId]" options={{ title: 'Session Chat' }} />
           <Stack.Screen name="rate-location" options={{ title: 'Rate This Spot' }} />
           <Stack.Screen name="settings" options={{ title: 'Settings' }} />
           <Stack.Screen name="notifications" options={{ title: 'Notifications' }} />

--- a/app/session-chat/[sessionId].tsx
+++ b/app/session-chat/[sessionId].tsx
@@ -1,0 +1,749 @@
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Button } from '@/components/ui/Button';
+import { Brand, Colors, FontFamily, Radius, Space, TypeScale } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { track } from '@/lib/analytics';
+import { subscribeToAuthState } from '@/lib/auth';
+import {
+  createSessionMessageId,
+  getBlockedUserIds,
+  getEarlierSessionMessages,
+  getProfilesByIds,
+  getSessionById,
+  markSessionChatRead,
+  sendSessionMessage,
+  subscribeToSessionMessages,
+  type SessionMessage,
+  type StudySessionListItem,
+  type UserProfile,
+} from '@/lib/firestore';
+import type { User } from 'firebase/auth';
+import type { QueryDocumentSnapshot } from 'firebase/firestore';
+
+// Analytics source for this screen open. Pushes from the notification
+// pipeline navigate by bare URL (no params), so a missing param means the
+// open came from a deep link rather than in-app navigation.
+type ChatOpenSource = 'session_detail' | 'auto_join' | 'deeplink';
+
+type FailedSend = {
+  messageId: string;
+  text: string;
+  isRetrying: boolean;
+};
+
+function toDate(value: unknown): Date | null {
+  if (!value || typeof value !== 'object' || !('toDate' in value)) {
+    return null;
+  }
+  return (value as { toDate: () => Date }).toDate();
+}
+
+function toMillis(value: unknown): number {
+  if (!value || typeof value !== 'object' || !('toMillis' in value)) {
+    return 0;
+  }
+  return (value as { toMillis: () => number }).toMillis();
+}
+
+/** Board ChatScreen day separator: "Today · 2:14 PM", "Mon, Jun 9 · 4:00 PM". */
+function formatDaySeparator(date: Date) {
+  const now = new Date();
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const dayLabel =
+    date.toDateString() === now.toDateString()
+      ? 'Today'
+      : date.toDateString() === yesterday.toDateString()
+        ? 'Yesterday'
+        : date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+  return `${dayLabel} · ${date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}`;
+}
+
+function formatTimestamp(value: unknown) {
+  const date = toDate(value);
+  if (!date) {
+    return '';
+  }
+
+  const now = new Date();
+  if (date.toDateString() === now.toDateString()) {
+    return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  }
+
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export default function SessionChatScreen() {
+  const router = useRouter();
+  const { sessionId, source } = useLocalSearchParams<{ sessionId?: string; source?: string }>();
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const insets = useSafeAreaInsets();
+
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [session, setSession] = useState<StudySessionListItem | null>(null);
+  const [isLoadingSession, setIsLoadingSession] = useState(true);
+  const [blockedUserIds, setBlockedUserIds] = useState<string[]>([]);
+  // Accumulated by ID so messages that scroll out of the live listener window
+  // never vanish and never gap against older pages (docs are immutable).
+  const [messagesById, setMessagesById] = useState<Map<string, SessionMessage>>(new Map());
+  const [threadLoaded, setThreadLoaded] = useState(false);
+  const [profilesById, setProfilesById] = useState<Map<string, UserProfile>>(new Map());
+  const [failedSends, setFailedSends] = useState<FailedSend[]>([]);
+  const [draft, setDraft] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [isLoadingEarlier, setIsLoadingEarlier] = useState(false);
+  const [threadError, setThreadError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+  const [focusNonce, setFocusNonce] = useState(0);
+  // Cursor/hasMore for paging backwards; starts from the live window's edge.
+  const cursorRef = useRef<QueryDocumentSnapshot | null>(null);
+  const [hasEarlier, setHasEarlier] = useState(false);
+  const startedPagingRef = useRef(false);
+
+  const isFocusedRef = useRef(false);
+  const shouldTrackOpenRef = useRef(false);
+  const lastMarkedMessageIdRef = useRef<string | null>(null);
+  const requestedProfileIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const unsubscribe = subscribeToAuthState((user) => {
+      setCurrentUser(user);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    if (!currentUser) {
+      setBlockedUserIds([]);
+      return;
+    }
+
+    getBlockedUserIds(currentUser.uid)
+      .then(setBlockedUserIds)
+      .catch(() => setBlockedUserIds([]));
+  }, [currentUser]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSession() {
+      if (!sessionId) {
+        setIsLoadingSession(false);
+        return;
+      }
+
+      try {
+        setIsLoadingSession(true);
+        const loadedSession = await getSessionById(sessionId);
+        if (!cancelled) {
+          setSession(loadedSession);
+          if (loadedSession) {
+            setProfilesById((current) => {
+              const next = new Map(current);
+              for (const profile of loadedSession.attendeeProfiles) {
+                next.set(profile.uid, profile);
+              }
+              if (loadedSession.hostProfile) {
+                next.set(loadedSession.hostProfile.uid, loadedSession.hostProfile);
+              }
+              return next;
+            });
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setSession(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingSession(false);
+        }
+      }
+    }
+
+    loadSession();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, retryNonce]);
+
+  const isParticipant =
+    !!currentUser && !!session && session.participantIds.includes(currentUser.uid);
+
+  const markRead = useCallback(
+    (newestMessageId: string | null) => {
+      if (!currentUser || !sessionId) {
+        return;
+      }
+      if (newestMessageId && newestMessageId === lastMarkedMessageIdRef.current) {
+        return;
+      }
+      lastMarkedMessageIdRef.current = newestMessageId;
+      markSessionChatRead(currentUser.uid, sessionId).catch(() => {
+        // Best-effort: a failed marker only means the unread dot lingers.
+        lastMarkedMessageIdRef.current = null;
+      });
+    },
+    [currentUser, sessionId]
+  );
+
+  // Live window over the newest page. Local optimistic sends surface here
+  // immediately (pending: true) and settle in place on ack.
+  useEffect(() => {
+    if (!currentUser || !sessionId || !isParticipant) {
+      return;
+    }
+
+    const unsubscribe = subscribeToSessionMessages(
+      sessionId,
+      (page) => {
+        setThreadLoaded(true);
+        setThreadError(null);
+        if (!startedPagingRef.current) {
+          cursorRef.current = page.cursor;
+          setHasEarlier(page.hasMore);
+        }
+        setMessagesById((current) => {
+          const next = new Map(current);
+          for (const message of page.messages) {
+            next.set(message.messageId, message);
+          }
+          return next;
+        });
+        // A send that comes back acknowledged is no longer failed (retry won).
+        setFailedSends((current) =>
+          current.filter((failed) => !page.messages.some((m) => m.messageId === failed.messageId))
+        );
+
+        const newestFromOthers = page.messages.find((m) => m.senderId !== currentUser.uid);
+        if (isFocusedRef.current && newestFromOthers) {
+          markRead(newestFromOthers.messageId);
+        }
+      },
+      () => {
+        setThreadError('Messages are unavailable right now.');
+      }
+    );
+
+    return unsubscribe;
+  }, [currentUser, sessionId, isParticipant, retryNonce, markRead]);
+
+  // Resolve display names for senders no longer in the attendee list
+  // (people who left the session but whose messages remain).
+  useEffect(() => {
+    const missing = [...messagesById.values()]
+      .map((message) => message.senderId)
+      .filter(
+        (uid) => uid && !profilesById.has(uid) && !requestedProfileIdsRef.current.has(uid)
+      );
+
+    if (missing.length === 0) {
+      return;
+    }
+
+    for (const uid of missing) {
+      requestedProfileIdsRef.current.add(uid);
+    }
+
+    getProfilesByIds([...new Set(missing)])
+      .then((loaded) => {
+        setProfilesById((current) => {
+          const next = new Map(current);
+          loaded.forEach((profile, uid) => {
+            if (profile) {
+              next.set(uid, profile);
+            }
+          });
+          return next;
+        });
+      })
+      .catch(() => {
+        // Names fall back to "Student"; retry happens naturally on next mount.
+      });
+  }, [messagesById, profilesById]);
+
+  useFocusEffect(
+    useCallback(() => {
+      isFocusedRef.current = true;
+      shouldTrackOpenRef.current = true;
+      // Effects don't re-run on focus alone; the nonce re-arms the one below.
+      setFocusNonce((nonce) => nonce + 1);
+      return () => {
+        isFocusedRef.current = false;
+      };
+    }, [])
+  );
+
+  // session_chat_opened fires once per focus, and only once the session is
+  // known (classId is a required property). Never on rerenders or sends.
+  useEffect(() => {
+    if (!shouldTrackOpenRef.current || !session || !isParticipant) {
+      return;
+    }
+    shouldTrackOpenRef.current = false;
+
+    const openSource: ChatOpenSource =
+      source === 'session_detail' || source === 'auto_join' ? source : 'deeplink';
+    track('session_chat_opened', { classId: session.classId, source: openSource });
+    markRead(null);
+  }, [session, isParticipant, source, markRead, focusNonce]);
+
+  const visibleMessages = useMemo(() => {
+    return [...messagesById.values()]
+      .filter((message) => !blockedUserIds.includes(message.senderId))
+      .sort((a, b) => toMillis(b.createdAt) - toMillis(a.createdAt));
+  }, [messagesById, blockedUserIds]);
+
+  async function handleSend() {
+    if (!currentUser || !sessionId) {
+      return;
+    }
+
+    const text = draft.trim();
+    if (!text) {
+      return;
+    }
+
+    const messageId = createSessionMessageId(sessionId);
+    setDraft('');
+
+    try {
+      setIsSending(true);
+      await sendSessionMessage(sessionId, currentUser.uid, text, messageId);
+    } catch {
+      // Keep the message; the bubble flips to a failed state with a retry.
+      setFailedSends((current) => [{ messageId, text, isRetrying: false }, ...current]);
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  async function handleRetry(failed: FailedSend) {
+    if (!currentUser || !sessionId || failed.isRetrying) {
+      return;
+    }
+
+    setFailedSends((current) =>
+      current.map((item) =>
+        item.messageId === failed.messageId ? { ...item, isRetrying: true } : item
+      )
+    );
+
+    try {
+      // Same pre-generated ID: a retry can never double-send.
+      await sendSessionMessage(sessionId, currentUser.uid, failed.text, failed.messageId);
+      setFailedSends((current) => current.filter((item) => item.messageId !== failed.messageId));
+    } catch {
+      setFailedSends((current) =>
+        current.map((item) =>
+          item.messageId === failed.messageId ? { ...item, isRetrying: false } : item
+        )
+      );
+    }
+  }
+
+  async function handleLoadEarlier() {
+    if (!sessionId || !cursorRef.current || isLoadingEarlier) {
+      return;
+    }
+
+    try {
+      setIsLoadingEarlier(true);
+      startedPagingRef.current = true;
+      const page = await getEarlierSessionMessages(sessionId, cursorRef.current);
+      cursorRef.current = page.cursor;
+      setHasEarlier(page.hasMore);
+      setMessagesById((current) => {
+        const next = new Map(current);
+        for (const message of page.messages) {
+          next.set(message.messageId, message);
+        }
+        return next;
+      });
+    } catch {
+      // Leave hasEarlier as-is so the user can try again by scrolling.
+    } finally {
+      setIsLoadingEarlier(false);
+    }
+  }
+
+  const participantCount = session?.participantIds.length ?? 0;
+  const senderName = useCallback(
+    (uid: string) => profilesById.get(uid)?.displayName.trim() || 'Student',
+    [profilesById]
+  );
+
+  const canSend = !isSending && draft.trim().length > 0;
+
+  if (isLoadingSession && !session) {
+    return (
+      <View style={[styles.centered, { backgroundColor: palette.background }]}>
+        <ActivityIndicator color={palette.tint} />
+      </View>
+    );
+  }
+
+  if (!session) {
+    return (
+      <View style={[styles.centered, { backgroundColor: palette.background }]}>
+        <Text style={[styles.emptyHeadline, { color: palette.text }]}>
+          Something went off-script.
+        </Text>
+        <Text style={[TypeScale.body, styles.emptyBody, { color: palette.icon }]}>
+          This session may have been removed, or the link is no longer valid.
+        </Text>
+        <Button label="Try again" variant="secondary" size="sm" onPress={() => setRetryNonce((n) => n + 1)} />
+      </View>
+    );
+  }
+
+  if (!isParticipant) {
+    return (
+      <View style={[styles.centered, { backgroundColor: palette.background }]}>
+        <Text style={[styles.emptyHeadline, { color: palette.text }]}>Join to chat</Text>
+        <Text style={[TypeScale.body, styles.emptyBody, { color: palette.icon }]}>
+          The session chat is just for people who are going.
+        </Text>
+        <Button
+          label="View session"
+          variant="secondary"
+          size="sm"
+          onPress={() =>
+            router.push({ pathname: '/session/[sessionId]', params: { sessionId: session.sessionId } })
+          }
+        />
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 88 : 0}
+      style={[styles.screen, { backgroundColor: palette.background }]}>
+      {/* Identity strip under the nav header — mirrors the DM conversation. */}
+      <View style={[styles.identityBar, { borderBottomColor: palette.border }]}>
+        <View style={styles.identityText}>
+          <Text style={[TypeScale.bodyStrong, { color: palette.text }]} numberOfLines={1}>
+            {session.title}
+          </Text>
+          <Text style={[TypeScale.caption, { color: palette.icon }]} numberOfLines={1}>
+            {threadError ?? `${session.classId} · ${participantCount} going`}
+          </Text>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() =>
+            router.push({ pathname: '/session/[sessionId]', params: { sessionId: session.sessionId } })
+          }
+          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}>
+          <Text style={[TypeScale.label, { color: palette.tint }]}>Details</Text>
+        </Pressable>
+      </View>
+
+      <FlatList
+        style={styles.thread}
+        inverted
+        data={visibleMessages}
+        keyExtractor={(message) => message.messageId}
+        contentContainerStyle={styles.threadContent}
+        onEndReachedThreshold={0.4}
+        onEndReached={hasEarlier ? handleLoadEarlier : undefined}
+        ListHeaderComponent={
+          failedSends.length > 0 ? (
+            // Inverted list: the header renders at the bottom, right above the
+            // composer — exactly where the failed sends belong.
+            <View style={styles.failedGroup}>
+              {failedSends.map((failed) => (
+                <View key={failed.messageId} style={[styles.messageGroup, styles.mine]}>
+                  <View style={[styles.bubble, styles.mineBubble, styles.failedBubble, { backgroundColor: palette.tint }]}>
+                    <Text style={[styles.bubbleText, { color: '#FFFFFF' }]}>{failed.text}</Text>
+                  </View>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Retry sending message"
+                    disabled={failed.isRetrying}
+                    onPress={() => handleRetry(failed)}
+                    style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}>
+                    <Text style={[styles.bubbleTime, { color: Brand.accent }]}>
+                      {failed.isRetrying ? 'Retrying…' : 'Not sent · Tap to retry'}
+                    </Text>
+                  </Pressable>
+                </View>
+              ))}
+            </View>
+          ) : null
+        }
+        ListFooterComponent={
+          isLoadingEarlier ? (
+            <ActivityIndicator style={styles.earlierSpinner} color={palette.tint} />
+          ) : null
+        }
+        ListEmptyComponent={
+          threadLoaded ? (
+            <View style={[styles.emptyThread, styles.invertedItem]}>
+              <Text style={[styles.emptyHeadline, { color: palette.text }]}>Say hi 👋</Text>
+              <Text style={[TypeScale.body, styles.emptyBody, { color: palette.icon }]}>
+                Coordinate seats, timing, and what to bring.
+              </Text>
+            </View>
+          ) : (
+            <ActivityIndicator style={styles.earlierSpinner} color={palette.tint} />
+          )
+        }
+        renderItem={({ item: message, index }) => {
+          const isCurrentUser = currentUser?.uid === message.senderId;
+          // Newest-first data: chronological neighbors are inverted.
+          const chronPrev = visibleMessages[index + 1];
+          const chronNext = visibleMessages[index - 1];
+          const showTime = !chronNext || chronNext.senderId !== message.senderId;
+          const showSenderName =
+            !isCurrentUser && (!chronPrev || chronPrev.senderId !== message.senderId);
+          const messageDate = toDate(message.createdAt);
+          const previousDate = chronPrev ? toDate(chronPrev.createdAt) : null;
+          const showDaySeparator =
+            !!messageDate &&
+            (!previousDate || previousDate.toDateString() !== messageDate.toDateString());
+
+          return (
+            <View style={[styles.messageGroup, isCurrentUser ? styles.mine : styles.theirs]}>
+              {showDaySeparator ? (
+                <Text style={[styles.daySeparator, { color: palette.icon }]}>
+                  {formatDaySeparator(messageDate)}
+                </Text>
+              ) : null}
+              {showSenderName ? (
+                <Text style={[styles.senderName, { color: palette.icon }]} numberOfLines={1}>
+                  {senderName(message.senderId)}
+                </Text>
+              ) : null}
+              <View
+                style={[
+                  styles.bubble,
+                  isCurrentUser
+                    ? [styles.mineBubble, { backgroundColor: palette.tint }]
+                    : [
+                        styles.theirsBubble,
+                        {
+                          backgroundColor: palette.surface,
+                          borderColor: palette.border,
+                          borderWidth: StyleSheet.hairlineWidth * 2,
+                        },
+                      ],
+                ]}>
+                <Text style={[styles.bubbleText, { color: isCurrentUser ? '#FFFFFF' : palette.text }]}>
+                  {message.text}
+                </Text>
+              </View>
+              {showTime ? (
+                <Text style={[styles.bubbleTime, { color: palette.icon }]}>
+                  {message.pending ? 'Sending…' : formatTimestamp(message.createdAt)}
+                </Text>
+              ) : null}
+            </View>
+          );
+        }}
+      />
+
+      <View
+        style={[
+          styles.composerBar,
+          {
+            borderTopColor: palette.border,
+            paddingBottom: Math.max(insets.bottom, Space.md),
+          },
+        ]}>
+        <View style={[styles.composer, { backgroundColor: palette.surfaceMuted }]}>
+          <TextInput
+            editable={!isSending}
+            multiline
+            onChangeText={setDraft}
+            placeholder="Message the group…"
+            placeholderTextColor={colorScheme === 'dark' ? '#8A8174' : Brand.textSubtle}
+            style={[styles.composerInput, { color: palette.text }]}
+            value={draft}
+          />
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Send message"
+            disabled={!canSend}
+            onPress={handleSend}
+            style={({ pressed }) => [
+              styles.sendButton,
+              {
+                backgroundColor: palette.tint,
+                opacity: !canSend ? 0.4 : pressed ? 0.8 : 1,
+              },
+            ]}>
+            {isSending ? (
+              <ActivityIndicator size="small" color="#FFFFFF" />
+            ) : (
+              <Text style={styles.sendGlyph}>↑</Text>
+            )}
+          </Pressable>
+        </View>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  centered: {
+    alignItems: 'center',
+    flex: 1,
+    gap: Space.sm,
+    justifyContent: 'center',
+    padding: Space.xl,
+  },
+  identityBar: {
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: Space.md,
+    paddingHorizontal: Space.lg + 4,
+    paddingVertical: Space.md,
+  },
+  identityText: {
+    flex: 1,
+    gap: 1,
+  },
+  thread: {
+    flex: 1,
+  },
+  threadContent: {
+    gap: Space.xs + 2,
+    padding: Space.lg,
+    paddingBottom: Space.xl,
+  },
+  invertedItem: {
+    // ListEmptyComponent renders inside the inverted container; flip it back.
+    transform: [{ scaleY: -1 }],
+  },
+  messageGroup: {
+    gap: Space.xs,
+  },
+  failedGroup: {
+    gap: Space.xs + 2,
+  },
+  daySeparator: {
+    alignSelf: 'center',
+    fontFamily: FontFamily.bodySemiBold,
+    fontSize: 10,
+    letterSpacing: 0.8,
+    lineHeight: 13,
+    marginVertical: Space.sm,
+    textAlign: 'center',
+    textTransform: 'uppercase',
+  },
+  senderName: {
+    fontFamily: FontFamily.bodyMedium,
+    fontSize: 11,
+    lineHeight: 14,
+    paddingHorizontal: Space.xs,
+  },
+  mine: {
+    alignItems: 'flex-end',
+  },
+  theirs: {
+    alignItems: 'flex-start',
+  },
+  bubble: {
+    borderRadius: Radius.xl - 2,
+    maxWidth: '80%',
+    paddingHorizontal: Space.md + 2,
+    paddingVertical: Space.sm + 2,
+  },
+  mineBubble: {
+    borderBottomRightRadius: Radius.sm - 2,
+  },
+  theirsBubble: {
+    borderBottomLeftRadius: Radius.sm - 2,
+  },
+  failedBubble: {
+    opacity: 0.55,
+  },
+  bubbleText: {
+    fontFamily: FontFamily.body,
+    fontSize: 14,
+    lineHeight: 19,
+  },
+  bubbleTime: {
+    fontFamily: FontFamily.bodyMedium,
+    fontSize: 10,
+    lineHeight: 13,
+    paddingHorizontal: Space.xs,
+  },
+  emptyThread: {
+    alignItems: 'center',
+    gap: Space.sm,
+    paddingVertical: Space.xxl + 8,
+  },
+  emptyHeadline: {
+    fontFamily: FontFamily.serifItalic,
+    fontSize: 24,
+    lineHeight: 30,
+  },
+  emptyBody: {
+    maxWidth: 280,
+    textAlign: 'center',
+  },
+  earlierSpinner: {
+    paddingVertical: Space.md,
+  },
+  composerBar: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: Space.lg,
+    paddingTop: Space.sm + 2,
+  },
+  composer: {
+    alignItems: 'flex-end',
+    borderRadius: Radius.xxl - 4,
+    flexDirection: 'row',
+    gap: Space.sm,
+    paddingHorizontal: Space.lg,
+    paddingVertical: Space.sm - 2,
+  },
+  composerInput: {
+    flex: 1,
+    fontFamily: FontFamily.body,
+    fontSize: 15,
+    lineHeight: 20,
+    maxHeight: 120,
+    paddingVertical: Space.sm,
+  },
+  sendButton: {
+    alignItems: 'center',
+    borderRadius: Radius.pill,
+    height: 32,
+    justifyContent: 'center',
+    marginBottom: Space.xs + 2,
+    width: 32,
+  },
+  sendGlyph: {
+    color: '#FFFFFF',
+    fontFamily: FontFamily.bodySemiBold,
+    fontSize: 16,
+    lineHeight: 20,
+  },
+});

--- a/app/session-chat/[sessionId].tsx
+++ b/app/session-chat/[sessionId].tsx
@@ -24,7 +24,9 @@ import {
   getEarlierSessionMessages,
   getProfilesByIds,
   getSessionById,
+  isGroupChatAvailable,
   markSessionChatRead,
+  MAX_GROUP_CHAT_PARTICIPANTS,
   sendSessionMessage,
   subscribeToSessionMessages,
   type SessionMessage,
@@ -190,9 +192,12 @@ export default function SessionChatScreen() {
 
   const isParticipant =
     !!currentUser && !!session && session.participantIds.includes(currentUser.uid);
-  // Cancelled sessions are read-only (rules deny new sends); retained
-  // participants keep the history.
+  // Two read-only states (rules deny new sends in both; history stays
+  // readable): cancelled sessions, and oversized legacy sessions past the
+  // group-chat fanout ceiling.
   const isCancelled = session?.status === 'cancelled';
+  const isOversized = !!session && !isGroupChatAvailable(session);
+  const isReadOnly = isCancelled || isOversized;
 
   const markRead = useCallback(
     (newestMessageId: string | null) => {
@@ -328,7 +333,7 @@ export default function SessionChatScreen() {
   }
 
   async function handleSend() {
-    if (!currentUser || !sessionId || isCancelled) {
+    if (!currentUser || !sessionId || isReadOnly) {
       return;
     }
 
@@ -353,7 +358,7 @@ export default function SessionChatScreen() {
   }
 
   async function handleRetry(failed: FailedSend) {
-    if (!currentUser || !sessionId || failed.isRetrying || isCancelled) {
+    if (!currentUser || !sessionId || failed.isRetrying || isReadOnly) {
       return;
     }
 
@@ -408,7 +413,7 @@ export default function SessionChatScreen() {
     [profilesById]
   );
 
-  const canSend = !isSending && !isCancelled && draft.trim().length > 0;
+  const canSend = !isSending && !isReadOnly && draft.trim().length > 0;
 
   if (isLoadingSession && !session) {
     return (
@@ -476,10 +481,12 @@ export default function SessionChatScreen() {
         </Pressable>
       </View>
 
-      {isCancelled ? (
+      {isReadOnly ? (
         <View style={[styles.readOnlyNotice, { backgroundColor: palette.surfaceMuted }]}>
           <Text style={[TypeScale.caption, styles.readOnlyText, { color: palette.icon }]}>
-            This session was cancelled. Chat history is still available.
+            {isCancelled
+              ? 'This session was cancelled. Chat history is still available.'
+              : `Group chat is unavailable for sessions with more than ${MAX_GROUP_CHAT_PARTICIPANTS} people.`}
           </Text>
         </View>
       ) : null}
@@ -505,11 +512,11 @@ export default function SessionChatScreen() {
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel="Retry sending message"
-                    disabled={failed.isRetrying || isCancelled}
+                    disabled={failed.isRetrying || isReadOnly}
                     onPress={() => handleRetry(failed)}
-                    style={({ pressed }) => ({ opacity: pressed && !isCancelled ? 0.6 : 1 })}>
+                    style={({ pressed }) => ({ opacity: pressed && !isReadOnly ? 0.6 : 1 })}>
                     <Text style={[styles.bubbleTime, { color: Brand.accent }]}>
-                      {isCancelled
+                      {isReadOnly
                         ? 'Not sent'
                         : failed.isRetrying
                           ? 'Retrying…'
@@ -603,13 +610,19 @@ export default function SessionChatScreen() {
         <View
           style={[
             styles.composer,
-            { backgroundColor: palette.surfaceMuted, opacity: isCancelled ? 0.55 : 1 },
+            { backgroundColor: palette.surfaceMuted, opacity: isReadOnly ? 0.55 : 1 },
           ]}>
           <TextInput
-            editable={!isSending && !isCancelled}
+            editable={!isSending && !isReadOnly}
             multiline
             onChangeText={setDraft}
-            placeholder={isCancelled ? 'This session was cancelled.' : 'Message the group…'}
+            placeholder={
+              isCancelled
+                ? 'This session was cancelled.'
+                : isOversized
+                  ? 'Chat is unavailable for this session.'
+                  : 'Message the group…'
+            }
             placeholderTextColor={colorScheme === 'dark' ? '#8A8174' : Brand.textSubtle}
             style={[styles.composerInput, { color: palette.text }]}
             value={draft}

--- a/app/session-chat/[sessionId].tsx
+++ b/app/session-chat/[sessionId].tsx
@@ -31,6 +31,7 @@ import {
   type StudySessionListItem,
   type UserProfile,
 } from '@/lib/firestore';
+import { FirebaseError } from 'firebase/app';
 import type { User } from 'firebase/auth';
 import type { QueryDocumentSnapshot } from 'firebase/firestore';
 
@@ -189,6 +190,9 @@ export default function SessionChatScreen() {
 
   const isParticipant =
     !!currentUser && !!session && session.participantIds.includes(currentUser.uid);
+  // Cancelled sessions are read-only (rules deny new sends); retained
+  // participants keep the history.
+  const isCancelled = session?.status === 'cancelled';
 
   const markRead = useCallback(
     (newestMessageId: string | null) => {
@@ -314,8 +318,17 @@ export default function SessionChatScreen() {
       .sort((a, b) => toMillis(b.createdAt) - toMillis(a.createdAt));
   }, [messagesById, blockedUserIds]);
 
+  // A denied write usually means the session state changed under us (e.g.
+  // the host cancelled while this screen was open) — reload the session so
+  // the read-only state renders instead of an endless retry loop.
+  function refreshSessionOnDenied(error: unknown) {
+    if (error instanceof FirebaseError && error.code === 'permission-denied') {
+      setRetryNonce((nonce) => nonce + 1);
+    }
+  }
+
   async function handleSend() {
-    if (!currentUser || !sessionId) {
+    if (!currentUser || !sessionId || isCancelled) {
       return;
     }
 
@@ -330,16 +343,17 @@ export default function SessionChatScreen() {
     try {
       setIsSending(true);
       await sendSessionMessage(sessionId, currentUser.uid, text, messageId);
-    } catch {
+    } catch (error) {
       // Keep the message; the bubble flips to a failed state with a retry.
       setFailedSends((current) => [{ messageId, text, isRetrying: false }, ...current]);
+      refreshSessionOnDenied(error);
     } finally {
       setIsSending(false);
     }
   }
 
   async function handleRetry(failed: FailedSend) {
-    if (!currentUser || !sessionId || failed.isRetrying) {
+    if (!currentUser || !sessionId || failed.isRetrying || isCancelled) {
       return;
     }
 
@@ -353,12 +367,13 @@ export default function SessionChatScreen() {
       // Same pre-generated ID: a retry can never double-send.
       await sendSessionMessage(sessionId, currentUser.uid, failed.text, failed.messageId);
       setFailedSends((current) => current.filter((item) => item.messageId !== failed.messageId));
-    } catch {
+    } catch (error) {
       setFailedSends((current) =>
         current.map((item) =>
           item.messageId === failed.messageId ? { ...item, isRetrying: false } : item
         )
       );
+      refreshSessionOnDenied(error);
     }
   }
 
@@ -393,7 +408,7 @@ export default function SessionChatScreen() {
     [profilesById]
   );
 
-  const canSend = !isSending && draft.trim().length > 0;
+  const canSend = !isSending && !isCancelled && draft.trim().length > 0;
 
   if (isLoadingSession && !session) {
     return (
@@ -461,6 +476,14 @@ export default function SessionChatScreen() {
         </Pressable>
       </View>
 
+      {isCancelled ? (
+        <View style={[styles.readOnlyNotice, { backgroundColor: palette.surfaceMuted }]}>
+          <Text style={[TypeScale.caption, styles.readOnlyText, { color: palette.icon }]}>
+            This session was cancelled. Chat history is still available.
+          </Text>
+        </View>
+      ) : null}
+
       <FlatList
         style={styles.thread}
         inverted
@@ -482,11 +505,15 @@ export default function SessionChatScreen() {
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel="Retry sending message"
-                    disabled={failed.isRetrying}
+                    disabled={failed.isRetrying || isCancelled}
                     onPress={() => handleRetry(failed)}
-                    style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}>
+                    style={({ pressed }) => ({ opacity: pressed && !isCancelled ? 0.6 : 1 })}>
                     <Text style={[styles.bubbleTime, { color: Brand.accent }]}>
-                      {failed.isRetrying ? 'Retrying…' : 'Not sent · Tap to retry'}
+                      {isCancelled
+                        ? 'Not sent'
+                        : failed.isRetrying
+                          ? 'Retrying…'
+                          : 'Not sent · Tap to retry'}
                     </Text>
                   </Pressable>
                 </View>
@@ -573,12 +600,16 @@ export default function SessionChatScreen() {
             paddingBottom: Math.max(insets.bottom, Space.md),
           },
         ]}>
-        <View style={[styles.composer, { backgroundColor: palette.surfaceMuted }]}>
+        <View
+          style={[
+            styles.composer,
+            { backgroundColor: palette.surfaceMuted, opacity: isCancelled ? 0.55 : 1 },
+          ]}>
           <TextInput
-            editable={!isSending}
+            editable={!isSending && !isCancelled}
             multiline
             onChangeText={setDraft}
-            placeholder="Message the group…"
+            placeholder={isCancelled ? 'This session was cancelled.' : 'Message the group…'}
             placeholderTextColor={colorScheme === 'dark' ? '#8A8174' : Brand.textSubtle}
             style={[styles.composerInput, { color: palette.text }]}
             value={draft}
@@ -627,6 +658,13 @@ const styles = StyleSheet.create({
   identityText: {
     flex: 1,
     gap: 1,
+  },
+  readOnlyNotice: {
+    paddingHorizontal: Space.lg,
+    paddingVertical: Space.sm + 2,
+  },
+  readOnlyText: {
+    textAlign: 'center',
   },
   thread: {
     flex: 1,

--- a/app/session/[sessionId].tsx
+++ b/app/session/[sessionId].tsx
@@ -37,6 +37,7 @@ import {
     getSessionById,
     getSessionChatLastReadAt,
     hasUnreadSessionChat,
+    isGroupChatAvailable,
     isSessionAtCapacity,
     joinSession,
     leaveSession,
@@ -318,10 +319,14 @@ export default function SessionDetailScreen() {
     ? session.participantIds.includes(currentUser.uid)
     : false;
   const isHost = currentUser && session ? session.hostId === currentUser.uid : false;
+  // Oversized legacy sessions (past the group-chat fanout ceiling) get a
+  // read-only chat — no unread dot, and the card says so.
+  const isChatAvailable = !!session && isGroupChatAvailable(session);
   const hasUnreadChat =
     !!currentUser &&
     !!session &&
     isParticipant &&
+    isChatAvailable &&
     hasUnreadSessionChat(session, currentUser.uid, chatLastReadAt);
   const visibleAttendees = session
     ? session.attendeeProfiles.filter((attendee) => !blockedUserIds.includes(attendee.uid))
@@ -485,9 +490,11 @@ export default function SessionDetailScreen() {
                       ) : null}
                     </View>
                     <Text style={[TypeScale.caption, { color: palette.icon }]} numberOfLines={1}>
-                      {hasUnreadChat
-                        ? 'New messages from your group.'
-                        : 'Coordinate with everyone going.'}
+                      {!isChatAvailable
+                        ? 'Chat is unavailable for sessions this large.'
+                        : hasUnreadChat
+                          ? 'New messages from your group.'
+                          : 'Coordinate with everyone going.'}
                     </Text>
                   </View>
                   <Button

--- a/app/session/[sessionId].tsx
+++ b/app/session/[sessionId].tsx
@@ -1,4 +1,4 @@
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     ActivityIndicator,
@@ -35,6 +35,8 @@ import {
     getBlockedUserIds,
     getOrCreateDirectConversation,
     getSessionById,
+    getSessionChatLastReadAt,
+    hasUnreadSessionChat,
     isSessionAtCapacity,
     joinSession,
     leaveSession,
@@ -44,6 +46,7 @@ import {
 import { getStudyLocationDisplayName } from '@/lib/catalog';
 import { FirebaseError } from 'firebase/app';
 import type { User } from 'firebase/auth';
+import type { Timestamp } from 'firebase/firestore';
 
 function formatDisplayName(name: string | undefined) {
   if (name && name.trim().length > 0) {
@@ -68,6 +71,7 @@ export default function SessionDetailScreen() {
   const [isJoining, setIsJoining] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
   const [isOpeningHostChat, setIsOpeningHostChat] = useState(false);
+  const [chatLastReadAt, setChatLastReadAt] = useState<Timestamp | null>(null);
   const { toast, show: showToast } = useSuccessToast();
 
   useEffect(() => {
@@ -123,6 +127,43 @@ export default function SessionDetailScreen() {
     loadSession();
   }, [loadSession]);
 
+  // Refresh the chat read marker every time the screen regains focus, so the
+  // unread dot clears right after coming back from the chat.
+  useFocusEffect(
+    useCallback(() => {
+      if (!currentUser || !sessionId) {
+        setChatLastReadAt(null);
+        return;
+      }
+
+      let cancelled = false;
+      getSessionChatLastReadAt(currentUser.uid, sessionId)
+        .then((lastReadAt) => {
+          if (!cancelled) {
+            setChatLastReadAt(lastReadAt);
+          }
+        })
+        .catch(() => {
+          // Indicator-only data; a failed read just leaves the dot conservative.
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }, [currentUser, sessionId])
+  );
+
+  function openSessionChat(source: 'session_detail' | 'auto_join') {
+    if (!sessionId) {
+      return;
+    }
+
+    router.push({
+      pathname: '/session-chat/[sessionId]',
+      params: { sessionId, source },
+    });
+  }
+
   async function handleRefresh() {
     setIsRefreshing(true);
     await loadSession();
@@ -153,6 +194,8 @@ export default function SessionDetailScreen() {
         }
         setStatus('Joined session successfully.');
         showToast('You’re in.', session?.title ?? 'See you at the table.');
+        // Land new members in the group chat so coordination starts right away.
+        openSessionChat('auto_join');
       }
     } catch (error) {
       // Lost the race for the last seat: reload so the Full state renders,
@@ -275,6 +318,11 @@ export default function SessionDetailScreen() {
     ? session.participantIds.includes(currentUser.uid)
     : false;
   const isHost = currentUser && session ? session.hostId === currentUser.uid : false;
+  const hasUnreadChat =
+    !!currentUser &&
+    !!session &&
+    isParticipant &&
+    hasUnreadSessionChat(session, currentUser.uid, chatLastReadAt);
   const visibleAttendees = session
     ? session.attendeeProfiles.filter((attendee) => !blockedUserIds.includes(attendee.uid))
     : [];
@@ -414,6 +462,43 @@ export default function SessionDetailScreen() {
                 />
               </View>
             </View>
+
+            {/* 2.5 SESSION CHAT — participants only (host included). */}
+            {isParticipant ? (
+              <View
+                style={[
+                  styles.card,
+                  Elevation.e1,
+                  { backgroundColor: palette.surface, borderColor: palette.border },
+                ]}>
+                <View style={styles.chatRow}>
+                  <View style={styles.chatText}>
+                    <View style={styles.chatTitleRow}>
+                      <Text style={[TypeScale.bodyStrong, { color: palette.text }]}>
+                        Session chat
+                      </Text>
+                      {hasUnreadChat ? (
+                        <View
+                          accessibilityLabel="Unread messages"
+                          style={[styles.unreadDot, { backgroundColor: palette.tint }]}
+                        />
+                      ) : null}
+                    </View>
+                    <Text style={[TypeScale.caption, { color: palette.icon }]} numberOfLines={1}>
+                      {hasUnreadChat
+                        ? 'New messages from your group.'
+                        : 'Coordinate with everyone going.'}
+                    </Text>
+                  </View>
+                  <Button
+                    label="Open chat"
+                    variant="secondary"
+                    size="sm"
+                    onPress={() => openSessionChat('session_detail')}
+                  />
+                </View>
+              </View>
+            ) : null}
 
             {/* 3. ATTENDANCE — attendee list, capacity state, join status. */}
             <View
@@ -695,6 +780,25 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: Space.md,
+  },
+  chatRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: Space.md,
+  },
+  chatText: {
+    flex: 1,
+    gap: 2,
+  },
+  chatTitleRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: Space.sm,
+  },
+  unreadDot: {
+    borderRadius: Radius.pill,
+    height: 8,
+    width: 8,
   },
   hostText: {
     flex: 1,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -28,6 +28,8 @@ from them. If a number ends up on a slide or a resume, its definition lives here
 | `uw_map_opened` | UW layers tapped from the study map | — |
 | `conversation_started` | New conversation doc created | — |
 | `message_sent` | `sendDirectMessage()` succeeds | `length` (number, not content) |
+| `session_chat_opened` | Session chat screen gains focus (once per focus) | `classId`, `source` (`session_detail` \| `auto_join` \| `deeplink`) |
+| `group_message_sent` | `sendSessionMessage()` succeeds | `length` (number, not content) |
 | `report_submitted` | Report saved | `reason`, `context` |
 | `user_blocked` | Block saved | `context` |
 | `account_deleted` | Deletion callable succeeds | — |

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -25,10 +25,20 @@ The notifications-center PR extends that into a persistent pipeline:
 - `/notifications` screen (protected) with unread badge on the Profile tab.
 
 Not implemented: App Check, RNFirebase messaging, friend notifications,
-client dismiss (no delete rule; records expire via TTL). Group-chat pushes are
-not block-filtered: two users who blocked each other can share a session
-(blocks only gate joining against the host), and the client hides their
-bubbles the same way it hides them in the attendee list.
+client dismiss (no delete rule; records expire via TTL).
+
+Group-message notifications are **block-filtered server-side**: before
+`notifyUser()` runs, `onSessionMessageCreated` checks both directions of the
+deterministic `userBlocks/{blocker}__{blocked}` docs in one batched `getAll`
+and drops blocked recipients entirely — no record, no push, regardless of any
+preference setting (the filter runs upstream of the pref check). Read cost:
+2 document lookups per recipient per message, bounded by session capacity
+(≤20 participants → ≤38 lookups in a single RPC). The chat message itself
+stays stored for the remaining participants; client bubble-hiding is a UI
+courtesy on top, not the enforcement. A cancelled session is read-only —
+rules deny new sends while retained participants keep the history — and
+group messages are fully immutable from the client (no edits, no deletes;
+account deletion cleans them up via the Admin SDK).
 
 ## Payload validation & deep-link safety
 
@@ -162,6 +172,17 @@ Group chat (this PR):
 - A message from A creates a `group_message` record for every other
   participant (never A) and pushes unless `groupMessages` is toggled off;
   tap opens `/session-chat/{id}`.
+- A blocked pair (either direction) gets neither the record nor the push,
+  even with every preference enabled; an unrelated participant in the same
+  session still gets both.
+- Cancelling a session flips its chat to read-only: the notice renders, the
+  composer disables, failed sends stop offering retry, and a deep link into
+  the cancelled chat shows history without crashing.
+- Account deletion is resumable: the account is disabled and refresh tokens
+  revoked before any cleanup, every step drains queries in bounded pages,
+  and re-calling the callable on an already-disabled account resumes the
+  idempotent cleanup (worst case: a locked-out account with residual data
+  until a retry or ops re-run completes).
 - The Session Details chat card shows the unread dot only for someone else's
   message arriving after your last visit to the chat, and clears when you
   come back from the chat.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -31,14 +31,26 @@ Group-message notifications are **block-filtered server-side**: before
 `notifyUser()` runs, `onSessionMessageCreated` checks both directions of the
 deterministic `userBlocks/{blocker}__{blocked}` docs in one batched `getAll`
 and drops blocked recipients entirely — no record, no push, regardless of any
-preference setting (the filter runs upstream of the pref check). Read cost:
-2 document lookups per recipient per message, bounded by session capacity
-(≤20 participants → ≤38 lookups in a single RPC). The chat message itself
-stays stored for the remaining participants; client bubble-hiding is a UI
-courtesy on top, not the enforcement. A cancelled session is read-only —
-rules deny new sends while retained participants keep the history — and
-group messages are fully immutable from the client (no edits, no deletes;
-account deletion cleans them up via the Admin SDK).
+preference setting (the filter runs upstream of the pref check). The chat
+message itself stays stored for the remaining participants; client
+bubble-hiding is a UI courtesy on top, not the enforcement.
+
+Group-chat fanout is **capped at 20 participants**
+(`MAX_GROUP_CHAT_PARTICIPANTS`), judged on the ACTUAL `participantIds`
+length — never the optional capacity field — so legacy uncapped sessions
+cannot force unbounded fanout. The same ceiling is enforced in three places
+(change them together): the messages create rule in `firestore.rules`
+(`participantIds.size() <= 20`), the client's read-only chat state
+(`lib/firestore.ts` `isGroupChatAvailable`), and the Cloud Function, which
+skips metadata + notifications entirely for oversized sessions rather than
+silently notifying a subset. Exact read cost: **at most 38 block-doc reads
+per message** — a full 20-participant session minus the sender is 19
+recipients × 2 directions, fetched in a single RPC.
+
+A cancelled session is read-only — rules deny new sends while retained
+participants keep the history — and group messages are fully immutable from
+the client (no edits, no deletes; account deletion cleans them up via the
+Admin SDK).
 
 ## Payload validation & deep-link safety
 
@@ -178,11 +190,22 @@ Group chat (this PR):
 - Cancelling a session flips its chat to read-only: the notice renders, the
   composer disables, failed sends stop offering retry, and a deep link into
   the cancelled chat shows history without crashing.
-- Account deletion is resumable: the account is disabled and refresh tokens
-  revoked before any cleanup, every step drains queries in bounded pages,
-  and re-calling the callable on an already-disabled account resumes the
-  idempotent cleanup (worst case: a locked-out account with residual data
-  until a retry or ops re-run completes).
+- Account deletion is job-tracked and resumable. A fresh request (recent
+  auth + rate limit) writes a durable `accountDeletionJobs/{uid}` marker
+  (Admin-only; clients denied by rules), then disables the account and
+  revokes refresh tokens, then runs the idempotent, page-bounded cleanup —
+  auth-user deletion last, `status: complete` after that. Resume requires
+  the marker: re-calling the callable continues the caller's own active job
+  (a **moderation-disabled account without a job is rejected and never
+  enters cleanup**), and after the user's ID token expires (≤1 h), ops
+  resumes with
+  `GOOGLE_CLOUD_PROJECT=<project> node scripts/resume-account-deletion.js <uid>`
+  — which refuses to run without an active job, so ops can't delete a
+  merely-disabled account either. Failures stay visible on the job doc
+  (`status: failed`, bounded `errorCode`, `lastStep`, `attemptCount`).
+  State machine unit tests: `npm run test:deletion`. Remaining live QA: one
+  end-to-end deletion against a dev project (no CF integration harness in
+  the repo).
 - The Session Details chat card shows the unread dot only for someone else's
   message arriving after your last visit to the chat, and clears when you
   come back from the chat.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -16,12 +16,19 @@ The notifications-center PR extends that into a persistent pipeline:
   key means enabled.
 - Events wired now: `dm_message`, `session_joined`, `session_updated`
   (material time/location edits only), `session_cancelled`,
-  `session_reminder`. `group_message`, `friend_request`, and
-  `friend_accepted` are reserved in the schema but not produced.
+  `session_reminder`, and `group_message` (session group chat —
+  `onSessionMessageCreated` notifies every participant except the sender and
+  stamps `lastMessageAt`/`lastMessageSenderId` onto the session doc for the
+  unread indicator; never message content, since session docs are readable by
+  all verified users). `friend_request` and `friend_accepted` are reserved in
+  the schema but not produced.
 - `/notifications` screen (protected) with unread badge on the Profile tab.
 
-Not implemented: App Check, RNFirebase messaging, group/friend notifications,
-client dismiss (no delete rule; records expire via TTL).
+Not implemented: App Check, RNFirebase messaging, friend notifications,
+client dismiss (no delete rule; records expire via TTL). Group-chat pushes are
+not block-filtered: two users who blocked each other can share a session
+(blocks only gate joining against the host), and the client hides their
+bubbles the same way it hides them in the attendee list.
 
 ## Payload validation & deep-link safety
 
@@ -34,9 +41,9 @@ allowlist. Invalid payloads are dropped — no record, no push.
 
 URL rules (server and client — the client mirror is
 `isAllowedNotificationUrl()` in `lib/notifications.ts`; change both
-together): exactly `/notifications`, `/conversation/{id}`, or
-`/session/{id}`, where `{id}` matches the safe-ID pattern and decodes to
-itself. Traversal (`.`/`..`), percent-encoded separators (`%2F`, `%5C`),
+together): exactly `/notifications`, `/conversation/{id}`, `/session/{id}`,
+or `/session-chat/{id}`, where `{id}` matches the safe-ID pattern and decodes
+to itself. Traversal (`.`/`..`), percent-encoded separators (`%2F`, `%5C`),
 malformed escapes, extra segments, query/hash suffixes, and external schemes
 all fail. Push taps additionally dedupe on the delivered notification's
 request identifier (module-level set surviving listener re-mounts), so one
@@ -64,6 +71,7 @@ by `npm run test:notifications`.
 | Session cancelled | `cancel_{eventId}` | participants except host; each real open→cancelled transition notifies |
 | Session updated | `update_{eventId}` | participants except host; every distinct material edit notifies, retries dedupe |
 | Session reminder | `reminder_{sessionId}_{uid}_{startTimeMillis}` | host + participants; one per recipient per session **start occurrence** — a reschedule reminds again |
+| Group message | `gm_{sessionId}_{eventId}` | participants except sender; session-scoped like the DM equivalent |
 
 ## Scheduled reminders
 
@@ -142,5 +150,22 @@ Pipeline + center (this PR):
   clears every unread row and survives pull-to-refresh; pagination loads
   older pages; empty and error states render.
 - Profile tab badge shows the unread count and clears after reading.
-- Deleting an account removes the user's notification records (covered by
-  the existing `recursiveDelete` on `users/{uid}`).
+- Deleting an account removes the user's notification records and chat read
+  markers (covered by the existing `recursiveDelete` on `users/{uid}`), the
+  full hosted-session trees including their chat messages, and every group
+  message the user sent elsewhere (collection-group query on `senderId` —
+  needs the `messages.senderId` `COLLECTION_GROUP` field override in
+  `firestore.indexes.json`, deployed with `firebase deploy --only
+  firestore:indexes`).
+
+Group chat (this PR):
+- A message from A creates a `group_message` record for every other
+  participant (never A) and pushes unless `groupMessages` is toggled off;
+  tap opens `/session-chat/{id}`.
+- The Session Details chat card shows the unread dot only for someone else's
+  message arriving after your last visit to the chat, and clears when you
+  come back from the chat.
+- Joining a session lands you in its chat; sends appear instantly, a failed
+  send shows "Not sent · Tap to retry", and retrying never duplicates.
+- Scrolling up pages older messages 30 at a time; messages from blocked
+  users stay hidden.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -199,10 +199,14 @@ Group chat (this PR):
   (a **moderation-disabled account without a job is rejected and never
   enters cleanup**), and after the user's ID token expires (≤1 h), ops
   resumes with
-  `GOOGLE_CLOUD_PROJECT=<project> node scripts/resume-account-deletion.js <uid>`
-  — which refuses to run without an active job, so ops can't delete a
-  merely-disabled account either. Failures stay visible on the job doc
-  (`status: failed`, bounded `errorCode`, `lastStep`, `attemptCount`).
+  `GOOGLE_APPLICATION_CREDENTIALS=<service-account.json> node scripts/resume-account-deletion.js <uid>`
+  — the script strictly validates the uid before touching Firebase, pins the
+  Admin SDK to `studi-b02c3` (any other ambient/resolved project aborts),
+  and refuses to run unless a well-formed active job naming that exact uid
+  exists — so ops can't delete a merely-disabled account either. Every
+  lifecycle phase (lock, running-write, each step, auth deletion, final
+  complete-write) persists failures to the job doc (`status: failed`,
+  bounded `errorCode`, failing phase in `lastStep`, `attemptCount`).
   State machine unit tests: `npm run test:deletion`. Remaining live QA: one
   end-to-end deletion against a dev project (no CF integration harness in
   the repo).

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -57,5 +57,28 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "messages",
+      "fieldPath": "senderId",
+      "indexes": [
+        {
+          "queryScope": "COLLECTION",
+          "order": "ASCENDING"
+        },
+        {
+          "queryScope": "COLLECTION",
+          "order": "DESCENDING"
+        },
+        {
+          "queryScope": "COLLECTION",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "queryScope": "COLLECTION_GROUP",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ]
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -178,14 +178,29 @@ service cloud.firestore {
 
       // Chat read markers (PR: group chat) — one tiny owner-only doc per
       // thread recording when the owner last opened it; unread is derived as
-      // session.lastMessageAt > lastReadAt. threadId is a sessionId today;
-      // DM threads can adopt the same shape later. Pinned to the server clock
-      // so a forged future marker can't hide messages that haven't arrived.
+      // session.lastMessageAt > lastReadAt. threadId must name a real thread
+      // the owner belongs to — a session or a DM conversation — so nobody can
+      // pile up junk marker docs. Pinned to the server clock so a forged
+      // future marker can't hide messages that haven't arrived. Costs at most
+      // two extra document reads per marker write.
       match /reads/{threadId} {
+        function isOwnSessionThread() {
+          return exists(/databases/$(database)/documents/sessions/$(threadId))
+            && request.auth.uid in
+               get(/databases/$(database)/documents/sessions/$(threadId)).data.participantIds;
+        }
+
+        function isOwnConversationThread() {
+          return exists(/databases/$(database)/documents/conversations/$(threadId))
+            && request.auth.uid in
+               get(/databases/$(database)/documents/conversations/$(threadId)).data.participantIds;
+        }
+
         allow read: if isOwner(userId);
         allow create, update: if isOwner(userId)
           && incoming().keys().hasOnly(['lastReadAt'])
-          && incoming().lastReadAt == request.time;
+          && incoming().lastReadAt == request.time
+          && (isOwnSessionThread() || isOwnConversationThread());
         allow delete: if false; // account deletion recursive-deletes the user tree
       }
     }
@@ -316,8 +331,10 @@ service cloud.firestore {
       // lastMessageAt/lastMessageSenderId unread metadata on the session doc
       // is written only by the Cloud Function (Admin SDK bypasses rules);
       // no client update branch exists for it. Leaving the session ends
-      // access; blocked pairs sharing a session are filtered client-side
-      // (same policy as the attendee list).
+      // access. A cancelled session is read-only: retained participants keep
+      // the history, nobody sends. Messages are fully immutable from the
+      // client — no edits, no deletes; account deletion cleans them up
+      // server-side (Admin SDK bypasses rules).
       match /messages/{messageId} {
         function parentSession() {
           return get(/databases/$(database)/documents/sessions/$(sessionId)).data;
@@ -327,6 +344,7 @@ service cloud.firestore {
           && request.auth.uid in parentSession().participantIds;
         allow create: if isVerifiedUwUser()
           && request.auth.uid == incoming().senderId
+          && parentSession().status in ['open', 'full']
           && request.auth.uid in parentSession().participantIds
           && incoming().keys().hasOnly(['senderId', 'text', 'createdAt'])
           && incoming().text is string
@@ -335,7 +353,7 @@ service cloud.firestore {
           && incoming().createdAt == request.time
           && hasFreshRateLimit(request.auth.uid, 'sendMessage');
         allow update: if false;
-        allow delete: if isVerifiedUwUser() && request.auth.uid == resource.data.senderId;
+        allow delete: if false;
       }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -175,6 +175,19 @@ service cloud.firestore {
           && incoming().readAt == request.time;
         allow delete: if false;
       }
+
+      // Chat read markers (PR: group chat) — one tiny owner-only doc per
+      // thread recording when the owner last opened it; unread is derived as
+      // session.lastMessageAt > lastReadAt. threadId is a sessionId today;
+      // DM threads can adopt the same shape later. Pinned to the server clock
+      // so a forged future marker can't hide messages that haven't arrived.
+      match /reads/{threadId} {
+        allow read: if isOwner(userId);
+        allow create, update: if isOwner(userId)
+          && incoming().keys().hasOnly(['lastReadAt'])
+          && incoming().lastReadAt == request.time;
+        allow delete: if false; // account deletion recursive-deletes the user tree
+      }
     }
 
     // ------------------------------------------------------------------
@@ -297,6 +310,33 @@ service cloud.firestore {
       allow update: if isVerifiedUwUser()
         && (isHostEdit() || isSelfJoin() || isSelfJoinNoOp() || isSelfLeave());
       allow delete: if isVerifiedUwUser() && request.auth.uid == resource.data.hostId;
+
+      // Session group chat (PR: group chat) — participant-gated via the
+      // parent session doc, message shape identical to DM messages. The
+      // lastMessageAt/lastMessageSenderId unread metadata on the session doc
+      // is written only by the Cloud Function (Admin SDK bypasses rules);
+      // no client update branch exists for it. Leaving the session ends
+      // access; blocked pairs sharing a session are filtered client-side
+      // (same policy as the attendee list).
+      match /messages/{messageId} {
+        function parentSession() {
+          return get(/databases/$(database)/documents/sessions/$(sessionId)).data;
+        }
+
+        allow read: if isVerifiedUwUser()
+          && request.auth.uid in parentSession().participantIds;
+        allow create: if isVerifiedUwUser()
+          && request.auth.uid == incoming().senderId
+          && request.auth.uid in parentSession().participantIds
+          && incoming().keys().hasOnly(['senderId', 'text', 'createdAt'])
+          && incoming().text is string
+          && incoming().text.size() >= 1
+          && incoming().text.size() <= 2000
+          && incoming().createdAt == request.time
+          && hasFreshRateLimit(request.auth.uid, 'sendMessage');
+        allow update: if false;
+        allow delete: if isVerifiedUwUser() && request.auth.uid == resource.data.senderId;
+      }
     }
 
     // ------------------------------------------------------------------

--- a/firestore.rules
+++ b/firestore.rules
@@ -332,9 +332,13 @@ service cloud.firestore {
       // is written only by the Cloud Function (Admin SDK bypasses rules);
       // no client update branch exists for it. Leaving the session ends
       // access. A cancelled session is read-only: retained participants keep
-      // the history, nobody sends. Messages are fully immutable from the
-      // client — no edits, no deletes; account deletion cleans them up
-      // server-side (Admin SDK bypasses rules).
+      // the history, nobody sends. Sends are also denied when the session
+      // holds more than 20 people — the group-chat fanout ceiling, judged on
+      // the ACTUAL participant count so legacy uncapped sessions can't force
+      // unbounded notification fanout (mirrors MAX_GROUP_CHAT_PARTICIPANTS
+      // in functions/notification-validation.js and lib/firestore.ts; change
+      // all three together). Messages are fully immutable from the client —
+      // no edits, no deletes; account deletion cleans them up server-side.
       match /messages/{messageId} {
         function parentSession() {
           return get(/databases/$(database)/documents/sessions/$(sessionId)).data;
@@ -346,6 +350,7 @@ service cloud.firestore {
           && request.auth.uid == incoming().senderId
           && parentSession().status in ['open', 'full']
           && request.auth.uid in parentSession().participantIds
+          && parentSession().participantIds.size() <= 20
           && incoming().keys().hasOnly(['senderId', 'text', 'createdAt'])
           && incoming().text is string
           && incoming().text.size() >= 1
@@ -484,6 +489,18 @@ service cloud.firestore {
         && incoming().createdAt == resource.data.createdAt
         && hasFreshRateLimit(request.auth.uid, 'locationRating');
       allow delete: if isVerifiedUwUser() && resource.data.userId == request.auth.uid;
+    }
+
+    // ------------------------------------------------------------------
+    // Account-deletion job markers — durable deletion intent + resumable
+    // progress, written ONLY by the Admin SDK (deleteUserAccount callable
+    // and scripts/resume-account-deletion.js). The default deny would
+    // already cover this; the explicit match documents the invariant and
+    // the tests pin it.
+    // ------------------------------------------------------------------
+
+    match /accountDeletionJobs/{uid} {
+      allow read, write: if false;
     }
 
     // ------------------------------------------------------------------

--- a/functions/account-deletion.js
+++ b/functions/account-deletion.js
@@ -1,0 +1,242 @@
+// functions/account-deletion.js — durable, resumable account-deletion state
+// machine. Dependency-free: the runner receives its Firebase handles via
+// injection, so the deleteUserAccount callable (functions/index.js), the ops
+// resume script (scripts/resume-account-deletion.js), and the unit tests
+// (tests/account-deletion.test.mjs) all drive the exact same code.
+//
+// Job docs live at accountDeletionJobs/{uid} — Admin SDK only, rules deny all
+// client access:
+//   userId, status: pending | running | complete | failed,
+//   requestedAt, createdAt, updatedAt, lastStep, attemptCount, errorCode?
+//
+// The job marker records deletion INTENT. An account that is merely disabled
+// (moderation/abuse) has no job and must never enter cleanup — deletion is
+// resumed only from an explicit, Admin-written marker.
+
+const DELETION_JOB_ACTIVE_STATUSES = ["pending", "running", "failed"];
+const DELETE_CLEANUP_PAGE_SIZE = 100;
+
+function isResumableJob(job) {
+  return !!job && DELETION_JOB_ACTIVE_STATUSES.includes(job.status);
+}
+
+/**
+ * How a deletion request must be treated:
+ *   fresh                  — enabled account, no job: full auth gates, then begin
+ *   resume                 — caller's own active job: continue the cleanup
+ *   reject-complete        — job finished; nothing may rerun destructively
+ *   reject-not-owner       — job belongs to a different user
+ *   reject-disabled-no-job — disabled without deletion intent (moderation):
+ *                            never enter cleanup
+ */
+function classifyDeletionRequest({ callerUid, job, authDisabled }) {
+  if (job && job.userId !== callerUid) {
+    return "reject-not-owner";
+  }
+  if (job && job.status === "complete") {
+    return "reject-complete";
+  }
+  if (isResumableJob(job)) {
+    return "resume";
+  }
+  if (authDisabled) {
+    return "reject-disabled-no-job";
+  }
+  return "fresh";
+}
+
+/** Non-sensitive, bounded error tag for the job doc (ops visibility only). */
+function boundedErrorCode(error) {
+  return String(error?.code ?? error?.name ?? "unknown").slice(0, 64);
+}
+
+/**
+ * deps: { db, auth, FieldValue } — Firestore Admin instance, admin.auth(),
+ * and admin.firestore.FieldValue (or fakes, in tests).
+ */
+function createAccountDeletionRunner({ db, auth, FieldValue }) {
+  const jobRef = (uid) => db.collection("accountDeletionJobs").doc(uid);
+
+  async function markJob(uid, fields) {
+    await jobRef(uid).set(
+      { userId: uid, updatedAt: FieldValue.serverTimestamp(), ...fields },
+      { merge: true }
+    );
+  }
+
+  async function getJob(uid) {
+    const snap = await jobRef(uid).get();
+    return snap.exists ? snap.data() : null;
+  }
+
+  // Disable + revoke is idempotent and tolerates an auth user that a prior
+  // attempt already deleted (the ops script can resume that state).
+  async function lockAccount(uid) {
+    try {
+      await auth.updateUser(uid, { disabled: true });
+      await auth.revokeRefreshTokens(uid);
+    } catch (error) {
+      if (error?.code !== "auth/user-not-found") {
+        throw error;
+      }
+    }
+  }
+
+  // Runs `handler` over fixed-size pages of `q` until the query is empty.
+  // Every handler MUST remove its docs from the query's own result set
+  // (delete the doc or mutate the queried field), so each pass strictly
+  // shrinks the remainder — that is what makes an interrupted run resume
+  // instead of loop.
+  async function drainQuery(q, handler) {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const snap = await q.limit(DELETE_CLEANUP_PAGE_SIZE).get();
+      if (snap.empty) return;
+      await handler(snap.docs);
+    }
+  }
+
+  async function deleteQueryBatch(q) {
+    await drainQuery(q, async (docs) => {
+      const batch = db.batch();
+      docs.forEach((d) => batch.delete(d.ref));
+      await batch.commit();
+    });
+  }
+
+  // Ordered, idempotent cleanup steps. Reports are intentionally retained
+  // (moderation evidence); rate-limit docs are inert leftovers.
+  function cleanupSteps(uid) {
+    return [
+      {
+        // Hosted sessions go recursively — a flat batch delete would orphan
+        // the group-chat messages subcollection.
+        name: "hosted-sessions",
+        run: () =>
+          drainQuery(db.collection("sessions").where("hostId", "==", uid), async (docs) => {
+            for (const docSnap of docs) {
+              await db.recursiveDelete(docSnap.ref);
+            }
+          }),
+      },
+      {
+        // arrayRemove is idempotent and takes the doc out of this query.
+        name: "joined-sessions",
+        run: () =>
+          drainQuery(
+            db.collection("sessions").where("participantIds", "array-contains", uid),
+            async (docs) => {
+              const batch = db.batch();
+              docs.forEach((docSnap) =>
+                batch.update(docSnap.ref, {
+                  participantIds: FieldValue.arrayRemove(uid),
+                  updatedAt: FieldValue.serverTimestamp(),
+                })
+              );
+              await batch.commit();
+            }
+          ),
+      },
+      {
+        // The counterpart loses the thread too — acceptable for a 1:1 DM
+        // model and required to avoid orphaned PII.
+        name: "conversations",
+        run: () =>
+          drainQuery(
+            db.collection("conversations").where("participantIds", "array-contains", uid),
+            async (docs) => {
+              for (const convo of docs) {
+                await db.recursiveDelete(convo.ref);
+              }
+            }
+          ),
+      },
+      {
+        // Group-chat messages sent in sessions the user didn't host —
+        // collection-group lookup on senderId (COLLECTION_GROUP index in
+        // firestore.indexes.json fieldOverrides).
+        name: "sent-messages",
+        run: () => deleteQueryBatch(db.collectionGroup("messages").where("senderId", "==", uid)),
+      },
+      {
+        name: "user-blocks",
+        run: async () => {
+          await deleteQueryBatch(db.collection("userBlocks").where("blockerUserId", "==", uid));
+          await deleteQueryBatch(db.collection("userBlocks").where("blockedUserId", "==", uid));
+        },
+      },
+      {
+        // The aggregate trigger decrements location counts per delete.
+        name: "location-ratings",
+        run: () => deleteQueryBatch(db.collection("locationRatings").where("userId", "==", uid)),
+      },
+      {
+        // Public doc + private, notifications, and reads subcollections.
+        name: "user-tree",
+        run: () => db.recursiveDelete(db.collection("users").doc(uid)),
+      },
+    ];
+  }
+
+  /**
+   * First step of a fresh deletion: record intent, then lock the account.
+   * The marker is written BEFORE anything is disabled or destroyed, so every
+   * later state is attributable to an explicit user request.
+   */
+  async function beginDeletion(uid) {
+    await markJob(uid, {
+      status: "pending",
+      requestedAt: FieldValue.serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
+      attemptCount: 0,
+    });
+    await lockAccount(uid);
+  }
+
+  /**
+   * Run (or re-run) the cleanup. Safe to call repeatedly: the account is
+   * re-locked first, every step is idempotent, the Auth user is deleted only
+   * after all data cleanup finished, and `complete` is written only after
+   * that — so an interrupted run always leaves a resumable job behind.
+   * `lastStep` is durable diagnostics, not a skip cursor: a resume re-runs
+   * every step (each is a no-op on already-clean data) rather than trusting
+   * a pointer that could hide a partially-failed page.
+   */
+  async function runCleanup(uid) {
+    await lockAccount(uid);
+    await markJob(uid, { status: "running", attemptCount: FieldValue.increment(1) });
+
+    try {
+      for (const step of cleanupSteps(uid)) {
+        await step.run();
+        await markJob(uid, { lastStep: step.name });
+      }
+
+      try {
+        await auth.deleteUser(uid);
+      } catch (error) {
+        if (error?.code !== "auth/user-not-found") {
+          throw error; // anything else is a real failure
+        }
+        // Already gone from a prior attempt — idempotent.
+      }
+
+      await markJob(uid, { status: "complete" });
+    } catch (error) {
+      // Keep the failure durably visible for ops; the job stays resumable.
+      await markJob(uid, { status: "failed", errorCode: boundedErrorCode(error) }).catch(() => {});
+      throw error;
+    }
+  }
+
+  return { beginDeletion, getJob, runCleanup };
+}
+
+module.exports = {
+  DELETE_CLEANUP_PAGE_SIZE,
+  DELETION_JOB_ACTIVE_STATUSES,
+  boundedErrorCode,
+  classifyDeletionRequest,
+  createAccountDeletionRunner,
+  isResumableJob,
+};

--- a/functions/account-deletion.js
+++ b/functions/account-deletion.js
@@ -16,8 +16,59 @@
 const DELETION_JOB_ACTIVE_STATUSES = ["pending", "running", "failed"];
 const DELETE_CLEANUP_PAGE_SIZE = 100;
 
+// The only project the ops resume script may ever touch. Matches .firebaserc
+// and firebaseConfig.ts.
+const DELETION_PROJECT_ID = "studi-b02c3";
+
+// Firebase Auth uids are ≤128 chars; the charset matches the backend-wide
+// safe-ID pattern (notification-validation.js). Rejects empty, padded,
+// path-like, dotted, and percent-encoded values outright.
+const SAFE_UID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+function isValidDeletionUid(value) {
+  return typeof value === "string" && SAFE_UID_PATTERN.test(value);
+}
+
+/**
+ * Preflight for the ops resume script — must pass BEFORE any Firebase
+ * initialization or reads. Returns { ok: true } or { ok: false, reason }.
+ */
+function validateResumeScriptArgs({ uid, projectId }) {
+  if (!isValidDeletionUid(uid)) {
+    return { ok: false, reason: "invalid-uid" };
+  }
+  if (projectId !== DELETION_PROJECT_ID) {
+    return { ok: false, reason: "wrong-project" };
+  }
+  return { ok: true };
+}
+
 function isResumableJob(job) {
   return !!job && DELETION_JOB_ACTIVE_STATUSES.includes(job.status);
+}
+
+/**
+ * Strict gate before runCleanup() may be driven from the ops path: the job
+ * doc must exist, be well-formed, belong to the target uid, and be in an
+ * active (non-complete) state. Returns { ok: true } or { ok: false, reason }.
+ */
+function validateResumableJob(job, uid) {
+  if (!job || typeof job !== "object") {
+    return { ok: false, reason: "missing-job" };
+  }
+  if (typeof job.userId !== "string" || typeof job.status !== "string") {
+    return { ok: false, reason: "malformed-job" };
+  }
+  if (job.userId !== uid) {
+    return { ok: false, reason: "user-mismatch" };
+  }
+  if (job.status === "complete") {
+    return { ok: false, reason: "already-complete" };
+  }
+  if (!DELETION_JOB_ACTIVE_STATUSES.includes(job.status)) {
+    return { ok: false, reason: "unknown-status" };
+  }
+  return { ok: true };
 }
 
 /**
@@ -179,18 +230,50 @@ function createAccountDeletionRunner({ db, auth, FieldValue }) {
   }
 
   /**
+   * Best-effort durable failure record. `lastStep` names the PHASE that was
+   * executing when the failure hit (per-step writes already recorded the
+   * last completed step up to that point). A failure while writing the
+   * failure state itself is logged loudly but never masks the original
+   * error — the caller always rethrows what actually broke.
+   */
+  async function persistFailure(uid, phase, originalError) {
+    try {
+      await markJob(uid, {
+        status: "failed",
+        lastStep: phase,
+        errorCode: boundedErrorCode(originalError),
+      });
+    } catch (writeError) {
+      console.error(
+        `Account-deletion failure state could not be persisted (uid: ${uid}, phase: ${phase});` +
+          " original error follows the rethrow",
+        writeError
+      );
+    }
+  }
+
+  /**
    * First step of a fresh deletion: record intent, then lock the account.
    * The marker is written BEFORE anything is disabled or destroyed, so every
-   * later state is attributable to an explicit user request.
+   * later state is attributable to an explicit user request. Both phases run
+   * inside the protected lifecycle — a lock failure lands on the job doc as
+   * status: failed instead of vanishing.
    */
   async function beginDeletion(uid) {
-    await markJob(uid, {
-      status: "pending",
-      requestedAt: FieldValue.serverTimestamp(),
-      createdAt: FieldValue.serverTimestamp(),
-      attemptCount: 0,
-    });
-    await lockAccount(uid);
+    let phase = "record-intent";
+    try {
+      await markJob(uid, {
+        status: "pending",
+        requestedAt: FieldValue.serverTimestamp(),
+        createdAt: FieldValue.serverTimestamp(),
+        attemptCount: 0,
+      });
+      phase = "lock-account";
+      await lockAccount(uid);
+    } catch (error) {
+      await persistFailure(uid, phase, error);
+      throw error;
+    }
   }
 
   /**
@@ -198,20 +281,29 @@ function createAccountDeletionRunner({ db, auth, FieldValue }) {
    * re-locked first, every step is idempotent, the Auth user is deleted only
    * after all data cleanup finished, and `complete` is written only after
    * that — so an interrupted run always leaves a resumable job behind.
-   * `lastStep` is durable diagnostics, not a skip cursor: a resume re-runs
-   * every step (each is a no-op on already-clean data) rather than trusting
-   * a pointer that could hide a partially-failed page.
+   * The ENTIRE lifecycle (lock, running-write, steps, auth deletion,
+   * complete-write) is failure-protected: whatever phase breaks is persisted
+   * as status: failed with that phase in lastStep. Per-step lastStep writes
+   * are durable diagnostics, not a skip cursor: a resume re-runs every step
+   * (each is a no-op on already-clean data) rather than trusting a pointer
+   * that could hide a partially-failed page. attemptCount increments only
+   * when a run reaches `running` — a pre-lock failure preserves it.
    */
   async function runCleanup(uid) {
-    await lockAccount(uid);
-    await markJob(uid, { status: "running", attemptCount: FieldValue.increment(1) });
-
+    let phase = "lock-account";
     try {
+      await lockAccount(uid);
+
+      phase = "mark-running";
+      await markJob(uid, { status: "running", attemptCount: FieldValue.increment(1) });
+
       for (const step of cleanupSteps(uid)) {
+        phase = step.name;
         await step.run();
         await markJob(uid, { lastStep: step.name });
       }
 
+      phase = "delete-auth-user";
       try {
         await auth.deleteUser(uid);
       } catch (error) {
@@ -221,10 +313,11 @@ function createAccountDeletionRunner({ db, auth, FieldValue }) {
         // Already gone from a prior attempt — idempotent.
       }
 
+      phase = "mark-complete";
       await markJob(uid, { status: "complete" });
     } catch (error) {
       // Keep the failure durably visible for ops; the job stays resumable.
-      await markJob(uid, { status: "failed", errorCode: boundedErrorCode(error) }).catch(() => {});
+      await persistFailure(uid, phase, error);
       throw error;
     }
   }
@@ -235,8 +328,12 @@ function createAccountDeletionRunner({ db, auth, FieldValue }) {
 module.exports = {
   DELETE_CLEANUP_PAGE_SIZE,
   DELETION_JOB_ACTIVE_STATUSES,
+  DELETION_PROJECT_ID,
   boundedErrorCode,
   classifyDeletionRequest,
   createAccountDeletionRunner,
   isResumableJob,
+  isValidDeletionUid,
+  validateResumableJob,
+  validateResumeScriptArgs,
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -14,6 +14,7 @@ const crypto = require("crypto");
 const { Expo } = require("expo-server-sdk");
 const {
   dmNotificationId,
+  groupMessageNotificationId,
   normalizeNotificationPayload,
   reminderNotificationId,
   sessionEventNotificationId,
@@ -406,6 +407,74 @@ exports.onDirectMessageCreated = onDocumentCreated(
   }
 );
 
+exports.onSessionMessageCreated = onDocumentCreated(
+  "sessions/{sessionId}/messages/{messageId}",
+  async (event) => {
+    const message = event.data?.data();
+    const senderId = message?.senderId;
+    const text = normalizePreview(message?.text);
+    const sessionId = event.params.sessionId;
+
+    if (!senderId || !sessionId || !text) {
+      return;
+    }
+
+    const sessionSnap = await db.collection("sessions").doc(sessionId).get();
+    if (!sessionSnap.exists) {
+      return;
+    }
+    const session = sessionSnap.data();
+
+    // Unread metadata for the session-details indicator: arrival time and
+    // sender only, never content — the session doc is readable by every
+    // verified user, so a text preview here would leak participant-only
+    // messages. The write re-fires onSessionParticipantsUpdated, which
+    // no-ops (no participant/status/time/location delta).
+    try {
+      await sessionSnap.ref.update({
+        lastMessageAt:
+          message.createdAt ?? admin.firestore.FieldValue.serverTimestamp(),
+        lastMessageSenderId: senderId,
+      });
+    } catch (error) {
+      console.warn("Session chat metadata update failed", error);
+    }
+
+    const participantIds = Array.isArray(session?.participantIds)
+      ? session.participantIds.filter((id) => typeof id === "string")
+      : [];
+    const recipients = participantIds.filter((uid) => uid !== senderId);
+
+    if (recipients.length === 0) {
+      return;
+    }
+
+    // Display name comes from the sender's profile doc (server truth), never
+    // from anything client-supplied on the message.
+    const senderName = (await getDisplayName(senderId)) || "Someone";
+    const title =
+      typeof session?.title === "string" && session.title.trim()
+        ? session.title.trim()
+        : "Session chat";
+
+    await Promise.all(
+      recipients.map((uid) =>
+        notifyUser(uid, {
+          // CloudEvent ID: retries of one message event dedupe, every new
+          // message notifies again. Session-scoped like the DM equivalent.
+          id: groupMessageNotificationId(sessionId, event.id),
+          type: "group_message",
+          title,
+          body: `${senderName}: ${text}`,
+          url: `/session-chat/${sessionId}`,
+          actorId: senderId,
+          sessionId,
+        })
+      )
+    );
+  }
+);
+
 // Historical export name (originally join-only); renaming a deployed function
 // forces a delete/create cycle, so the name stays while the trigger now covers
 // joins, cancellation, and material time/location edits.
@@ -643,8 +712,12 @@ exports.deleteUserAccount = onCall(async (request) => {
 
   await enforceDeleteAccountRateLimit(uid);
 
-  // 1. Sessions hosted by the user: delete outright.
-  await deleteQueryBatch(db.collection("sessions").where("hostId", "==", uid));
+  // 1. Sessions hosted by the user: delete outright, including the group-chat
+  //    messages subcollection — a flat batch delete would orphan it.
+  const hosted = await db.collection("sessions").where("hostId", "==", uid).get();
+  for (const docSnap of hosted.docs) {
+    await db.recursiveDelete(docSnap.ref);
+  }
 
   // 2. Sessions joined: remove from participant arrays.
   const joined = await db
@@ -669,6 +742,12 @@ exports.deleteUserAccount = onCall(async (request) => {
     await db.recursiveDelete(convo.ref);
   }
 
+  // 3b. Group-chat messages the user sent in sessions they didn't host —
+  //     collection-group lookup on senderId (COLLECTION_GROUP index in
+  //     firestore.indexes.json fieldOverrides). Messages under the user's own
+  //     hosted sessions and DM conversations are already gone (steps 1 and 3).
+  await deleteQueryBatch(db.collectionGroup("messages").where("senderId", "==", uid));
+
   // 4. Blocks in either direction.
   await deleteQueryBatch(db.collection("userBlocks").where("blockerUserId", "==", uid));
   await deleteQueryBatch(db.collection("userBlocks").where("blockedUserId", "==", uid));
@@ -676,9 +755,9 @@ exports.deleteUserAccount = onCall(async (request) => {
   // 5. Location ratings (the aggregate trigger above decrements counts).
   await deleteQueryBatch(db.collection("locationRatings").where("userId", "==", uid));
 
-  // 6. Profile (public doc + private and notifications subcollections — the
-  //    notification records double as reminder/dedupe state, so nothing else
-  //    to clean), then the Auth user.
+  // 6. Profile (public doc + private, notifications, and reads subcollections
+  //    — the notification records double as reminder/dedupe state, so nothing
+  //    else to clean), then the Auth user.
   await db.recursiveDelete(db.collection("users").doc(uid));
   await admin.auth().deleteUser(uid);
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -17,10 +17,15 @@ const {
   dmNotificationId,
   filterBlockedRecipients,
   groupMessageNotificationId,
+  isWithinGroupChatFanoutLimit,
   normalizeNotificationPayload,
   reminderNotificationId,
   sessionEventNotificationId,
 } = require("./notification-validation");
+const {
+  classifyDeletionRequest,
+  createAccountDeletionRunner,
+} = require("./account-deletion");
 
 admin.initializeApp();
 setGlobalOptions({ region: "us-central1", maxInstances: 5 });
@@ -427,6 +432,19 @@ exports.onSessionMessageCreated = onDocumentCreated(
     }
     const session = sessionSnap.data();
 
+    const participantIds = Array.isArray(session?.participantIds)
+      ? session.participantIds.filter((id) => typeof id === "string")
+      : [];
+
+    // Fanout ceiling (shared with firestore.rules and the client): oversized
+    // legacy sessions get no metadata bump and no notifications. The rules
+    // deny new sends there, so this only fires on a race or an Admin write —
+    // and silently notifying a subset would be worse than notifying nobody.
+    // This also structurally bounds the block lookups below at ≤38 reads.
+    if (!isWithinGroupChatFanoutLimit(participantIds.length)) {
+      return;
+    }
+
     // Unread metadata for the session-details indicator: arrival time and
     // sender only, never content — the session doc is readable by every
     // verified user, so a text preview here would leak participant-only
@@ -442,9 +460,6 @@ exports.onSessionMessageCreated = onDocumentCreated(
       console.warn("Session chat metadata update failed", error);
     }
 
-    const participantIds = Array.isArray(session?.participantIds)
-      ? session.participantIds.filter((id) => typeof id === "string")
-      : [];
     const candidates = participantIds.filter((uid) => uid !== senderId);
 
     if (candidates.length === 0) {
@@ -455,9 +470,10 @@ exports.onSessionMessageCreated = onDocumentCreated(
     // neither the record nor the push — client bubble-hiding is a courtesy,
     // not the enforcement. One batched getAll over both block-doc directions
     // per recipient: 2 document reads per recipient per message, bounded by
-    // session capacity (≤20 participants → ≤38 lookups in a single RPC).
-    // A lookup failure throws so Eventarc retries the whole event; the
-    // idempotent record IDs make that retry safe.
+    // the fanout ceiling above (20 participants incl. sender → 19 recipients
+    // → at most 38 lookups in a single RPC). A lookup failure throws so
+    // Eventarc retries the whole event; the idempotent record IDs make that
+    // retry safe.
     const blockRefs = candidates.flatMap((uid) =>
       blockPairIdsFor(senderId, uid).map((id) => db.collection("userBlocks").doc(id))
     );
@@ -679,38 +695,20 @@ exports.sendSessionReminders = onSchedule("every 10 minutes", async () => {
 // so client-side cleanup write-paths no longer exist in the rules at all.
 // Reports are intentionally retained (moderation evidence).
 //
-// Bounded + resumable: the account is disabled (and refresh tokens revoked)
-// BEFORE any data is touched, every cleanup step drains a query in fixed-size
-// pages whose handler removes the docs from the query's own result set, and
-// re-invoking the callable on an already-disabled account skips the
-// freshness/rate-limit gates and resumes the idempotent cleanup where it
-// stopped. Worst case a run is cut off repeatedly: the user is locked out
-// (existing sessions die at ID-token expiry, ≤1 h) and residual data is
-// orphaned-but-inaccessible until a retry or ops re-run finishes the job.
+// The state machine and cleanup runner live in ./account-deletion.js. Deletion
+// intent is recorded as a durable accountDeletionJobs/{uid} marker BEFORE the
+// account is disabled or any data is touched; cleanup drains queries in
+// bounded pages and is idempotent, so it can resume — via this callable while
+// the user's ID token lives (≤1 h after the request), and via the ops script
+// scripts/resume-account-deletion.js after that. A disabled account WITHOUT a
+// job marker is a moderation action and never enters cleanup.
 // ---------------------------------------------------------------------------
 
-const DELETE_CLEANUP_PAGE_SIZE = 100;
-
-// Runs `handler` over fixed-size pages of `q` until the query is empty. Every
-// handler MUST remove its docs from the query's result set (delete the doc or
-// mutate the queried field) so each pass strictly shrinks the remainder — that
-// is what makes an interrupted run resume instead of loop.
-async function drainQuery(q, handler) {
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const snap = await q.limit(DELETE_CLEANUP_PAGE_SIZE).get();
-    if (snap.empty) return;
-    await handler(snap.docs);
-  }
-}
-
-async function deleteQueryBatch(q) {
-  await drainQuery(q, async (docs) => {
-    const batch = db.batch();
-    docs.forEach((d) => batch.delete(d.ref));
-    await batch.commit();
-  });
-}
+const accountDeletion = createAccountDeletionRunner({
+  db,
+  auth: admin.auth(),
+  FieldValue: admin.firestore.FieldValue,
+});
 
 async function enforceDeleteAccountRateLimit(uid) {
   const ref = db.collection("rateLimits").doc(uid).collection("actions").doc("deleteAccount");
@@ -746,18 +744,29 @@ exports.deleteUserAccount = onCall({ timeoutSeconds: 540 }, async (request) => {
   try {
     userRecord = await admin.auth().getUser(uid);
   } catch {
-    // Auth user already gone means a previous run completed everything
-    // (deleteUser is the final step below).
     throw new HttpsError("failed-precondition", "This account no longer exists.");
   }
 
-  // Resume path: a previous run disabled the account but was cut off before
-  // cleanup finished. The user cannot re-authenticate a disabled account, so
-  // the freshness and rate-limit gates are skipped — the destructive intent
-  // was already proven, and everything below is idempotent.
-  const isResume = userRecord.disabled === true;
+  const job = await accountDeletion.getJob(uid);
+  const decision = classifyDeletionRequest({
+    callerUid: uid,
+    job,
+    authDisabled: userRecord.disabled === true,
+  });
 
-  if (!isResume) {
+  if (decision === "reject-disabled-no-job") {
+    // Disabled without a deletion job = moderation action, not a deletion in
+    // progress. Cleanup must never start from here.
+    throw new HttpsError("permission-denied", "This account is disabled. Contact support.");
+  }
+  if (decision === "reject-complete") {
+    throw new HttpsError("failed-precondition", "This account has already been deleted.");
+  }
+  if (decision === "reject-not-owner") {
+    throw new HttpsError("permission-denied", "You can only delete your own account.");
+  }
+
+  if (decision === "fresh") {
     if (
       typeof authTime !== "number" ||
       Date.now() / 1000 - authTime > DELETE_ACCOUNT_MAX_AUTH_AGE_SECONDS
@@ -770,69 +779,25 @@ exports.deleteUserAccount = onCall({ timeoutSeconds: 540 }, async (request) => {
 
     await enforceDeleteAccountRateLimit(uid);
 
-    // Lock the account BEFORE touching any data: even if this run is cut off
-    // mid-cleanup, no new sign-in is possible and revoked refresh tokens cap
-    // existing sessions at ID-token expiry (≤1 h). The still-valid ID token
-    // lets the client retry this callable to resume.
-    await admin.auth().updateUser(uid, { disabled: true });
-    await admin.auth().revokeRefreshTokens(uid);
+    // Durable job marker first (deletion intent on record), then disable +
+    // revoke refresh tokens. From here the flow is resumable: by this
+    // callable while the user's ID token lives, then by the ops script.
+    await accountDeletion.beginDeletion(uid);
   }
+  // decision === "resume": the caller's own active job exists — the
+  // freshness/rate-limit gates are skipped (a disabled account cannot
+  // re-authenticate; intent is proven by the marker) and the idempotent
+  // cleanup simply continues.
 
-  // 1. Sessions hosted by the user: delete outright, including the group-chat
-  //    messages subcollection — a flat batch delete would orphan it.
-  await drainQuery(db.collection("sessions").where("hostId", "==", uid), async (docs) => {
-    for (const docSnap of docs) {
-      await db.recursiveDelete(docSnap.ref);
-    }
-  });
-
-  // 2. Sessions joined: remove from participant arrays (arrayRemove is
-  //    idempotent and takes the doc out of this query's results).
-  await drainQuery(
-    db.collection("sessions").where("participantIds", "array-contains", uid),
-    async (docs) => {
-      const batch = db.batch();
-      docs.forEach((docSnap) =>
-        batch.update(docSnap.ref, {
-          participantIds: admin.firestore.FieldValue.arrayRemove(uid),
-          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        })
-      );
-      await batch.commit();
-    }
-  );
-
-  // 3. Conversations: delete the thread and its messages (the counterpart
-  //    loses the thread too — acceptable for a 1:1 DM model and required to
-  //    avoid orphaned PII; messages contain the deleted user's words).
-  await drainQuery(
-    db.collection("conversations").where("participantIds", "array-contains", uid),
-    async (docs) => {
-      for (const convo of docs) {
-        await db.recursiveDelete(convo.ref);
-      }
-    }
-  );
-
-  // 3b. Group-chat messages the user sent in sessions they didn't host —
-  //     collection-group lookup on senderId (COLLECTION_GROUP index in
-  //     firestore.indexes.json fieldOverrides). Messages under the user's own
-  //     hosted sessions and DM conversations are already gone (steps 1 and 3).
-  await deleteQueryBatch(db.collectionGroup("messages").where("senderId", "==", uid));
-
-  // 4. Blocks in either direction.
-  await deleteQueryBatch(db.collection("userBlocks").where("blockerUserId", "==", uid));
-  await deleteQueryBatch(db.collection("userBlocks").where("blockedUserId", "==", uid));
-
-  // 5. Location ratings (the aggregate trigger above decrements counts).
-  await deleteQueryBatch(db.collection("locationRatings").where("userId", "==", uid));
-
-  // 6. Profile (public doc + private, notifications, and reads subcollections
-  //    — the notification records double as reminder/dedupe state, so nothing
-  //    else to clean), then the Auth user — last, so a lost run can always
-  //    resume through the disabled-account path above.
-  await db.recursiveDelete(db.collection("users").doc(uid));
-  await admin.auth().deleteUser(uid);
+  try {
+    await accountDeletion.runCleanup(uid);
+  } catch (error) {
+    console.warn("Account deletion cleanup failed", error);
+    throw new HttpsError(
+      "internal",
+      "Account deletion did not finish. Try again to resume."
+    );
+  }
 
   return { status: "deleted" };
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,7 +13,9 @@ const admin = require("firebase-admin");
 const crypto = require("crypto");
 const { Expo } = require("expo-server-sdk");
 const {
+  blockPairIdsFor,
   dmNotificationId,
+  filterBlockedRecipients,
   groupMessageNotificationId,
   normalizeNotificationPayload,
   reminderNotificationId,
@@ -443,7 +445,27 @@ exports.onSessionMessageCreated = onDocumentCreated(
     const participantIds = Array.isArray(session?.participantIds)
       ? session.participantIds.filter((id) => typeof id === "string")
       : [];
-    const recipients = participantIds.filter((uid) => uid !== senderId);
+    const candidates = participantIds.filter((uid) => uid !== senderId);
+
+    if (candidates.length === 0) {
+      return;
+    }
+
+    // Server-side block filtering: a blocked pair (either direction) gets
+    // neither the record nor the push — client bubble-hiding is a courtesy,
+    // not the enforcement. One batched getAll over both block-doc directions
+    // per recipient: 2 document reads per recipient per message, bounded by
+    // session capacity (≤20 participants → ≤38 lookups in a single RPC).
+    // A lookup failure throws so Eventarc retries the whole event; the
+    // idempotent record IDs make that retry safe.
+    const blockRefs = candidates.flatMap((uid) =>
+      blockPairIdsFor(senderId, uid).map((id) => db.collection("userBlocks").doc(id))
+    );
+    const blockSnaps = await db.getAll(...blockRefs);
+    const existingBlockIds = new Set(
+      blockSnaps.filter((snap) => snap.exists).map((snap) => snap.id)
+    );
+    const recipients = filterBlockedRecipients(senderId, candidates, existingBlockIds);
 
     if (recipients.length === 0) {
       return;
@@ -656,18 +678,38 @@ exports.sendSessionReminders = onSchedule("every 10 minutes", async () => {
 // Account deletion (D8): single authoritative path. Admin SDK bypasses rules,
 // so client-side cleanup write-paths no longer exist in the rules at all.
 // Reports are intentionally retained (moderation evidence).
+//
+// Bounded + resumable: the account is disabled (and refresh tokens revoked)
+// BEFORE any data is touched, every cleanup step drains a query in fixed-size
+// pages whose handler removes the docs from the query's own result set, and
+// re-invoking the callable on an already-disabled account skips the
+// freshness/rate-limit gates and resumes the idempotent cleanup where it
+// stopped. Worst case a run is cut off repeatedly: the user is locked out
+// (existing sessions die at ID-token expiry, ≤1 h) and residual data is
+// orphaned-but-inaccessible until a retry or ops re-run finishes the job.
 // ---------------------------------------------------------------------------
 
-async function deleteQueryBatch(q) {
-  // Deletes in pages to stay under batch limits.
+const DELETE_CLEANUP_PAGE_SIZE = 100;
+
+// Runs `handler` over fixed-size pages of `q` until the query is empty. Every
+// handler MUST remove its docs from the query's result set (delete the doc or
+// mutate the queried field) so each pass strictly shrinks the remainder — that
+// is what makes an interrupted run resume instead of loop.
+async function drainQuery(q, handler) {
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const snap = await q.limit(200).get();
+    const snap = await q.limit(DELETE_CLEANUP_PAGE_SIZE).get();
     if (snap.empty) return;
-    const batch = db.batch();
-    snap.docs.forEach((d) => batch.delete(d.ref));
-    await batch.commit();
+    await handler(snap.docs);
   }
+}
+
+async function deleteQueryBatch(q) {
+  await drainQuery(q, async (docs) => {
+    const batch = db.batch();
+    docs.forEach((d) => batch.delete(d.ref));
+    await batch.commit();
+  });
 }
 
 async function enforceDeleteAccountRateLimit(uid) {
@@ -692,7 +734,7 @@ async function enforceDeleteAccountRateLimit(uid) {
   });
 }
 
-exports.deleteUserAccount = onCall(async (request) => {
+exports.deleteUserAccount = onCall({ timeoutSeconds: 540 }, async (request) => {
   const uid = request.auth?.uid;
   const authTime = request.auth?.token?.auth_time;
 
@@ -700,47 +742,77 @@ exports.deleteUserAccount = onCall(async (request) => {
     throw new HttpsError("unauthenticated", "Sign in to delete your account.");
   }
 
-  if (
-    typeof authTime !== "number" ||
-    Date.now() / 1000 - authTime > DELETE_ACCOUNT_MAX_AUTH_AGE_SECONDS
-  ) {
-    throw new HttpsError(
-      "failed-precondition",
-      "Please sign in again before deleting your account."
-    );
+  let userRecord;
+  try {
+    userRecord = await admin.auth().getUser(uid);
+  } catch {
+    // Auth user already gone means a previous run completed everything
+    // (deleteUser is the final step below).
+    throw new HttpsError("failed-precondition", "This account no longer exists.");
   }
 
-  await enforceDeleteAccountRateLimit(uid);
+  // Resume path: a previous run disabled the account but was cut off before
+  // cleanup finished. The user cannot re-authenticate a disabled account, so
+  // the freshness and rate-limit gates are skipped — the destructive intent
+  // was already proven, and everything below is idempotent.
+  const isResume = userRecord.disabled === true;
+
+  if (!isResume) {
+    if (
+      typeof authTime !== "number" ||
+      Date.now() / 1000 - authTime > DELETE_ACCOUNT_MAX_AUTH_AGE_SECONDS
+    ) {
+      throw new HttpsError(
+        "failed-precondition",
+        "Please sign in again before deleting your account."
+      );
+    }
+
+    await enforceDeleteAccountRateLimit(uid);
+
+    // Lock the account BEFORE touching any data: even if this run is cut off
+    // mid-cleanup, no new sign-in is possible and revoked refresh tokens cap
+    // existing sessions at ID-token expiry (≤1 h). The still-valid ID token
+    // lets the client retry this callable to resume.
+    await admin.auth().updateUser(uid, { disabled: true });
+    await admin.auth().revokeRefreshTokens(uid);
+  }
 
   // 1. Sessions hosted by the user: delete outright, including the group-chat
   //    messages subcollection — a flat batch delete would orphan it.
-  const hosted = await db.collection("sessions").where("hostId", "==", uid).get();
-  for (const docSnap of hosted.docs) {
-    await db.recursiveDelete(docSnap.ref);
-  }
+  await drainQuery(db.collection("sessions").where("hostId", "==", uid), async (docs) => {
+    for (const docSnap of docs) {
+      await db.recursiveDelete(docSnap.ref);
+    }
+  });
 
-  // 2. Sessions joined: remove from participant arrays.
-  const joined = await db
-    .collection("sessions")
-    .where("participantIds", "array-contains", uid)
-    .get();
-  for (const docSnap of joined.docs) {
-    await docSnap.ref.update({
-      participantIds: admin.firestore.FieldValue.arrayRemove(uid),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    });
-  }
+  // 2. Sessions joined: remove from participant arrays (arrayRemove is
+  //    idempotent and takes the doc out of this query's results).
+  await drainQuery(
+    db.collection("sessions").where("participantIds", "array-contains", uid),
+    async (docs) => {
+      const batch = db.batch();
+      docs.forEach((docSnap) =>
+        batch.update(docSnap.ref, {
+          participantIds: admin.firestore.FieldValue.arrayRemove(uid),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        })
+      );
+      await batch.commit();
+    }
+  );
 
   // 3. Conversations: delete the thread and its messages (the counterpart
   //    loses the thread too — acceptable for a 1:1 DM model and required to
   //    avoid orphaned PII; messages contain the deleted user's words).
-  const conversations = await db
-    .collection("conversations")
-    .where("participantIds", "array-contains", uid)
-    .get();
-  for (const convo of conversations.docs) {
-    await db.recursiveDelete(convo.ref);
-  }
+  await drainQuery(
+    db.collection("conversations").where("participantIds", "array-contains", uid),
+    async (docs) => {
+      for (const convo of docs) {
+        await db.recursiveDelete(convo.ref);
+      }
+    }
+  );
 
   // 3b. Group-chat messages the user sent in sessions they didn't host —
   //     collection-group lookup on senderId (COLLECTION_GROUP index in
@@ -757,7 +829,8 @@ exports.deleteUserAccount = onCall(async (request) => {
 
   // 6. Profile (public doc + private, notifications, and reads subcollections
   //    — the notification records double as reminder/dedupe state, so nothing
-  //    else to clean), then the Auth user.
+  //    else to clean), then the Auth user — last, so a lost run can always
+  //    resume through the disabled-account path above.
   await db.recursiveDelete(db.collection("users").doc(uid));
   await admin.auth().deleteUser(uid);
 

--- a/functions/notification-validation.js
+++ b/functions/notification-validation.js
@@ -32,7 +32,7 @@ function isSafeId(value) {
 /**
  * Strict allowlist for notification navigation targets. Valid forms:
  *   /notifications
- *   /conversation/{id}   /session/{id}
+ *   /conversation/{id}   /session/{id}   /session-chat/{id}
  * where {id} must be a safe internal ID (see SAFE_ID_PATTERN). The segment is
  * also run through decodeURIComponent and must decode to itself, so
  * percent-encoded separators (%2F, %5C), traversal (`.`/`..`), external
@@ -47,7 +47,7 @@ function isAllowedNotificationUrl(url) {
     return true;
   }
 
-  const match = /^\/(conversation|session)\/([^/]+)$/.exec(url);
+  const match = /^\/(conversation|session|session-chat)\/([^/]+)$/.exec(url);
   if (!match) {
     return false;
   }
@@ -132,6 +132,11 @@ function sessionEventNotificationId(kind, eventId) {
   return `${kind}_${sanitizeIdPart(eventId)}`;
 }
 
+/** Retries of one group-chat message event dedupe; session scoping mirrors dmNotificationId. */
+function groupMessageNotificationId(sessionId, eventId) {
+  return `gm_${sanitizeIdPart(sessionId)}_${sanitizeIdPart(eventId)}`;
+}
+
 /**
  * One reminder per recipient per session *start occurrence* — rescheduling a
  * session changes startTimeMillis, so the new occurrence reminds again. The
@@ -146,6 +151,7 @@ module.exports = {
   BODY_MAX_LENGTH,
   TITLE_MAX_LENGTH,
   dmNotificationId,
+  groupMessageNotificationId,
   isAllowedNotificationUrl,
   isSafeId,
   normalizeNotificationPayload,

--- a/functions/notification-validation.js
+++ b/functions/notification-validation.js
@@ -137,6 +137,32 @@ function groupMessageNotificationId(sessionId, eventId) {
   return `gm_${sanitizeIdPart(sessionId)}_${sanitizeIdPart(eventId)}`;
 }
 
+// ---------------------------------------------------------------------------
+// Server-side block filtering for group-message notifications. Blocked
+// recipients (either direction) are removed BEFORE notifyUser() is ever
+// called, so neither the persistent record nor the push exists for them —
+// and because the filter runs upstream of any preference check, no
+// notificationPrefs setting can resurrect a blocked notification. The chat
+// message itself stays stored for the remaining participants.
+// ---------------------------------------------------------------------------
+
+/** Both directions of the deterministic userBlocks/{blocker}__{blocked} doc ID. */
+function blockPairIdsFor(senderId, recipientId) {
+  return [`${senderId}__${recipientId}`, `${recipientId}__${senderId}`];
+}
+
+/**
+ * Drops every recipient with a block in either direction against the sender.
+ * `existingBlockIds` is the set of userBlocks doc IDs that actually exist
+ * (the caller looks them up in one batched getAll — 2 lookups per recipient,
+ * bounded by session capacity).
+ */
+function filterBlockedRecipients(senderId, recipients, existingBlockIds) {
+  return recipients.filter(
+    (uid) => !blockPairIdsFor(senderId, uid).some((id) => existingBlockIds.has(id))
+  );
+}
+
 /**
  * One reminder per recipient per session *start occurrence* — rescheduling a
  * session changes startTimeMillis, so the new occurrence reminds again. The
@@ -150,7 +176,9 @@ function reminderNotificationId(sessionId, uid, startTimeMillis) {
 module.exports = {
   BODY_MAX_LENGTH,
   TITLE_MAX_LENGTH,
+  blockPairIdsFor,
   dmNotificationId,
+  filterBlockedRecipients,
   groupMessageNotificationId,
   isAllowedNotificationUrl,
   isSafeId,

--- a/functions/notification-validation.js
+++ b/functions/notification-validation.js
@@ -137,6 +137,21 @@ function groupMessageNotificationId(sessionId, eventId) {
   return `gm_${sanitizeIdPart(sessionId)}_${sanitizeIdPart(eventId)}`;
 }
 
+// Group-chat fanout ceiling. New sessions are capacity-capped at 20 already,
+// but legacy sessions have no capacity field and unbounded participantIds —
+// the ceiling is judged on the ACTUAL participant count, never on capacity.
+// firestore.rules (messages create) and lib/firestore.ts
+// (MAX_GROUP_CHAT_PARTICIPANTS) hardcode the same 20 — change all three
+// together. Bounds the per-message block lookups at 38 doc reads (20
+// participants, sender excluded → 19 recipients × 2 directions).
+const MAX_GROUP_CHAT_PARTICIPANTS = 20;
+
+function isWithinGroupChatFanoutLimit(participantCount) {
+  return (
+    Number.isInteger(participantCount) && participantCount <= MAX_GROUP_CHAT_PARTICIPANTS
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Server-side block filtering for group-message notifications. Blocked
 // recipients (either direction) are removed BEFORE notifyUser() is ever
@@ -176,12 +191,14 @@ function reminderNotificationId(sessionId, uid, startTimeMillis) {
 module.exports = {
   BODY_MAX_LENGTH,
   TITLE_MAX_LENGTH,
+  MAX_GROUP_CHAT_PARTICIPANTS,
   blockPairIdsFor,
   dmNotificationId,
   filterBlockedRecipients,
   groupMessageNotificationId,
   isAllowedNotificationUrl,
   isSafeId,
+  isWithinGroupChatFanoutLimit,
   normalizeNotificationPayload,
   reminderNotificationId,
   sanitizeIdPart,

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -77,6 +77,8 @@ export type AnalyticsEvent =
   | "uw_map_opened"
   | "message_sent"
   | "conversation_started"
+  | "session_chat_opened"
+  | "group_message_sent"
   | "report_submitted"
   | "user_blocked"
   | "user_unblocked"

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -1155,6 +1155,18 @@ export function subscribeToConversationMessages(
 
 export const SESSION_MESSAGES_PAGE_SIZE = 30;
 
+/** Group-chat fanout ceiling, judged on the ACTUAL participant count (the
+ *  optional capacity field can be absent on legacy sessions). Mirrors
+ *  firestore.rules (messages create) and MAX_GROUP_CHAT_PARTICIPANTS in
+ *  functions/notification-validation.js — change all three together. */
+export const MAX_GROUP_CHAT_PARTICIPANTS = 20;
+
+/** Oversized legacy sessions get a read-only chat: rules deny new sends and
+ *  the Cloud Function skips notification fanout entirely. */
+export function isGroupChatAvailable(session: Pick<StudySession, "participantIds">) {
+  return session.participantIds.length <= MAX_GROUP_CHAT_PARTICIPANTS;
+}
+
 function sessionMessagesCollection(sessionId: string) {
   return collection(db, COLLECTIONS.sessions, sessionId, "messages");
 }

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -110,6 +110,11 @@ export type StudySession = {
   classId: string;
   endTime: Timestamp;
   hostId: string;
+  /** Group-chat unread metadata, written only by the Cloud Function on each
+   *  message — arrival time and sender, never content (the session doc is
+   *  readable by all verified users). Absent until the first message. */
+  lastMessageAt?: Timestamp;
+  lastMessageSenderId?: string;
   locationId: string;
   participantIds: string[];
   sessionId: string;
@@ -180,6 +185,19 @@ export type ConversationMessage = {
   createdAt?: unknown;
   messageId: string;
   senderId: string;
+  text: string;
+};
+
+/** Session group-chat message — same shape as a DM message (senderId, text,
+ *  createdAt); sender names resolve from public profiles at render time, so
+ *  nothing forgeable or stale is denormalized onto the doc. */
+export type SessionMessage = {
+  createdAt?: unknown;
+  messageId: string;
+  /** True while the local optimistic write hasn't been acknowledged yet. */
+  pending: boolean;
+  senderId: string;
+  sessionId: string;
   text: string;
 };
 
@@ -729,6 +747,8 @@ function normalizeSessionDoc(
     return null;
   }
 
+  const lastMessageAt = normalizeSessionTimestamp(data.lastMessageAt);
+
   return {
     sessionId,
     classId: typeof data.classId === "string" ? data.classId : "",
@@ -744,6 +764,11 @@ function normalizeSessionDoc(
     // Pre-capacity docs have no field — leave undefined (unlimited).
     ...(typeof data.capacity === "number" && Number.isInteger(data.capacity)
       ? { capacity: data.capacity }
+      : {}),
+    // Group-chat unread metadata (CF-written) — absent until the first message.
+    ...(lastMessageAt ? { lastMessageAt } : {}),
+    ...(typeof data.lastMessageSenderId === "string" && data.lastMessageSenderId
+      ? { lastMessageSenderId: data.lastMessageSenderId }
       : {}),
   };
 }
@@ -1118,6 +1143,159 @@ export function subscribeToConversationMessages(
 
     listener(messages);
   });
+}
+
+// ---------------------------------------------------------------------------
+// Session group chat (PR: group chat). Messages live in
+// sessions/{sessionId}/messages with the same doc shape as DM messages;
+// rules gate everything on parent-session participation. The chat screen
+// keeps a live window over the newest page and pages backwards on demand,
+// so no unbounded reads.
+// ---------------------------------------------------------------------------
+
+export const SESSION_MESSAGES_PAGE_SIZE = 30;
+
+function sessionMessagesCollection(sessionId: string) {
+  return collection(db, COLLECTIONS.sessions, sessionId, "messages");
+}
+
+function mapSessionMessageDoc(
+  sessionId: string,
+  messageDoc: QueryDocumentSnapshot
+): SessionMessage {
+  // Estimated server timestamps keep an in-flight optimistic send ordered and
+  // renderable instead of surfacing createdAt: null until the ack arrives.
+  const data = messageDoc.data({ serverTimestamps: "estimate" });
+
+  return {
+    sessionId,
+    messageId: messageDoc.id,
+    pending: messageDoc.metadata.hasPendingWrites,
+    senderId: typeof data.senderId === "string" ? data.senderId : "",
+    text: typeof data.text === "string" ? data.text : "",
+    createdAt: data.createdAt,
+  };
+}
+
+/** Pre-generates the message doc ID so a failed send can be retried under the
+ *  same ID without ever duplicating on screen or in Firestore. */
+export function createSessionMessageId(sessionId: string): string {
+  return doc(sessionMessagesCollection(sessionId)).id;
+}
+
+export async function sendSessionMessage(
+  sessionId: string,
+  senderId: string,
+  text: string,
+  messageId: string
+) {
+  const trimmedText = text.trim();
+
+  if (!trimmedText) {
+    throw new Error("Write a message before sending.");
+  }
+
+  const batch = writeBatch(db);
+  batch.set(doc(db, COLLECTIONS.sessions, sessionId, "messages", messageId), {
+    senderId,
+    text: trimmedText.slice(0, 2000),
+    createdAt: serverTimestamp(),
+  });
+  stageRateLimit(batch, senderId, "sendMessage");
+  await batch.commit();
+  track("group_message_sent", { length: trimmedText.length });
+}
+
+export type SessionMessagesPage = {
+  /** Newest-first, matching the inverted chat list. */
+  messages: SessionMessage[];
+  /** Cursor for the next-older page; null when this page came up short. */
+  cursor: QueryDocumentSnapshot | null;
+  hasMore: boolean;
+};
+
+/**
+ * Live window over the newest page of messages (newest-first). Local sends
+ * appear immediately via latency compensation (`pending: true`) and settle in
+ * place when the server acks. Older history loads through
+ * getEarlierSessionMessages using the returned cursor.
+ */
+export function subscribeToSessionMessages(
+  sessionId: string,
+  listener: (page: SessionMessagesPage) => void,
+  onError?: (error: Error) => void
+) {
+  const messagesQuery = query(
+    sessionMessagesCollection(sessionId),
+    orderBy("createdAt", "desc"),
+    limit(SESSION_MESSAGES_PAGE_SIZE)
+  );
+
+  return onSnapshot(
+    messagesQuery,
+    (snapshot) => {
+      const hasFullPage = snapshot.docs.length === SESSION_MESSAGES_PAGE_SIZE;
+      listener({
+        messages: snapshot.docs.map((messageDoc) =>
+          mapSessionMessageDoc(sessionId, messageDoc)
+        ),
+        cursor: hasFullPage ? snapshot.docs[snapshot.docs.length - 1] : null,
+        hasMore: hasFullPage,
+      });
+    },
+    onError
+  );
+}
+
+export async function getEarlierSessionMessages(
+  sessionId: string,
+  cursor: QueryDocumentSnapshot
+): Promise<SessionMessagesPage> {
+  const snapshot = await getDocs(
+    query(
+      sessionMessagesCollection(sessionId),
+      orderBy("createdAt", "desc"),
+      startAfter(cursor),
+      limit(SESSION_MESSAGES_PAGE_SIZE)
+    )
+  );
+
+  const hasFullPage = snapshot.docs.length === SESSION_MESSAGES_PAGE_SIZE;
+  return {
+    messages: snapshot.docs.map((messageDoc) => mapSessionMessageDoc(sessionId, messageDoc)),
+    cursor: hasFullPage ? snapshot.docs[snapshot.docs.length - 1] : null,
+    hasMore: hasFullPage,
+  };
+}
+
+/** Records "I've seen this thread as of now" — rules pin the value to the
+ *  server clock. threadId is the sessionId for group chats. */
+export async function markSessionChatRead(userId: string, sessionId: string) {
+  await setDoc(doc(db, COLLECTIONS.users, userId, "reads", sessionId), {
+    lastReadAt: serverTimestamp(),
+  });
+}
+
+export async function getSessionChatLastReadAt(
+  userId: string,
+  sessionId: string
+): Promise<Timestamp | null> {
+  const snap = await getDoc(doc(db, COLLECTIONS.users, userId, "reads", sessionId));
+  const lastReadAt = snap.exists() ? snap.data()?.lastReadAt : null;
+  return lastReadAt instanceof Timestamp ? lastReadAt : null;
+}
+
+/** Unread = someone else's message arrived after the viewer's read marker.
+ *  Your own sends never count, so the indicator can't flag you for talking. */
+export function hasUnreadSessionChat(
+  session: Pick<StudySession, "lastMessageAt" | "lastMessageSenderId">,
+  currentUserId: string,
+  lastReadAt: Timestamp | null
+): boolean {
+  if (!session.lastMessageAt || session.lastMessageSenderId === currentUserId) {
+    return false;
+  }
+  return !lastReadAt || session.lastMessageAt.toMillis() > lastReadAt.toMillis();
 }
 
 export function subscribeToUserConversations(

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -26,10 +26,10 @@ const SAFE_ROUTE_ID_PATTERN = /^[A-Za-z0-9_-]{1,200}$/;
 /**
  * Strict allowlist for navigation triggered by notification payloads — push
  * taps and Notifications Center rows both validate through here. Valid forms:
- * `/notifications`, `/conversation/{id}`, `/session/{id}` where {id} is a
- * safe internal ID. The segment must also decode to itself, so traversal
- * (`.`/`..`), percent-encoded separators (%2F, %5C), malformed escapes, and
- * external schemes never pass.
+ * `/notifications`, `/conversation/{id}`, `/session/{id}`, `/session-chat/{id}`
+ * where {id} is a safe internal ID. The segment must also decode to itself, so
+ * traversal (`.`/`..`), percent-encoded separators (%2F, %5C), malformed
+ * escapes, and external schemes never pass.
  */
 export function isAllowedNotificationUrl(url: unknown): url is string {
   if (typeof url !== 'string') {
@@ -40,7 +40,7 @@ export function isAllowedNotificationUrl(url: unknown): url is string {
     return true;
   }
 
-  const match = /^\/(conversation|session)\/([^/]+)$/.exec(url);
+  const match = /^\/(conversation|session|session-chat)\/([^/]+)$/.exec(url);
   if (!match) {
     return false;
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "web:export": "expo export --platform web",
     "lint": "expo lint",
     "rules:test": "firebase emulators:exec --only firestore \"mocha tests/firestore-rules.test.mjs --timeout 10000\"",
-    "test:notifications": "mocha tests/notification-validation.test.mjs"
+    "test:notifications": "mocha tests/notification-validation.test.mjs",
+    "test:deletion": "mocha tests/account-deletion.test.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/cormorant-garamond": "^0.4.1",

--- a/scripts/resume-account-deletion.js
+++ b/scripts/resume-account-deletion.js
@@ -5,37 +5,76 @@
 // only while their last ID token is still valid (≤1 h). After that, this
 // script continues the job with service-account credentials.
 //
-// Usage (Application Default Credentials or GOOGLE_APPLICATION_CREDENTIALS):
-//   GOOGLE_CLOUD_PROJECT=<project-id> node scripts/resume-account-deletion.js <uid>
+// Usage:
+//   GOOGLE_APPLICATION_CREDENTIALS=<service-account.json> \
+//     node scripts/resume-account-deletion.js <uid>
 //
-// Safety: it refuses to run unless accountDeletionJobs/{uid} exists with an
-// active (pending | running | failed) status — deletion must have been
-// explicitly requested by the user through the callable (which records the
-// marker before disabling anything), so ops can never destructively delete a
-// merely-disabled (moderation) account, and completed jobs can never restart.
+// Safety (all checks run through the same helpers as production code, in
+// functions/account-deletion.js):
+//   - the uid is strictly validated BEFORE any Firebase initialization or
+//     read (safe charset, ≤128 chars; empty/padded/path-like values abort);
+//   - the Admin SDK is pinned to the studi-b02c3 project explicitly — an ADC
+//     context pointing anywhere else aborts before and after initialization;
+//   - accountDeletionJobs/{uid} must exist, be well-formed, name this exact
+//     uid, and be in an active (pending | running | failed) state. Deletion
+//     must have been user-initiated through the callable (which records the
+//     marker before disabling anything), so ops can never destructively
+//     delete a merely-disabled (moderation) account, and completed jobs can
+//     never restart.
 // The cleanup itself is the exact same idempotent runner the callable uses.
 
 const path = require("node:path");
 const { createRequire } = require("node:module");
 
-// firebase-admin lives in the functions package, not the app root.
-const requireFromFunctions = createRequire(path.join(__dirname, "..", "functions", "index.js"));
-const admin = requireFromFunctions("firebase-admin");
-
 const {
+  DELETION_PROJECT_ID,
   createAccountDeletionRunner,
-  isResumableJob,
+  validateResumableJob,
+  validateResumeScriptArgs,
 } = require("../functions/account-deletion");
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
 
 async function main() {
   const uid = process.argv[2];
 
-  if (!uid) {
-    console.error("Usage: node scripts/resume-account-deletion.js <uid>");
-    process.exit(1);
+  // Environment project context, if present, must agree with the pin —
+  // checked before touching Firebase at all.
+  const envProject =
+    process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || DELETION_PROJECT_ID;
+
+  const preflight = validateResumeScriptArgs({ uid, projectId: envProject });
+  if (!preflight.ok) {
+    if (preflight.reason === "invalid-uid") {
+      fail(
+        "Invalid uid argument — expected a bare Firebase uid ([A-Za-z0-9_-], ≤128 chars).\n" +
+          "Usage: node scripts/resume-account-deletion.js <uid>"
+      );
+    }
+    fail(
+      `Project context '${envProject}' is not '${DELETION_PROJECT_ID}' — refusing. ` +
+        "This script only ever operates on the pinned project."
+    );
   }
 
-  admin.initializeApp();
+  // firebase-admin lives in the functions package, not the app root.
+  const requireFromFunctions = createRequire(
+    path.join(__dirname, "..", "functions", "index.js")
+  );
+  const admin = requireFromFunctions("firebase-admin");
+
+  // Explicit pin — never trust whatever project the ambient ADC resolves to.
+  admin.initializeApp({ projectId: DELETION_PROJECT_ID });
+  const resolvedProject = admin.app().options.projectId;
+  if (resolvedProject !== DELETION_PROJECT_ID) {
+    fail(
+      `Resolved project '${resolvedProject}' is not '${DELETION_PROJECT_ID}' — aborting.`
+    );
+  }
+
   const runner = createAccountDeletionRunner({
     db: admin.firestore(),
     auth: admin.auth(),
@@ -43,19 +82,19 @@ async function main() {
   });
 
   const job = await runner.getJob(uid);
-
-  if (!job) {
-    console.error(
-      `No accountDeletionJobs/${uid} marker — refusing. Deletion must be ` +
+  const verdict = validateResumableJob(job, uid);
+  if (!verdict.ok) {
+    const explanation = {
+      "missing-job":
+        `No accountDeletionJobs/${uid} marker — refusing. Deletion must be ` +
         "user-initiated through the deleteUserAccount callable; a disabled " +
-        "account without a job is a moderation state, not a deletion."
-    );
-    process.exit(1);
-  }
-
-  if (!isResumableJob(job)) {
-    console.error(`Job for ${uid} has status '${job.status}' — nothing to resume.`);
-    process.exit(1);
+        "account without a job is a moderation state, not a deletion.",
+      "malformed-job": `Job doc for ${uid} is malformed — refusing to act on it.`,
+      "user-mismatch": `Job doc for ${uid} names a different userId — refusing.`,
+      "already-complete": `Job for ${uid} is already complete — nothing to resume.`,
+      "unknown-status": `Job for ${uid} has an unrecognized status — refusing.`,
+    }[verdict.reason];
+    fail(explanation ?? `Job validation failed (${verdict.reason}).`);
   }
 
   console.log(

--- a/scripts/resume-account-deletion.js
+++ b/scripts/resume-account-deletion.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// scripts/resume-account-deletion.js — ops resume path for account-deletion
+// jobs that outlived the user's token window. Once a deletion begins, the
+// Auth account is disabled: the user can retry the deleteUserAccount callable
+// only while their last ID token is still valid (≤1 h). After that, this
+// script continues the job with service-account credentials.
+//
+// Usage (Application Default Credentials or GOOGLE_APPLICATION_CREDENTIALS):
+//   GOOGLE_CLOUD_PROJECT=<project-id> node scripts/resume-account-deletion.js <uid>
+//
+// Safety: it refuses to run unless accountDeletionJobs/{uid} exists with an
+// active (pending | running | failed) status — deletion must have been
+// explicitly requested by the user through the callable (which records the
+// marker before disabling anything), so ops can never destructively delete a
+// merely-disabled (moderation) account, and completed jobs can never restart.
+// The cleanup itself is the exact same idempotent runner the callable uses.
+
+const path = require("node:path");
+const { createRequire } = require("node:module");
+
+// firebase-admin lives in the functions package, not the app root.
+const requireFromFunctions = createRequire(path.join(__dirname, "..", "functions", "index.js"));
+const admin = requireFromFunctions("firebase-admin");
+
+const {
+  createAccountDeletionRunner,
+  isResumableJob,
+} = require("../functions/account-deletion");
+
+async function main() {
+  const uid = process.argv[2];
+
+  if (!uid) {
+    console.error("Usage: node scripts/resume-account-deletion.js <uid>");
+    process.exit(1);
+  }
+
+  admin.initializeApp();
+  const runner = createAccountDeletionRunner({
+    db: admin.firestore(),
+    auth: admin.auth(),
+    FieldValue: admin.firestore.FieldValue,
+  });
+
+  const job = await runner.getJob(uid);
+
+  if (!job) {
+    console.error(
+      `No accountDeletionJobs/${uid} marker — refusing. Deletion must be ` +
+        "user-initiated through the deleteUserAccount callable; a disabled " +
+        "account without a job is a moderation state, not a deletion."
+    );
+    process.exit(1);
+  }
+
+  if (!isResumableJob(job)) {
+    console.error(`Job for ${uid} has status '${job.status}' — nothing to resume.`);
+    process.exit(1);
+  }
+
+  console.log(
+    `Resuming deletion for ${uid} ` +
+      `(status: ${job.status}, attempts: ${job.attemptCount ?? 0}, lastStep: ${job.lastStep ?? "none"})`
+  );
+  await runner.runCleanup(uid);
+  console.log(`Deletion complete for ${uid}.`);
+}
+
+main().catch((error) => {
+  console.error("Resume failed (job remains resumable):", error);
+  process.exit(1);
+});

--- a/tests/account-deletion.test.mjs
+++ b/tests/account-deletion.test.mjs
@@ -1,0 +1,248 @@
+// tests/account-deletion.test.mjs
+// Run: npm run test:deletion  (plain mocha — no emulator needed)
+// Unit tests for the account-deletion state machine and cleanup runner in
+// functions/account-deletion.js. The runner takes its Firebase handles by
+// injection, so these tests drive the exact code the deleteUserAccount
+// callable and scripts/resume-account-deletion.js run — with fakes recording
+// operation order. Remaining live QA (documented in docs/push-notifications.md):
+// one end-to-end deletion against a dev project, since the repo has no Cloud
+// Functions integration harness.
+
+import { strict as assert } from 'node:assert';
+import deletion from '../functions/account-deletion.js';
+
+const {
+  classifyDeletionRequest,
+  createAccountDeletionRunner,
+  isResumableJob,
+  boundedErrorCode,
+} = deletion;
+
+const UID = 'aliceUid';
+
+const EXPECTED_STEP_ORDER = [
+  'hosted-sessions',
+  'joined-sessions',
+  'conversations',
+  'sent-messages',
+  'user-blocks',
+  'location-ratings',
+  'user-tree',
+];
+
+// Minimal fakes for the Firestore/Auth surface the runner touches. Queries
+// always come back empty (each cleanup step is exercised as a no-op pass);
+// a named collection can be made to throw to simulate a mid-run failure.
+function createFakes() {
+  const ops = [];
+  const jobWrites = [];
+  let jobData = null;
+  let authUserExists = true;
+  const failures = { collection: null };
+
+  const jobDoc = {
+    async set(fields) {
+      jobWrites.push(fields);
+      ops.push(`job:${fields.status ?? `step:${fields.lastStep}`}`);
+      jobData = { ...(jobData ?? {}), ...fields };
+    },
+    async get() {
+      return { exists: jobData !== null, data: () => jobData };
+    },
+  };
+
+  function makeQuery(name) {
+    const query = {
+      where: () => query,
+      limit: () => query,
+      async get() {
+        if (failures.collection === name) {
+          const error = new Error(`${name} query failed`);
+          error.code = 'unavailable';
+          throw error;
+        }
+        return { empty: true, docs: [] };
+      },
+    };
+    return query;
+  }
+
+  const db = {
+    collection(name) {
+      return {
+        doc: () => (name === 'accountDeletionJobs' ? jobDoc : { path: `${name}/doc` }),
+        where: () => makeQuery(name),
+      };
+    },
+    collectionGroup(name) {
+      return { where: () => makeQuery(`cg:${name}`) };
+    },
+    batch() {
+      return { update() {}, delete() {}, async commit() {} };
+    },
+    async recursiveDelete() {
+      ops.push('recursiveDelete');
+    },
+  };
+
+  const auth = {
+    async updateUser() {
+      ops.push('auth:disable');
+    },
+    async revokeRefreshTokens() {
+      ops.push('auth:revoke');
+    },
+    async deleteUser() {
+      if (!authUserExists) {
+        const error = new Error('user not found');
+        error.code = 'auth/user-not-found';
+        throw error;
+      }
+      authUserExists = false;
+      ops.push('auth:deleteUser');
+    },
+  };
+
+  const FieldValue = {
+    serverTimestamp: () => 'server-ts',
+    increment: (n) => ({ increment: n }),
+    arrayRemove: (v) => ({ arrayRemove: v }),
+  };
+
+  return {
+    ops,
+    jobWrites,
+    failures,
+    getJobData: () => jobData,
+    runner: createAccountDeletionRunner({ db, auth, FieldValue }),
+  };
+}
+
+describe('deletion request classification', () => {
+  it('moderation-disabled account without a job never enters cleanup', () => {
+    assert.equal(
+      classifyDeletionRequest({ callerUid: UID, job: null, authDisabled: true }),
+      'reject-disabled-no-job'
+    );
+  });
+
+  it('enabled account without a job is a fresh request (full gates apply)', () => {
+    assert.equal(
+      classifyDeletionRequest({ callerUid: UID, job: null, authDisabled: false }),
+      'fresh'
+    );
+  });
+
+  it('an active job resumes, whatever its intermediate status', () => {
+    for (const status of ['pending', 'running', 'failed']) {
+      assert.equal(
+        classifyDeletionRequest({
+          callerUid: UID,
+          job: { userId: UID, status },
+          authDisabled: true,
+        }),
+        'resume'
+      );
+    }
+  });
+
+  it('a completed job can never rerun destructively', () => {
+    assert.equal(
+      classifyDeletionRequest({
+        callerUid: UID,
+        job: { userId: UID, status: 'complete' },
+        authDisabled: true,
+      }),
+      'reject-complete'
+    );
+    assert.equal(isResumableJob({ userId: UID, status: 'complete' }), false);
+    assert.equal(isResumableJob(null), false);
+    assert.equal(isResumableJob({ userId: UID, status: 'pending' }), true);
+  });
+
+  it("one user cannot resume another user's job", () => {
+    assert.equal(
+      classifyDeletionRequest({
+        callerUid: 'malloryUid',
+        job: { userId: UID, status: 'running' },
+        authDisabled: false,
+      }),
+      'reject-not-owner'
+    );
+  });
+
+  it('error codes stored on the job are bounded and non-sensitive', () => {
+    assert.equal(boundedErrorCode({ code: 'unavailable' }), 'unavailable');
+    assert.equal(boundedErrorCode(new Error('x'.repeat(500))).length <= 64, true);
+    assert.equal(boundedErrorCode(undefined), 'unknown');
+  });
+});
+
+describe('deletion runner (same code path as callable + ops script)', () => {
+  it('beginDeletion writes the job marker BEFORE disabling the account', async () => {
+    const fakes = createFakes();
+    await fakes.runner.beginDeletion(UID);
+
+    assert.deepEqual(fakes.ops, ['job:pending', 'auth:disable', 'auth:revoke']);
+    assert.equal(fakes.jobWrites[0].status, 'pending');
+    assert.equal(fakes.jobWrites[0].attemptCount, 0);
+    assert.equal(fakes.jobWrites[0].userId, UID);
+    assert.ok(fakes.jobWrites[0].requestedAt);
+    assert.ok(fakes.jobWrites[0].createdAt);
+  });
+
+  it('runCleanup re-locks, runs every step in order, deletes auth last, then marks complete', async () => {
+    const fakes = createFakes();
+    await fakes.runner.runCleanup(UID);
+
+    // Lock precedes any destructive work.
+    assert.deepEqual(fakes.ops.slice(0, 3), ['auth:disable', 'auth:revoke', 'job:running']);
+    // Durable per-step progress, in the documented order.
+    const stepWrites = fakes.jobWrites
+      .map((write) => write.lastStep)
+      .filter((step) => step !== undefined);
+    assert.deepEqual(stepWrites, EXPECTED_STEP_ORDER);
+    // Auth deletion only after all cleanup; completion only after that.
+    const deleteIndex = fakes.ops.indexOf('auth:deleteUser');
+    assert.ok(deleteIndex > fakes.ops.indexOf('job:step:user-tree'));
+    assert.equal(fakes.ops[fakes.ops.length - 1], 'job:complete');
+    assert.equal(fakes.getJobData().status, 'complete');
+  });
+
+  it('a failed step persists partial progress and leaves the job resumable', async () => {
+    const fakes = createFakes();
+    fakes.failures.collection = 'conversations';
+
+    await assert.rejects(() => fakes.runner.runCleanup(UID));
+
+    const job = fakes.getJobData();
+    assert.equal(job.status, 'failed');
+    assert.equal(job.lastStep, 'joined-sessions'); // last step that finished
+    assert.equal(job.errorCode, 'unavailable');
+    assert.equal(isResumableJob(job), true);
+    // The auth user was never deleted on the failed run.
+    assert.equal(fakes.ops.includes('auth:deleteUser'), false);
+  });
+
+  it('a retry after failure resumes idempotently and completes — no request context needed', async () => {
+    const fakes = createFakes();
+    fakes.failures.collection = 'conversations';
+    await assert.rejects(() => fakes.runner.runCleanup(UID));
+
+    // Ops-style resume: just the uid, no user token, no callable request.
+    fakes.failures.collection = null;
+    await fakes.runner.runCleanup(UID);
+
+    assert.equal(fakes.getJobData().status, 'complete');
+  });
+
+  it('repeated full runs stay idempotent even after the auth user is gone', async () => {
+    const fakes = createFakes();
+    await fakes.runner.runCleanup(UID);
+    // Second run: deleteUser throws auth/user-not-found — swallowed.
+    await fakes.runner.runCleanup(UID);
+
+    assert.equal(fakes.getJobData().status, 'complete');
+    assert.equal(fakes.ops.filter((op) => op === 'auth:deleteUser').length, 1);
+  });
+});

--- a/tests/account-deletion.test.mjs
+++ b/tests/account-deletion.test.mjs
@@ -12,10 +12,14 @@ import { strict as assert } from 'node:assert';
 import deletion from '../functions/account-deletion.js';
 
 const {
+  DELETION_PROJECT_ID,
+  boundedErrorCode,
   classifyDeletionRequest,
   createAccountDeletionRunner,
   isResumableJob,
-  boundedErrorCode,
+  isValidDeletionUid,
+  validateResumableJob,
+  validateResumeScriptArgs,
 } = deletion;
 
 const UID = 'aliceUid';
@@ -38,10 +42,18 @@ function createFakes() {
   const jobWrites = [];
   let jobData = null;
   let authUserExists = true;
-  const failures = { collection: null };
+  // failures.collection: named query throws; failures.jobWriteStatus: the
+  // job-doc write carrying that status throws; failures.disableAccount:
+  // auth.updateUser throws.
+  const failures = { collection: null, jobWriteStatus: null, disableAccount: false };
 
   const jobDoc = {
     async set(fields) {
+      if (failures.jobWriteStatus && fields.status === failures.jobWriteStatus) {
+        const error = new Error(`job write rejected (${fields.status})`);
+        error.code = 'job-write-denied';
+        throw error;
+      }
       jobWrites.push(fields);
       ops.push(`job:${fields.status ?? `step:${fields.lastStep}`}`);
       jobData = { ...(jobData ?? {}), ...fields };
@@ -87,6 +99,11 @@ function createFakes() {
 
   const auth = {
     async updateUser() {
+      if (failures.disableAccount) {
+        const error = new Error('auth disable failed');
+        error.code = 'auth/internal-error';
+        throw error;
+      }
       ops.push('auth:disable');
     },
     async revokeRefreshTokens() {
@@ -209,7 +226,7 @@ describe('deletion runner (same code path as callable + ops script)', () => {
     assert.equal(fakes.getJobData().status, 'complete');
   });
 
-  it('a failed step persists partial progress and leaves the job resumable', async () => {
+  it('a failed step persists the failing phase and leaves the job resumable', async () => {
     const fakes = createFakes();
     fakes.failures.collection = 'conversations';
 
@@ -217,9 +234,12 @@ describe('deletion runner (same code path as callable + ops script)', () => {
 
     const job = fakes.getJobData();
     assert.equal(job.status, 'failed');
-    assert.equal(job.lastStep, 'joined-sessions'); // last step that finished
+    assert.equal(job.lastStep, 'conversations'); // the phase that broke
     assert.equal(job.errorCode, 'unavailable');
     assert.equal(isResumableJob(job), true);
+    // The last COMPLETED step was still durably recorded along the way.
+    const stepWrites = fakes.jobWrites.map((w) => w.lastStep).filter(Boolean);
+    assert.ok(stepWrites.includes('joined-sessions'));
     // The auth user was never deleted on the failed run.
     assert.equal(fakes.ops.includes('auth:deleteUser'), false);
   });
@@ -244,5 +264,138 @@ describe('deletion runner (same code path as callable + ops script)', () => {
 
     assert.equal(fakes.getJobData().status, 'complete');
     assert.equal(fakes.ops.filter((op) => op === 'auth:deleteUser').length, 1);
+  });
+});
+
+describe('full-lifecycle failure persistence', () => {
+  it('a lockAccount failure persists failed status + errorCode on the job', async () => {
+    const fakes = createFakes();
+    fakes.failures.disableAccount = true;
+
+    await assert.rejects(() => fakes.runner.runCleanup(UID), /auth disable failed/);
+
+    const job = fakes.getJobData();
+    assert.equal(job.status, 'failed');
+    assert.equal(job.lastStep, 'lock-account');
+    assert.equal(job.errorCode, 'auth/internal-error');
+    // attemptCount was never incremented — the run died before `running`.
+    assert.equal('attemptCount' in job, false);
+    assert.equal(isResumableJob(job), true);
+  });
+
+  it("beginDeletion's lock phase cannot fail silently", async () => {
+    const fakes = createFakes();
+    fakes.failures.disableAccount = true;
+
+    await assert.rejects(() => fakes.runner.beginDeletion(UID), /auth disable failed/);
+
+    const job = fakes.getJobData();
+    // Intent was recorded, the lock failure landed on the doc, and the job
+    // is resumable — the marker keeps attemptCount at its initial 0.
+    assert.equal(job.status, 'failed');
+    assert.equal(job.lastStep, 'lock-account');
+    assert.equal(job.attemptCount, 0);
+    assert.equal(isResumableJob(job), true);
+  });
+
+  it('an initial running-write failure is persisted without masking the error', async () => {
+    const fakes = createFakes();
+    fakes.failures.jobWriteStatus = 'running';
+
+    await assert.rejects(() => fakes.runner.runCleanup(UID), /job write rejected \(running\)/);
+
+    const job = fakes.getJobData();
+    assert.equal(job.status, 'failed');
+    assert.equal(job.lastStep, 'mark-running');
+    assert.equal(job.errorCode, 'job-write-denied');
+  });
+
+  it('a failure-state write failure does not hide the original error', async () => {
+    const fakes = createFakes();
+    fakes.failures.collection = 'conversations';
+    fakes.failures.jobWriteStatus = 'failed'; // the failure write itself breaks
+
+    // The rejection is the ORIGINAL step error, not the write error.
+    await assert.rejects(() => fakes.runner.runCleanup(UID), /conversations query failed/);
+    // And nothing pretended to succeed: the job never reached 'failed'.
+    assert.notEqual(fakes.getJobData().status, 'failed');
+  });
+
+  it('a retry after a pre-step (lock) failure resumes idempotently to complete', async () => {
+    const fakes = createFakes();
+    fakes.failures.disableAccount = true;
+    await assert.rejects(() => fakes.runner.runCleanup(UID));
+
+    fakes.failures.disableAccount = false;
+    await fakes.runner.runCleanup(UID);
+
+    assert.equal(fakes.getJobData().status, 'complete');
+  });
+});
+
+describe('ops resume script preflight (shared helpers)', () => {
+  const GOOD_UID = 'AbC123_x-9';
+
+  it('rejects empty, padded, path-like, and malformed uids before any Firebase use', () => {
+    for (const bad of [
+      undefined,
+      null,
+      '',
+      '   ',
+      ` ${GOOD_UID}`,
+      `${GOOD_UID} `,
+      'a/b',
+      '../x',
+      'users/aliceUid',
+      'a.b',
+      'a%2Fb',
+      'a b',
+      'x'.repeat(129),
+      42,
+    ]) {
+      assert.equal(isValidDeletionUid(bad), false, `expected invalid: ${String(bad)}`);
+      assert.equal(
+        validateResumeScriptArgs({ uid: bad, projectId: DELETION_PROJECT_ID }).reason,
+        'invalid-uid'
+      );
+    }
+    assert.equal(isValidDeletionUid(GOOD_UID), true);
+    assert.equal(isValidDeletionUid('x'.repeat(128)), true);
+  });
+
+  it('rejects any project other than the pinned studi-b02c3', () => {
+    assert.equal(DELETION_PROJECT_ID, 'studi-b02c3');
+    for (const project of ['studi-prod', 'demo-studi-b02c3', '', undefined]) {
+      assert.deepEqual(validateResumeScriptArgs({ uid: GOOD_UID, projectId: project }), {
+        ok: false,
+        reason: 'wrong-project',
+      });
+    }
+    assert.deepEqual(
+      validateResumeScriptArgs({ uid: GOOD_UID, projectId: DELETION_PROJECT_ID }),
+      { ok: true }
+    );
+  });
+
+  it('job validation: missing, malformed, mismatched, complete, and unknown-status jobs are rejected', () => {
+    assert.equal(validateResumableJob(null, UID).reason, 'missing-job');
+    assert.equal(validateResumableJob('running', UID).reason, 'missing-job');
+    assert.equal(validateResumableJob({ status: 'running' }, UID).reason, 'malformed-job');
+    assert.equal(validateResumableJob({ userId: UID }, UID).reason, 'malformed-job');
+    assert.equal(
+      validateResumableJob({ userId: 'someoneElse', status: 'running' }, UID).reason,
+      'user-mismatch'
+    );
+    assert.equal(
+      validateResumableJob({ userId: UID, status: 'complete' }, UID).reason,
+      'already-complete'
+    );
+    assert.equal(
+      validateResumableJob({ userId: UID, status: 'archived' }, UID).reason,
+      'unknown-status'
+    );
+    for (const status of ['pending', 'running', 'failed']) {
+      assert.deepEqual(validateResumableJob({ userId: UID, status }, UID), { ok: true });
+    }
   });
 });

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -1161,6 +1161,29 @@ describe('session group chat (sessions/{sessionId}/messages)', () => {
     }));
   });
 
+  it('fanout ceiling: exactly 20 participants can chat (legacy, no capacity field)', async () => {
+    // validSession has no capacity — this is the legacy-uncapped shape.
+    const twenty = [ALICE, BOB, ...Array.from({ length: 18 }, (_, i) => `filler${i}`)];
+    await seedChatSession('s20', { participantIds: twenty });
+
+    await assertSucceeds(createSessionChatMessage(ctx(ALICE), ALICE, 's20', 'm1', {
+      senderId: ALICE, text: 'big group, still fine', createdAt: serverTimestamp(),
+    }));
+    await assertSucceeds(getDocs(collection(ctx(BOB), 'sessions', 's20', 'messages')));
+  });
+
+  it('fanout ceiling: 21 participants cannot send (legacy uncapped session)', async () => {
+    const twentyOne = [ALICE, BOB, ...Array.from({ length: 19 }, (_, i) => `filler${i}`)];
+    await seedChatSession('s21', { participantIds: twentyOne });
+
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's21', 'm1', {
+      senderId: BOB, text: 'too many of us', createdAt: serverTimestamp(),
+    }));
+    await assertFails(createSessionChatMessage(ctx(ALICE), ALICE, 's21', 'm2', {
+      senderId: ALICE, text: 'host is capped too', createdAt: serverTimestamp(),
+    }));
+  });
+
   it('leaving the session ends read and send access', async () => {
     // Same shape as seedChatSession but BOB is no longer seated.
     await seed('sessions/s2', validSession(ALICE, {
@@ -1257,6 +1280,28 @@ describe('chat read markers (users/{uid}/reads)', () => {
     await assertFails(getDoc(readRef(ctx(BOB), ALICE)));
     await assertFails(setDoc(readRef(ctx(BOB), ALICE), { lastReadAt: serverTimestamp() }));
     await assertFails(deleteDoc(readRef(ctx(ALICE), ALICE)));
+  });
+});
+
+describe('account deletion jobs (Admin SDK only)', () => {
+  it('clients can never read or write deletion-job docs — not even their own', async () => {
+    await seed(`accountDeletionJobs/${ALICE}`, {
+      userId: ALICE, status: 'running', attemptCount: 1,
+      createdAt: Timestamp.now(), updatedAt: Timestamp.now(), requestedAt: Timestamp.now(),
+    });
+
+    await assertFails(getDoc(doc(ctx(ALICE), 'accountDeletionJobs', ALICE)));
+    await assertFails(updateDoc(doc(ctx(ALICE), 'accountDeletionJobs', ALICE), {
+      status: 'complete',
+    }));
+    await assertFails(deleteDoc(doc(ctx(ALICE), 'accountDeletionJobs', ALICE)));
+    // Nobody can forge a job for themselves or anyone else.
+    await assertFails(setDoc(doc(ctx(BOB), 'accountDeletionJobs', BOB), {
+      userId: BOB, status: 'pending',
+    }));
+    await assertFails(setDoc(doc(ctx(MALLORY), 'accountDeletionJobs', ALICE), {
+      userId: ALICE, status: 'failed',
+    }));
   });
 });
 

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -123,6 +123,14 @@ function updateConversationWithRateLimit(db, uid, conversationId, data) {
   return batch.commit();
 }
 
+// Mirrors sendSessionMessage in lib/firestore.ts: session-chat message +
+// sendMessage rate-limit write in a single batch.
+function createSessionChatMessage(db, uid, sessionId, messageId, message) {
+  const batch = batchWithRateLimit(db, uid, 'sendMessage');
+  batch.set(doc(db, 'sessions', sessionId, 'messages', messageId), message);
+  return batch.commit();
+}
+
 // Mirrors sendDirectMessage in lib/firestore.ts: message + metadata bump +
 // sendMessage rate-limit write in a single batch.
 function clientSendFlow(db, uid, conversationId, messageId, text) {
@@ -1025,6 +1033,150 @@ describe('conversations + messages', () => {
     await assertFails(createMessageWithRateLimit(ctx(ALICE), ALICE, cid, 'm5', {
       senderId: ALICE, text: 'still here', createdAt: serverTimestamp(),
     }));
+  });
+});
+
+// ------------------------------------------- session group chat (PR: group chat)
+describe('session group chat (sessions/{sessionId}/messages)', () => {
+  // ALICE hosts, BOB joined, MALLORY is outside the session.
+  async function seedChatSession(sessionId = 's1') {
+    await seed(`sessions/${sessionId}`, validSession(ALICE, {
+      participantIds: [ALICE, BOB],
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+    }));
+  }
+
+  it('participants read and list messages; outsiders and unverified cannot', async () => {
+    await seedChatSession();
+    await seed('sessions/s1/messages/m1', {
+      senderId: ALICE, text: 'front table', createdAt: Timestamp.now(),
+    });
+
+    await assertSucceeds(getDoc(doc(ctx(ALICE), 'sessions', 's1', 'messages', 'm1')));
+    await assertSucceeds(getDocs(collection(ctx(BOB), 'sessions', 's1', 'messages')));
+    await assertFails(getDoc(doc(ctx(MALLORY), 'sessions', 's1', 'messages', 'm1')));
+    await assertFails(getDocs(collection(ctx(MALLORY), 'sessions', 's1', 'messages')));
+    await assertFails(
+      getDoc(doc(ctx(ALICE, { verified: false }), 'sessions', 's1', 'messages', 'm1'))
+    );
+  });
+
+  it('participant (non-host too) sends with the fresh rate-limit batch', async () => {
+    await seedChatSession();
+    await assertSucceeds(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm1', {
+      senderId: BOB, text: 'running 5 late', createdAt: serverTimestamp(),
+    }));
+    await assertSucceeds(createSessionChatMessage(ctx(ALICE), ALICE, 's1', 'm2', {
+      senderId: ALICE, text: 'no rush', createdAt: serverTimestamp(),
+    }));
+  });
+
+  it('send without the rate-limit batch is denied; too-soon resend is denied', async () => {
+    await seedChatSession();
+    await assertFails(setDoc(doc(ctx(BOB), 'sessions', 's1', 'messages', 'm1'), {
+      senderId: BOB, text: 'no rate limit', createdAt: serverTimestamp(),
+    }));
+    await seed(`rateLimits/${BOB}/actions/sendMessage`, { updatedAt: Timestamp.now() });
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm2', {
+      senderId: BOB, text: 'too soon', createdAt: serverTimestamp(),
+    }));
+  });
+
+  it('non-participants cannot send; sender spoofing is denied', async () => {
+    await seedChatSession();
+    await assertFails(createSessionChatMessage(ctx(MALLORY), MALLORY, 's1', 'm1', {
+      senderId: MALLORY, text: 'intruder', createdAt: serverTimestamp(),
+    }));
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm2', {
+      senderId: ALICE, text: 'spoofed', createdAt: serverTimestamp(),
+    }));
+  });
+
+  it('rejects extra keys, empty and oversized text, forged createdAt', async () => {
+    await seedChatSession();
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm1', {
+      senderId: BOB, senderName: 'Professor X', text: 'hi', createdAt: serverTimestamp(),
+    }));
+    await seed(`rateLimits/${BOB}/actions/sendMessage`, {
+      updatedAt: Timestamp.fromMillis(Date.now() - 10_000),
+    });
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm2', {
+      senderId: BOB, text: '', createdAt: serverTimestamp(),
+    }));
+    await seed(`rateLimits/${BOB}/actions/sendMessage`, {
+      updatedAt: Timestamp.fromMillis(Date.now() - 10_000),
+    });
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm3', {
+      senderId: BOB, text: 'x'.repeat(2001), createdAt: serverTimestamp(),
+    }));
+    await seed(`rateLimits/${BOB}/actions/sendMessage`, {
+      updatedAt: Timestamp.fromMillis(Date.now() - 10_000),
+    });
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm4', {
+      senderId: BOB, text: 'forged clock',
+      createdAt: Timestamp.fromMillis(Date.now() + 86_400_000),
+    }));
+  });
+
+  it('messages are immutable; only the sender may delete', async () => {
+    await seedChatSession();
+    await seed('sessions/s1/messages/m1', {
+      senderId: BOB, text: 'original', createdAt: Timestamp.now(),
+    });
+
+    await assertFails(updateDoc(doc(ctx(BOB), 'sessions', 's1', 'messages', 'm1'), {
+      text: 'edited',
+    }));
+    await assertFails(deleteDoc(doc(ctx(ALICE), 'sessions', 's1', 'messages', 'm1')));
+    await assertSucceeds(deleteDoc(doc(ctx(BOB), 'sessions', 's1', 'messages', 'm1')));
+  });
+
+  it('leaving the session ends read and send access', async () => {
+    // Same shape as seedChatSession but BOB is no longer seated.
+    await seed('sessions/s2', validSession(ALICE, {
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+    }));
+    await seed('sessions/s2/messages/m1', {
+      senderId: ALICE, text: 'anyone here?', createdAt: Timestamp.now(),
+    });
+
+    await assertFails(getDoc(doc(ctx(BOB), 'sessions', 's2', 'messages', 'm1')));
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's2', 'm2', {
+      senderId: BOB, text: 'i left but…', createdAt: serverTimestamp(),
+    }));
+  });
+});
+
+describe('chat read markers (users/{uid}/reads)', () => {
+  const readRef = (db, uid, threadId = 's1') => doc(db, 'users', uid, 'reads', threadId);
+
+  it('owner writes lastReadAt at server time, and can re-mark later', async () => {
+    await assertSucceeds(setDoc(readRef(ctx(ALICE), ALICE), {
+      lastReadAt: serverTimestamp(),
+    }));
+    await assertSucceeds(setDoc(readRef(ctx(ALICE), ALICE), {
+      lastReadAt: serverTimestamp(),
+    }));
+    await assertSucceeds(getDoc(readRef(ctx(ALICE), ALICE)));
+  });
+
+  it('rejects forged timestamps and extra keys', async () => {
+    await assertFails(setDoc(readRef(ctx(ALICE), ALICE), {
+      lastReadAt: Timestamp.fromMillis(Date.now() + 86_400_000),
+    }));
+    await assertFails(setDoc(readRef(ctx(ALICE), ALICE), {
+      lastReadAt: serverTimestamp(), sneaky: true,
+    }));
+  });
+
+  it('only the owner reads or writes; delete is denied', async () => {
+    await seed(`users/${ALICE}/reads/s1`, { lastReadAt: Timestamp.now() });
+
+    await assertFails(getDoc(readRef(ctx(BOB), ALICE)));
+    await assertFails(setDoc(readRef(ctx(BOB), ALICE), { lastReadAt: serverTimestamp() }));
+    await assertFails(deleteDoc(readRef(ctx(ALICE), ALICE)));
   });
 });
 

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -1039,11 +1039,12 @@ describe('conversations + messages', () => {
 // ------------------------------------------- session group chat (PR: group chat)
 describe('session group chat (sessions/{sessionId}/messages)', () => {
   // ALICE hosts, BOB joined, MALLORY is outside the session.
-  async function seedChatSession(sessionId = 's1') {
+  async function seedChatSession(sessionId = 's1', overrides = {}) {
     await seed(`sessions/${sessionId}`, validSession(ALICE, {
       participantIds: [ALICE, BOB],
       createdAt: Timestamp.now(),
       updatedAt: Timestamp.now(),
+      ...overrides,
     }));
   }
 
@@ -1119,7 +1120,7 @@ describe('session group chat (sessions/{sessionId}/messages)', () => {
     }));
   });
 
-  it('messages are immutable; only the sender may delete', async () => {
+  it('messages are fully immutable — no client edits or deletes, even by the sender', async () => {
     await seedChatSession();
     await seed('sessions/s1/messages/m1', {
       senderId: BOB, text: 'original', createdAt: Timestamp.now(),
@@ -1128,8 +1129,36 @@ describe('session group chat (sessions/{sessionId}/messages)', () => {
     await assertFails(updateDoc(doc(ctx(BOB), 'sessions', 's1', 'messages', 'm1'), {
       text: 'edited',
     }));
+    await assertFails(deleteDoc(doc(ctx(BOB), 'sessions', 's1', 'messages', 'm1')));
     await assertFails(deleteDoc(doc(ctx(ALICE), 'sessions', 's1', 'messages', 'm1')));
-    await assertSucceeds(deleteDoc(doc(ctx(BOB), 'sessions', 's1', 'messages', 'm1')));
+    await assertFails(deleteDoc(doc(ctx(MALLORY), 'sessions', 's1', 'messages', 'm1')));
+  });
+
+  it('cancellation makes the chat read-only for retained participants', async () => {
+    await seedChatSession();
+    // Before cancellation the participant can send…
+    await assertSucceeds(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm1', {
+      senderId: BOB, text: 'see you there', createdAt: serverTimestamp(),
+    }));
+
+    await seedChatSession('s1', { status: 'cancelled' });
+    // …after it, the same participant (and the host) cannot send…
+    await seed(`rateLimits/${BOB}/actions/sendMessage`, {
+      updatedAt: Timestamp.fromMillis(Date.now() - 10_000),
+    });
+    await assertFails(createSessionChatMessage(ctx(BOB), BOB, 's1', 'm2', {
+      senderId: BOB, text: 'anyone still going?', createdAt: serverTimestamp(),
+    }));
+    await assertFails(createSessionChatMessage(ctx(ALICE), ALICE, 's1', 'm3', {
+      senderId: ALICE, text: 'sorry all', createdAt: serverTimestamp(),
+    }));
+    // …but retained participants keep the history, and outsiders still get nothing.
+    await assertSucceeds(getDoc(doc(ctx(BOB), 'sessions', 's1', 'messages', 'm1')));
+    await assertSucceeds(getDocs(collection(ctx(ALICE), 'sessions', 's1', 'messages')));
+    await assertFails(getDoc(doc(ctx(MALLORY), 'sessions', 's1', 'messages', 'm1')));
+    await assertFails(createSessionChatMessage(ctx(MALLORY), MALLORY, 's1', 'm4', {
+      senderId: MALLORY, text: 'intruder', createdAt: serverTimestamp(),
+    }));
   });
 
   it('leaving the session ends read and send access', async () => {
@@ -1152,7 +1181,18 @@ describe('session group chat (sessions/{sessionId}/messages)', () => {
 describe('chat read markers (users/{uid}/reads)', () => {
   const readRef = (db, uid, threadId = 's1') => doc(db, 'users', uid, 'reads', threadId);
 
-  it('owner writes lastReadAt at server time, and can re-mark later', async () => {
+  // Markers must point at a real thread the owner belongs to.
+  async function seedOwnSession(sessionId = 's1', overrides = {}) {
+    await seed(`sessions/${sessionId}`, validSession(BOB, {
+      participantIds: [BOB, ALICE],
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+      ...overrides,
+    }));
+  }
+
+  it('owner marks a session thread they belong to, and can re-mark later', async () => {
+    await seedOwnSession();
     await assertSucceeds(setDoc(readRef(ctx(ALICE), ALICE), {
       lastReadAt: serverTimestamp(),
     }));
@@ -1162,7 +1202,46 @@ describe('chat read markers (users/{uid}/reads)', () => {
     await assertSucceeds(getDoc(readRef(ctx(ALICE), ALICE)));
   });
 
+  it('owner marks a DM conversation thread they belong to', async () => {
+    const cid = convoId(ALICE, BOB);
+    await seed(`conversations/${cid}`, {
+      ...validConversation(ALICE, BOB),
+      createdAt: Timestamp.now(), updatedAt: Timestamp.now(),
+      lastMessageAt: Timestamp.now(),
+    });
+    await assertSucceeds(setDoc(readRef(ctx(ALICE), ALICE, cid), {
+      lastReadAt: serverTimestamp(),
+    }));
+  });
+
+  it('rejects junk thread ids that name no session or conversation', async () => {
+    await assertFails(setDoc(readRef(ctx(ALICE), ALICE, 'no-such-thread'), {
+      lastReadAt: serverTimestamp(),
+    }));
+  });
+
+  it('rejects threads that do not include the owner', async () => {
+    // A session ALICE is not part of…
+    await seed('sessions/others', validSession(BOB, {
+      createdAt: Timestamp.now(), updatedAt: Timestamp.now(),
+    }));
+    await assertFails(setDoc(readRef(ctx(ALICE), ALICE, 'others'), {
+      lastReadAt: serverTimestamp(),
+    }));
+    // …and a conversation between two other people.
+    const cid = convoId(BOB, MALLORY);
+    await seed(`conversations/${cid}`, {
+      ...validConversation(BOB, MALLORY),
+      createdAt: Timestamp.now(), updatedAt: Timestamp.now(),
+      lastMessageAt: Timestamp.now(),
+    });
+    await assertFails(setDoc(readRef(ctx(ALICE), ALICE, cid), {
+      lastReadAt: serverTimestamp(),
+    }));
+  });
+
   it('rejects forged timestamps and extra keys', async () => {
+    await seedOwnSession();
     await assertFails(setDoc(readRef(ctx(ALICE), ALICE), {
       lastReadAt: Timestamp.fromMillis(Date.now() + 86_400_000),
     }));
@@ -1172,6 +1251,7 @@ describe('chat read markers (users/{uid}/reads)', () => {
   });
 
   it('only the owner reads or writes; delete is denied', async () => {
+    await seedOwnSession();
     await seed(`users/${ALICE}/reads/s1`, { lastReadAt: Timestamp.now() });
 
     await assertFails(getDoc(readRef(ctx(BOB), ALICE)));

--- a/tests/notification-validation.test.mjs
+++ b/tests/notification-validation.test.mjs
@@ -12,6 +12,7 @@ const {
   BODY_MAX_LENGTH,
   TITLE_MAX_LENGTH,
   dmNotificationId,
+  groupMessageNotificationId,
   isAllowedNotificationUrl,
   normalizeNotificationPayload,
   reminderNotificationId,
@@ -33,10 +34,21 @@ function validPayload(overrides = {}) {
 }
 
 describe('notification URL allowlist', () => {
-  it('accepts the three internal route shapes', () => {
+  it('accepts the four internal route shapes', () => {
     assert.equal(isAllowedNotificationUrl('/notifications'), true);
     assert.equal(isAllowedNotificationUrl(`/conversation/${CONVO}`), true);
     assert.equal(isAllowedNotificationUrl('/session/AbC123_x-9'), true);
+    assert.equal(isAllowedNotificationUrl('/session-chat/AbC123_x-9'), true);
+  });
+
+  it('holds /session-chat to the same segment rules as the other routes', () => {
+    assert.equal(isAllowedNotificationUrl('/session-chat/..'), false);
+    assert.equal(isAllowedNotificationUrl('/session-chat/../admin'), false);
+    assert.equal(isAllowedNotificationUrl('/session-chat/a%2Fb'), false);
+    assert.equal(isAllowedNotificationUrl('/session-chat/'), false);
+    assert.equal(isAllowedNotificationUrl('/session-chat'), false);
+    assert.equal(isAllowedNotificationUrl('/session-chat/a/b'), false);
+    assert.equal(isAllowedNotificationUrl(`/session-chat/${'a'.repeat(201)}`), false);
   });
 
   it('rejects traversal and dot segments', () => {
@@ -183,6 +195,25 @@ describe('idempotent record IDs (CloudEvent-keyed)', () => {
       reminderNotificationId('s1', 'aliceUid', start),
       reminderNotificationId('s2', 'aliceUid', start)
     );
+  });
+
+  it('group messages: retries dedupe, new messages notify, sessions never collide', () => {
+    // Same CloudEvent delivered twice (retry) → identical ID.
+    assert.equal(
+      groupMessageNotificationId('s1', 'event-1'),
+      groupMessageNotificationId('s1', 'event-1')
+    );
+    // Every new message is a new event → distinct IDs.
+    assert.notEqual(
+      groupMessageNotificationId('s1', 'event-1'),
+      groupMessageNotificationId('s1', 'event-2')
+    );
+    // Same event ID string under another session can never collide.
+    assert.notEqual(
+      groupMessageNotificationId('s1', 'event-1'),
+      groupMessageNotificationId('s2', 'event-1')
+    );
+    assert.equal(/^[A-Za-z0-9_-]+$/.test(groupMessageNotificationId('a/b', 'e.v')), true);
   });
 
   it('sanitizes unexpected characters out of doc IDs', () => {

--- a/tests/notification-validation.test.mjs
+++ b/tests/notification-validation.test.mjs
@@ -10,12 +10,14 @@ import validation from '../functions/notification-validation.js';
 
 const {
   BODY_MAX_LENGTH,
+  MAX_GROUP_CHAT_PARTICIPANTS,
   TITLE_MAX_LENGTH,
   blockPairIdsFor,
   dmNotificationId,
   filterBlockedRecipients,
   groupMessageNotificationId,
   isAllowedNotificationUrl,
+  isWithinGroupChatFanoutLimit,
   normalizeNotificationPayload,
   reminderNotificationId,
   sessionEventNotificationId,
@@ -266,5 +268,28 @@ describe('group-message block filtering (server-side)', () => {
       filterBlockedRecipients(SENDER, RECIPIENTS, blocks),
       ['bobUid', 'caraUid']
     );
+  });
+});
+
+describe('group-chat fanout ceiling', () => {
+  // Judged on the actual participant count, never the optional capacity
+  // field — a legacy uncapped session is bounded by the same ceiling. The
+  // same 20 is hardcoded in firestore.rules (messages create) and mirrored
+  // in lib/firestore.ts.
+  it('a full 20-participant session (legacy or capped) fans out', () => {
+    assert.equal(MAX_GROUP_CHAT_PARTICIPANTS, 20);
+    assert.equal(isWithinGroupChatFanoutLimit(20), true);
+    assert.equal(isWithinGroupChatFanoutLimit(2), true);
+  });
+
+  it('21 participants (legacy uncapped session) do not fan out', () => {
+    assert.equal(isWithinGroupChatFanoutLimit(21), false);
+    assert.equal(isWithinGroupChatFanoutLimit(500), false);
+  });
+
+  it('non-integer counts never pass', () => {
+    assert.equal(isWithinGroupChatFanoutLimit(Number.NaN), false);
+    assert.equal(isWithinGroupChatFanoutLimit('20'), false);
+    assert.equal(isWithinGroupChatFanoutLimit(undefined), false);
   });
 });

--- a/tests/notification-validation.test.mjs
+++ b/tests/notification-validation.test.mjs
@@ -11,7 +11,9 @@ import validation from '../functions/notification-validation.js';
 const {
   BODY_MAX_LENGTH,
   TITLE_MAX_LENGTH,
+  blockPairIdsFor,
   dmNotificationId,
+  filterBlockedRecipients,
   groupMessageNotificationId,
   isAllowedNotificationUrl,
   normalizeNotificationPayload,
@@ -219,5 +221,50 @@ describe('idempotent record IDs (CloudEvent-keyed)', () => {
   it('sanitizes unexpected characters out of doc IDs', () => {
     const id = dmNotificationId('a/b', 'e.v/t');
     assert.equal(/^[A-Za-z0-9_-]+$/.test(id), true);
+  });
+});
+
+describe('group-message block filtering (server-side)', () => {
+  // onSessionMessageCreated removes blocked recipients BEFORE notifyUser()
+  // runs, so a filtered recipient gets neither the persistent record nor the
+  // push — and since the filter takes no preference input, no
+  // notificationPrefs value can resurrect a blocked notification. (Prefs are
+  // applied later, inside notifyUser, and only ever suppress the push.)
+  const SENDER = 'senderUid';
+  const RECIPIENTS = ['bobUid', 'caraUid', 'danUid'];
+
+  it('returns both block-doc directions for a pair', () => {
+    assert.deepEqual(blockPairIdsFor('a', 'b'), ['a__b', 'b__a']);
+  });
+
+  it('sender-blocked-recipient is excluded — no record, no push', () => {
+    const blocks = new Set(['senderUid__bobUid']); // sender blocked bob
+    assert.deepEqual(
+      filterBlockedRecipients(SENDER, RECIPIENTS, blocks),
+      ['caraUid', 'danUid']
+    );
+  });
+
+  it('recipient-blocked-sender is excluded — no record, no push', () => {
+    const blocks = new Set(['caraUid__senderUid']); // cara blocked the sender
+    assert.deepEqual(
+      filterBlockedRecipients(SENDER, RECIPIENTS, blocks),
+      ['bobUid', 'danUid']
+    );
+  });
+
+  it('unrelated participants still notify; blocks between recipients are irrelevant', () => {
+    // bob and cara blocked each other — neither is blocked against the sender.
+    const blocks = new Set(['bobUid__caraUid', 'caraUid__bobUid']);
+    assert.deepEqual(filterBlockedRecipients(SENDER, RECIPIENTS, blocks), RECIPIENTS);
+  });
+
+  it('no blocks means everyone stays; both directions at once still exclude once', () => {
+    assert.deepEqual(filterBlockedRecipients(SENDER, RECIPIENTS, new Set()), RECIPIENTS);
+    const blocks = new Set(['senderUid__danUid', 'danUid__senderUid']);
+    assert.deepEqual(
+      filterBlockedRecipients(SENDER, RECIPIENTS, blocks),
+      ['bobUid', 'caraUid']
+    );
   });
 });


### PR DESCRIPTION
## What

Session-scoped group chat per the approved architecture: `sessions/{sessionId}/messages`, participants-only, fully integrated with the PR #51 notification pipeline. The 1:1 DM architecture is untouched.

> **Rev 2** (`6a4576d`): cancelled sessions read-only, server-side block filtering, immutable messages, bounded/resumable deletion, validated read markers.
> **Rev 3** (`65bdfba`): explicit deletion-job state machine (no more inferring intent from `auth.disabled`), ops resume path, and a hard 20-participant group-chat fanout ceiling.
> **Rev 4** (`85e6e53`): hardened ops resume script (strict uid validation, project pinned to `studi-b02c3`, job-doc validation via shared helpers) and full-lifecycle failure persistence in the deletion runner (lock/running-write/steps/auth-delete/complete-write all land on the job doc as `status: failed` + failing phase + bounded `errorCode`; a failure-write failure logs loudly without masking the original error). Deletion unit suite now 19 passing.

## Data model & rules

- **Messages** — `sessions/{sessionId}/messages/{messageId}`, DM message shape (`senderId`, `text` 1–2000, `createdAt == request.time`). Create requires session `status in [open, full]`, **`participantIds.size() <= 20`** (fanout ceiling), membership, sender-matching auth, and the fresh `sendMessage` rate-limit batch. Read is participant-only; **update and delete denied for everyone** — cleanup is Admin-only.
- **Unread markers** — `users/{uid}/reads/{threadId}`, owner-only, `lastReadAt == request.time`, and `threadId` must name an existing session or DM conversation containing the owner (≤2 extra reads per write).
- **Session metadata** — CF-only `lastMessageAt`/`lastMessageSenderId`, never content.
- **`accountDeletionJobs/{uid}`** — Admin SDK only; explicit rules match denies all client read/write (tested).

## Group-chat fanout ceiling (Rev 3, High 2)

`MAX_GROUP_CHAT_PARTICIPANTS = 20`, judged on the **actual `participantIds.length`**, never the optional capacity field — so legacy uncapped sessions can't force unbounded fanout. One ceiling, three enforcement points, cross-referenced to change together:

- **Rules**: message create denies when `participantIds.size() > 20`.
- **Client**: `isGroupChatAvailable()` — an oversized session renders the chat read-only with "Group chat is unavailable for sessions with more than 20 people.", disabled composer, no retry, no unread dot, and the Session Details card says so. History (from when the session was ≤20) stays readable; nobody is silently subset-notified while others chat.
- **CF**: `onSessionMessageCreated` returns before metadata + notifications when the count exceeds the limit (defense-in-depth for races/Admin writes).

**Exact read cost: at most 38 block-doc reads per message** — full 20-participant session, sender excluded → 19 recipients × 2 directions, one batched `getAll`. Both-direction block filtering still runs before any record/push is created.

## Account deletion — explicit intent + real ops resume (Rev 3, High 1 + Medium)

**Job schema** — `accountDeletionJobs/{uid}`: `userId`, `status: pending | running | complete | failed`, `requestedAt`, `createdAt`, `updatedAt`, `lastStep`, `attemptCount`, `errorCode` (bounded 64 chars, non-sensitive).

**Initial request flow** — verify recent auth (≤5 min) → rate limit → **write the job marker (intent on record) → disable the account → revoke refresh tokens → run cleanup**. The marker is written before anything is disabled or destroyed.

**Resume authorization** — `classifyDeletionRequest()` (pure, unit-tested): resume only when an active (`pending|running|failed`) job exists **and** belongs to the caller. `auth.disabled` alone proves nothing: a **moderation-disabled account without a job is rejected (`permission-denied`) and never enters cleanup**. Completed jobs reject — they can never rerun destructively. A job owned by another uid rejects.

**Ops resume path** — `scripts/resume-account-deletion.js` (service-account / ADC): `GOOGLE_CLOUD_PROJECT=<project> node scripts/resume-account-deletion.js <uid>`. Refuses without an active job (ops cannot delete a merely-disabled account either), then drives the **exact same runner** the callable uses. Covers jobs that outlive the user's ≤1 h token window.

**Progress & idempotency** — the runner (extracted to `functions/account-deletion.js`, dependency-injected) re-locks the account, marks `running` + increments `attemptCount`, persists `lastStep` after each of 7 ordered idempotent steps (each drains its query in 100-doc pages that strictly shrink), deletes the Auth user **only after all data cleanup**, and writes `complete` only after that. A mid-run failure writes `status: failed` + `errorCode` durably (visible for ops) and stays resumable; `lastStep` is diagnostics, not a skip cursor — resumes re-run every step (no-ops on clean data) rather than trusting a pointer. `auth/user-not-found` on re-delete is swallowed, so retries never corrupt state.

## Also in this PR (Rev 1–2 recap)

- Chat screen reusing DM styling; optimistic sends with same-ID retry; cursor pagination; auto-open after join; unread dot on Session Details; cancelled sessions read-only end-to-end (rules + UI + live-cancel detection via permission-denied reload); `/session-chat/{id}` in the strict URL allowlist (server + client); account deletion cleans hosted-session trees + sent messages (`messages.senderId` COLLECTION_GROUP fieldOverride — deploy step, not deployed); analytics `session_chat_opened` / `group_message_sent`.

## Tests

- **Rules (+3, 86 passing)**: 20-participant legacy (no capacity) session sends fine; 21-participant legacy session denied for member and host; deletion-job docs unreadable/unwritable by owner, self-forgers, and third parties. (Existing: cancellation read-only, immutability, read-marker thread validation, block/spoof/rate-limit branches.)
- **Deletion unit suite (NEW, `npm run test:deletion`, 11 passing)** via injected fakes driving the real runner: moderation-disabled-without-job never enters cleanup; fresh vs resume vs reject-complete vs reject-not-owner classification; **marker written before disable**; steps run in order with durable per-step progress; auth deleted last, `complete` after; failed step persists `lastStep`/`errorCode` and stays resumable; retry resumes with no request context (the ops path); repeated runs idempotent after the auth user is gone; bounded error codes.
- **Notification unit tests (+3, 26 passing)**: ceiling passes at 20, fails at 21/500, rejects non-integers — plus the existing block-filter and URL/ID suites.
- Remaining live QA (documented): one end-to-end deletion against a dev project — the repo has no CF integration harness; everything unit-testable was extracted and tested.

## Validation

`npx tsc --noEmit` ✅ · `npm run lint` ✅ · `npm run rules:test` ✅ 86 passing · `npm run test:notifications` ✅ 26 passing · `npm run test:deletion` ✅ 19 passing · `npx expo export --platform web` ✅ · `node --check` on `functions/index.js`, `functions/notification-validation.js`, `functions/account-deletion.js`, `scripts/resume-account-deletion.js` ✅ (all re-run for Rev 4)

Not deployed. Not merged. No new product scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
