### PR TITLE
fix: stop AIRMap child-index crash by making MapView children deterministic

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -523,12 +523,13 @@ export default function StudyLocationsScreen() {
 
       <View style={styles.mapAndSheet}>
         <CampusMap
-          locations={filteredLocations}
+          locations={locations}
           onOpenCampusMap={openCampusMap}
           onSelectLocation={selectLocation}
           selectedLocationId={selectedLocationId}
           sessionTimingByLocation={sessionTimingByLocation}
           sessionsByLocation={sessionsByLocation}
+          visibleLocationIds={visibleLocationIds}
         />
 
         {filteredLocations.length > 0 ? (

--- a/components/campus-map.native.tsx
+++ b/components/campus-map.native.tsx
@@ -37,11 +37,6 @@ const CAMPUS_REGION = {
 const MAP_PADDING = { bottom: 24, left: 8, right: 8, top: 8 };
 const FIT_PADDING = { bottom: 64, left: 44, right: 44, top: 64 };
 
-// How long a marker keeps tracksViewChanges on after its appearance changes.
-// Long enough for iOS to re-snapshot the custom view, short enough to keep
-// the map cheap while idle.
-const TRACK_APPEARANCE_MS = 350;
-
 function markerCoordinate(location: StudyLocation): LatLng | null {
   if (!isRenderableCoordinate(location.coordinates)) {
     return null;
@@ -81,10 +76,14 @@ type CampusMapMarkerProps = {
   timing: MapSessionTiming;
 };
 
-// Markers stay mounted for the whole location set; search and filters only
-// flip isVisible/appearance. AIRMap's native child array must never see
-// churn from filtering — remount-by-key is what crashed the map under the
-// Fabric interop, so selection/timing may only change props here.
+// Markers stay mounted for the whole location set; search, filters, and
+// selection only flip scalar props and styles. Under the Fabric legacy
+// interop, AIRMap's native child array must never see structural churn:
+// remount-by-key crashed it, and so does a changing zIndex — Fabric sorts
+// absolute-positioned siblings by zIndex and emits remove/insert mutations
+// to reorder them (verified via crash reports; see PR #54). So: no zIndex,
+// no key churn, no conditional children, and an identical subtree shape in
+// every state.
 const CampusMapMarker = memo(function CampusMapMarker({
   coordinate,
   isSelected,
@@ -96,16 +95,6 @@ const CampusMapMarker = memo(function CampusMapMarker({
   timing,
 }: CampusMapMarkerProps) {
   const timingColor = getTimingColor(timing, palette.tint, palette.icon);
-  const [tracksViewChanges, setTracksViewChanges] = useState(true);
-
-  // iOS snapshots custom marker views once tracksViewChanges turns off, so
-  // pulse it back on whenever the rendered appearance changes.
-  useEffect(() => {
-    setTracksViewChanges(true);
-    const timer = setTimeout(() => setTracksViewChanges(false), TRACK_APPEARANCE_MS);
-
-    return () => clearTimeout(timer);
-  }, [isSelected, isVisible, timingColor, palette.surface, palette.border]);
 
   const handlePress = useCallback(() => {
     if (isVisible) {
@@ -122,10 +111,14 @@ const CampusMapMarker = memo(function CampusMapMarker({
       identifier={location.locationId}
       onPress={handlePress}
       opacity={isVisible ? 1 : 0}
-      tracksViewChanges={tracksViewChanges}
-      zIndex={isSelected ? 4 : sessionCount > 0 ? 3 : 2}>
-      <View style={styles.markerTouchTarget}>
+      tracksViewChanges>
+      {/* collapsable={false} keeps Fabric from flattening/unflattening these
+          views as their styles change, so the marker's native subtree shape
+          is identical in every state. tracksViewChanges stays constant true
+          so style updates render without timer-driven prop churn. */}
+      <View collapsable={false} style={styles.markerTouchTarget}>
         <View
+          collapsable={false}
           style={[
             styles.markerHalo,
             {
@@ -133,6 +126,7 @@ const CampusMapMarker = memo(function CampusMapMarker({
             },
           ]}>
           <View
+            collapsable={false}
             style={[
               styles.markerCore,
               isSelected && styles.markerCoreSelected,
@@ -143,6 +137,7 @@ const CampusMapMarker = memo(function CampusMapMarker({
               },
             ]}>
             <View
+              collapsable={false}
               style={[
                 styles.markerStatus,
                 isSelected && styles.markerStatusSelected,
@@ -189,6 +184,35 @@ export function CampusMap({
     () => markers.filter((marker) => visibleLocationIds.has(marker.location.locationId)),
     [markers, visibleLocationIds]
   );
+
+  useEffect(() => {
+    if (!__DEV__) {
+      return;
+    }
+
+    const seenKeys = new Set<string>();
+
+    for (const { canonicalId, location } of markers) {
+      if (seenKeys.has(canonicalId)) {
+        console.error(
+          `[CampusMap] Duplicate marker key "${canonicalId}" (source id "${location.locationId}"). ` +
+            'Marker keys must be unique or AIRMap child indexes diverge.'
+        );
+      }
+      seenKeys.add(canonicalId);
+    }
+
+    console.log(
+      '[CampusMap] markers',
+      markers.map(({ canonicalId, coordinate, location }) => ({
+        key: canonicalId,
+        sourceId: location.locationId,
+        latitude: coordinate.latitude,
+        longitude: coordinate.longitude,
+        selected: selectedLocationId === location.locationId,
+      }))
+    );
+  }, [markers, selectedLocationId]);
 
   const fitVisibleMarkers = useCallback(() => {
     if (!isMapReady || visibleMarkers.length === 0) {

--- a/components/campus-map.native.tsx
+++ b/components/campus-map.native.tsx
@@ -1,6 +1,6 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import MapView, { Marker, type LatLng } from 'react-native-maps';
 
 import {
@@ -15,8 +15,10 @@ import { useColorScheme } from '@/hooks/use-color-scheme';
 import { canonicalStudyLocationId } from '@/lib/catalog';
 import type { StudyLocation } from '@/lib/firestore';
 import {
+  ANDROID_TRACK_REFRESH_MS,
   buildCampusMarkerEntries,
   isRenderableCoordinate,
+  markerAppearanceSignature,
   planCampusMarkers,
 } from '@/lib/map-markers';
 import type { MapSessionTiming } from '@/components/campus-map.types';
@@ -88,6 +90,8 @@ type CampusMapMarkerProps = {
 // to reorder them (verified via crash reports; see PR #54). So: no zIndex,
 // no key churn, no conditional children, and an identical subtree shape in
 // every state.
+const IS_ANDROID = Platform.OS === 'android';
+
 const CampusMapMarker = memo(function CampusMapMarker({
   coordinate,
   isSelected,
@@ -99,6 +103,36 @@ const CampusMapMarker = memo(function CampusMapMarker({
   timing,
 }: CampusMapMarkerProps) {
   const timingColor = getTimingColor(timing, palette.tint, palette.icon);
+
+  // Android redraws tracked custom markers on a ~40 ms loop, so tracking is
+  // only pulsed on for a bounded window when the rendered appearance (or the
+  // native position, e.g. a hidden marker relocating) actually changes, then
+  // switched back off. iOS Apple Maps ignores the prop entirely, so it stays
+  // a constant false there. The toggle is a prop update only — same key,
+  // same child position, identical subtree.
+  const appearanceSignature = markerAppearanceSignature({
+    isSelected,
+    isVisible,
+    latitude: coordinate.latitude,
+    longitude: coordinate.longitude,
+    sessionCount,
+    theme: `${palette.surface}|${palette.border}|${palette.tint}|${palette.icon}`,
+    timing,
+  });
+  const [tracksViewChanges, setTracksViewChanges] = useState(IS_ANDROID);
+
+  useEffect(() => {
+    if (!IS_ANDROID) {
+      return;
+    }
+
+    setTracksViewChanges(true);
+    const timer = setTimeout(() => setTracksViewChanges(false), ANDROID_TRACK_REFRESH_MS);
+
+    // Restarts the window on rapid changes and prevents any state update
+    // after unmount — the pending timer is always cleared first.
+    return () => clearTimeout(timer);
+  }, [appearanceSignature]);
 
   const handlePress = useCallback(() => {
     // Hidden markers are relocated off-campus and never selectable, but keep
@@ -117,12 +151,10 @@ const CampusMapMarker = memo(function CampusMapMarker({
       identifier={location.locationId}
       onPress={handlePress}
       opacity={isVisible ? 1 : 0}
-      tracksViewChanges>
+      tracksViewChanges={tracksViewChanges}>
       {/* collapsable={false} keeps Fabric from flattening/unflattening these
           views as their styles change, so the marker's native subtree shape
-          is identical in every state. tracksViewChanges is inert on the
-          Apple provider (not implemented in AIRMapMarker); it stays a
-          constant so there is no timer-driven prop churn on any platform. */}
+          is identical in every state. */}
       <View collapsable={false} style={styles.markerTouchTarget}>
         <View
           collapsable={false}

--- a/components/campus-map.native.tsx
+++ b/components/campus-map.native.tsx
@@ -1,5 +1,5 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import MapView, { Marker, type LatLng } from 'react-native-maps';
 
@@ -12,7 +12,9 @@ import {
   TypeScale,
 } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { canonicalStudyLocationId } from '@/lib/catalog';
 import type { StudyLocation } from '@/lib/firestore';
+import { buildCampusMarkerEntries, isRenderableCoordinate } from '@/lib/map-markers';
 import type { MapSessionTiming } from '@/components/campus-map.types';
 
 type CampusMapProps = {
@@ -22,6 +24,7 @@ type CampusMapProps = {
   selectedLocationId: string | null;
   sessionTimingByLocation: Map<string, MapSessionTiming>;
   sessionsByLocation: Map<string, number>;
+  visibleLocationIds: Set<string>;
 };
 
 const CAMPUS_REGION = {
@@ -34,24 +37,13 @@ const CAMPUS_REGION = {
 const MAP_PADDING = { bottom: 24, left: 8, right: 8, top: 8 };
 const FIT_PADDING = { bottom: 64, left: 44, right: 44, top: 64 };
 
-function isUsableCoordinate(coordinate: StudyLocation['coordinates'] | undefined) {
-  const latitude = coordinate?.latitude;
-  const longitude = coordinate?.longitude;
-
-  if (typeof latitude !== 'number' || typeof longitude !== 'number') {
-    return false;
-  }
-
-  return (
-    Number.isFinite(latitude) &&
-    Number.isFinite(longitude) &&
-    Math.abs(latitude) <= 90 &&
-    Math.abs(longitude) <= 180
-  );
-}
+// How long a marker keeps tracksViewChanges on after its appearance changes.
+// Long enough for iOS to re-snapshot the custom view, short enough to keep
+// the map cheap while idle.
+const TRACK_APPEARANCE_MS = 350;
 
 function markerCoordinate(location: StudyLocation): LatLng | null {
-  if (!isUsableCoordinate(location.coordinates)) {
+  if (!isRenderableCoordinate(location.coordinates)) {
     return null;
   }
 
@@ -78,6 +70,92 @@ function getTimingColor(timing: MapSessionTiming, tint: string, icon: string) {
   }
 }
 
+type CampusMapMarkerProps = {
+  coordinate: LatLng;
+  isSelected: boolean;
+  isVisible: boolean;
+  location: StudyLocation;
+  onSelectLocation: (locationId: string) => void;
+  palette: (typeof Colors)[keyof typeof Colors];
+  sessionCount: number;
+  timing: MapSessionTiming;
+};
+
+// Markers stay mounted for the whole location set; search and filters only
+// flip isVisible/appearance. AIRMap's native child array must never see
+// churn from filtering — remount-by-key is what crashed the map under the
+// Fabric interop, so selection/timing may only change props here.
+const CampusMapMarker = memo(function CampusMapMarker({
+  coordinate,
+  isSelected,
+  isVisible,
+  location,
+  onSelectLocation,
+  palette,
+  sessionCount,
+  timing,
+}: CampusMapMarkerProps) {
+  const timingColor = getTimingColor(timing, palette.tint, palette.icon);
+  const [tracksViewChanges, setTracksViewChanges] = useState(true);
+
+  // iOS snapshots custom marker views once tracksViewChanges turns off, so
+  // pulse it back on whenever the rendered appearance changes.
+  useEffect(() => {
+    setTracksViewChanges(true);
+    const timer = setTimeout(() => setTracksViewChanges(false), TRACK_APPEARANCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [isSelected, isVisible, timingColor, palette.surface, palette.border]);
+
+  const handlePress = useCallback(() => {
+    if (isVisible) {
+      onSelectLocation(location.locationId);
+    }
+  }, [isVisible, location.locationId, onSelectLocation]);
+
+  return (
+    <Marker
+      anchor={{ x: 0.5, y: 0.5 }}
+      accessibilityElementsHidden={!isVisible}
+      accessibilityLabel={`${location.name}, ${sessionCount} upcoming ${sessionCount === 1 ? 'session' : 'sessions'}, ${timing === 'live' ? 'happening now' : timing === 'soon' ? 'starting soon' : timing === 'later' ? 'later' : 'no scheduled sessions'}`}
+      coordinate={coordinate}
+      identifier={location.locationId}
+      onPress={handlePress}
+      opacity={isVisible ? 1 : 0}
+      tracksViewChanges={tracksViewChanges}
+      zIndex={isSelected ? 4 : sessionCount > 0 ? 3 : 2}>
+      <View style={styles.markerTouchTarget}>
+        <View
+          style={[
+            styles.markerHalo,
+            {
+              backgroundColor: isSelected ? `${timingColor}20` : 'transparent',
+            },
+          ]}>
+          <View
+            style={[
+              styles.markerCore,
+              isSelected && styles.markerCoreSelected,
+              Elevation.e1,
+              {
+                backgroundColor: palette.surface,
+                borderColor: isSelected ? timingColor : palette.border,
+              },
+            ]}>
+            <View
+              style={[
+                styles.markerStatus,
+                isSelected && styles.markerStatusSelected,
+                { backgroundColor: timingColor },
+              ]}
+            />
+          </View>
+        </View>
+      </View>
+    </Marker>
+  );
+});
+
 export function CampusMap({
   locations,
   onOpenCampusMap,
@@ -85,43 +163,44 @@ export function CampusMap({
   selectedLocationId,
   sessionTimingByLocation,
   sessionsByLocation,
+  visibleLocationIds,
 }: CampusMapProps) {
   const mapRef = useRef<MapView | null>(null);
   const colorScheme = useColorScheme() ?? 'light';
   const palette = Colors[colorScheme];
   const [isMapReady, setIsMapReady] = useState(false);
+
+  // One entry per canonical location id, in canonical-id order, valid
+  // coordinates only — MapView's direct children are exactly this list and
+  // nothing else, so the native child array stays deterministic.
   const markers = useMemo(
     () =>
-      locations.flatMap((location) => {
-        const coordinate = markerCoordinate(location);
+      buildCampusMarkerEntries(locations, { canonicalize: canonicalStudyLocationId }).flatMap(
+        ({ canonicalId, location }) => {
+          const coordinate = markerCoordinate(location);
 
-        if (!coordinate) {
-          return [];
+          return coordinate ? [{ canonicalId, coordinate, location }] : [];
         }
+      ),
+    [locations]
+  );
 
-        return [
-          {
-            coordinate,
-            location,
-            sessionCount: sessionsByLocation.get(location.locationId) ?? 0,
-            timing: sessionTimingByLocation.get(location.locationId) ?? 'none',
-          },
-        ];
-      }),
-    [locations, sessionTimingByLocation, sessionsByLocation]
+  const visibleMarkers = useMemo(
+    () => markers.filter((marker) => visibleLocationIds.has(marker.location.locationId)),
+    [markers, visibleLocationIds]
   );
 
   const fitVisibleMarkers = useCallback(() => {
-    if (!isMapReady || markers.length === 0) {
+    if (!isMapReady || visibleMarkers.length === 0) {
       return;
     }
 
     requestAnimationFrame(() => {
       try {
-        if (markers.length === 1) {
+        if (visibleMarkers.length === 1) {
           mapRef.current?.animateToRegion(
             {
-              ...markers[0].coordinate,
+              ...visibleMarkers[0].coordinate,
               latitudeDelta: 0.004,
               longitudeDelta: 0.004,
             },
@@ -131,7 +210,7 @@ export function CampusMap({
         }
 
         mapRef.current?.fitToCoordinates(
-          markers.map((marker) => marker.coordinate),
+          visibleMarkers.map((marker) => marker.coordinate),
           { animated: true, edgePadding: FIT_PADDING }
         );
       } catch {
@@ -139,7 +218,7 @@ export function CampusMap({
         // leaving the current region is safer than letting search/filter crash.
       }
     });
-  }, [isMapReady, markers]);
+  }, [isMapReady, visibleMarkers]);
 
   useEffect(() => {
     fitVisibleMarkers();
@@ -170,54 +249,22 @@ export function CampusMap({
         style={StyleSheet.absoluteFill}
         toolbarEnabled={false}
         userInterfaceStyle={colorScheme}>
-        {markers.map(({ coordinate, location, sessionCount, timing }) => {
-          const isSelected = selectedLocationId === location.locationId;
-          const timingColor = getTimingColor(timing, palette.tint, palette.icon);
-
-          return (
-            <Marker
-              anchor={{ x: 0.5, y: 0.5 }}
-              accessibilityLabel={`${location.name}, ${sessionCount} upcoming ${sessionCount === 1 ? 'session' : 'sessions'}, ${timing === 'live' ? 'happening now' : timing === 'soon' ? 'starting soon' : timing === 'later' ? 'later' : 'no scheduled sessions'}`}
-              coordinate={coordinate}
-              identifier={location.locationId}
-              key={`${location.locationId}-${isSelected ? 'selected' : 'idle'}-${timing}`}
-              onPress={() => onSelectLocation(location.locationId)}
-              tracksViewChanges={false}
-              zIndex={isSelected ? 4 : sessionCount > 0 ? 3 : 2}>
-              <View style={styles.markerTouchTarget}>
-                <View
-                  style={[
-                    styles.markerHalo,
-                    {
-                      backgroundColor: isSelected ? `${timingColor}20` : 'transparent',
-                    },
-                  ]}>
-                  <View
-                    style={[
-                      styles.markerCore,
-                      isSelected && styles.markerCoreSelected,
-                      Elevation.e1,
-                      {
-                        backgroundColor: palette.surface,
-                        borderColor: isSelected ? timingColor : palette.border,
-                      },
-                    ]}>
-                    <View
-                      style={[
-                        styles.markerStatus,
-                        isSelected && styles.markerStatusSelected,
-                        { backgroundColor: timingColor },
-                      ]}
-                    />
-                  </View>
-                </View>
-              </View>
-            </Marker>
-          );
-        })}
+        {markers.map(({ canonicalId, coordinate, location }) => (
+          <CampusMapMarker
+            key={canonicalId}
+            coordinate={coordinate}
+            isSelected={selectedLocationId === location.locationId}
+            isVisible={visibleLocationIds.has(location.locationId)}
+            location={location}
+            onSelectLocation={onSelectLocation}
+            palette={palette}
+            sessionCount={sessionsByLocation.get(location.locationId) ?? 0}
+            timing={sessionTimingByLocation.get(location.locationId) ?? 'none'}
+          />
+        ))}
       </MapView>
 
-      {markers.length === 0 ? (
+      {visibleMarkers.length === 0 ? (
         <View
           pointerEvents="none"
           style={[

--- a/components/campus-map.native.tsx
+++ b/components/campus-map.native.tsx
@@ -14,7 +14,11 @@ import {
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { canonicalStudyLocationId } from '@/lib/catalog';
 import type { StudyLocation } from '@/lib/firestore';
-import { buildCampusMarkerEntries, isRenderableCoordinate } from '@/lib/map-markers';
+import {
+  buildCampusMarkerEntries,
+  isRenderableCoordinate,
+  planCampusMarkers,
+} from '@/lib/map-markers';
 import type { MapSessionTiming } from '@/components/campus-map.types';
 
 type CampusMapProps = {
@@ -97,6 +101,8 @@ const CampusMapMarker = memo(function CampusMapMarker({
   const timingColor = getTimingColor(timing, palette.tint, palette.icon);
 
   const handlePress = useCallback(() => {
+    // Hidden markers are relocated off-campus and never selectable, but keep
+    // the guard so a tap racing a visibility change cannot select one.
     if (isVisible) {
       onSelectLocation(location.locationId);
     }
@@ -114,8 +120,9 @@ const CampusMapMarker = memo(function CampusMapMarker({
       tracksViewChanges>
       {/* collapsable={false} keeps Fabric from flattening/unflattening these
           views as their styles change, so the marker's native subtree shape
-          is identical in every state. tracksViewChanges stays constant true
-          so style updates render without timer-driven prop churn. */}
+          is identical in every state. tracksViewChanges is inert on the
+          Apple provider (not implemented in AIRMapMarker); it stays a
+          constant so there is no timer-driven prop churn on any platform. */}
       <View collapsable={false} style={styles.markerTouchTarget}>
         <View
           collapsable={false}
@@ -180,8 +187,11 @@ export function CampusMap({
     [locations]
   );
 
-  const visibleMarkers = useMemo(
-    () => markers.filter((marker) => visibleLocationIds.has(marker.location.locationId)),
+  // Same-length, same-order, same-key list on every render: hidden markers
+  // are relocated off-campus (renderCoordinate) instead of unmounted, and
+  // only visible markers feed the camera fit.
+  const markerPlan = useMemo(
+    () => planCampusMarkers(markers, visibleLocationIds),
     [markers, visibleLocationIds]
   );
 
@@ -215,16 +225,18 @@ export function CampusMap({
   }, [markers, selectedLocationId]);
 
   const fitVisibleMarkers = useCallback(() => {
-    if (!isMapReady || visibleMarkers.length === 0) {
+    const { fitCoordinates } = markerPlan;
+
+    if (!isMapReady || fitCoordinates.length === 0) {
       return;
     }
 
     requestAnimationFrame(() => {
       try {
-        if (visibleMarkers.length === 1) {
+        if (fitCoordinates.length === 1) {
           mapRef.current?.animateToRegion(
             {
-              ...visibleMarkers[0].coordinate,
+              ...fitCoordinates[0],
               latitudeDelta: 0.004,
               longitudeDelta: 0.004,
             },
@@ -233,16 +245,16 @@ export function CampusMap({
           return;
         }
 
-        mapRef.current?.fitToCoordinates(
-          visibleMarkers.map((marker) => marker.coordinate),
-          { animated: true, edgePadding: FIT_PADDING }
-        );
+        mapRef.current?.fitToCoordinates(fitCoordinates, {
+          animated: true,
+          edgePadding: FIT_PADDING,
+        });
       } catch {
         // Native maps can reject camera updates while mounting or unmounting;
         // leaving the current region is safer than letting search/filter crash.
       }
     });
-  }, [isMapReady, visibleMarkers]);
+  }, [isMapReady, markerPlan]);
 
   useEffect(() => {
     fitVisibleMarkers();
@@ -273,12 +285,12 @@ export function CampusMap({
         style={StyleSheet.absoluteFill}
         toolbarEnabled={false}
         userInterfaceStyle={colorScheme}>
-        {markers.map(({ canonicalId, coordinate, location }) => (
+        {markerPlan.markers.map(({ canonicalId, isVisible, location, renderCoordinate }) => (
           <CampusMapMarker
             key={canonicalId}
-            coordinate={coordinate}
+            coordinate={renderCoordinate}
             isSelected={selectedLocationId === location.locationId}
-            isVisible={visibleLocationIds.has(location.locationId)}
+            isVisible={isVisible}
             location={location}
             onSelectLocation={onSelectLocation}
             palette={palette}
@@ -288,7 +300,7 @@ export function CampusMap({
         ))}
       </MapView>
 
-      {visibleMarkers.length === 0 ? (
+      {markerPlan.fitCoordinates.length === 0 ? (
         <View
           pointerEvents="none"
           style={[

--- a/components/campus-map.tsx
+++ b/components/campus-map.tsx
@@ -1,10 +1,13 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import type { MapSessionTiming } from '@/components/campus-map.types';
 import { Brand, Colors, Elevation, FontFamily, Radius, TypeScale } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { canonicalStudyLocationId } from '@/lib/catalog';
 import type { StudyLocation } from '@/lib/firestore';
+import { buildCampusMarkerEntries } from '@/lib/map-markers';
 
 type CampusMapProps = {
   locations: StudyLocation[];
@@ -13,6 +16,7 @@ type CampusMapProps = {
   selectedLocationId: string | null;
   sessionTimingByLocation: Map<string, MapSessionTiming>;
   sessionsByLocation: Map<string, number>;
+  visibleLocationIds: Set<string>;
 };
 
 const TIMING_LABELS: { timing: Exclude<MapSessionTiming, 'none'>; label: string }[] = [
@@ -65,10 +69,21 @@ export function CampusMap({
   selectedLocationId,
   sessionTimingByLocation,
   sessionsByLocation,
+  visibleLocationIds,
 }: CampusMapProps) {
   const colorScheme = useColorScheme() ?? 'light';
   const palette = Colors[colorScheme];
   const isDark = colorScheme === 'dark';
+
+  // Same dedupe/ordering as the native map so both variants agree on which
+  // pin represents an aliased location.
+  const visibleMarkers = useMemo(
+    () =>
+      buildCampusMarkerEntries(locations, { canonicalize: canonicalStudyLocationId }).filter(
+        ({ location }) => visibleLocationIds.has(location.locationId)
+      ),
+    [locations, visibleLocationIds]
+  );
 
   return (
     <View
@@ -135,7 +150,7 @@ export function CampusMap({
         ))}
       </View>
 
-      {locations.map((location) => {
+      {visibleMarkers.map(({ canonicalId, location }) => {
         const isSelected = selectedLocationId === location.locationId;
         const sessionCount = sessionsByLocation.get(location.locationId) ?? 0;
         const timing = sessionTimingByLocation.get(location.locationId) ?? 'none';
@@ -148,7 +163,7 @@ export function CampusMap({
             accessibilityRole="button"
             accessibilityState={{ selected: isSelected }}
             hitSlop={8}
-            key={location.locationId}
+            key={canonicalId}
             onPress={() => onSelectLocation(location.locationId)}
             style={({ pressed }) => [
               styles.markerWrap,
@@ -190,7 +205,7 @@ export function CampusMap({
         );
       })}
 
-      {locations.length === 0 ? (
+      {visibleMarkers.length === 0 ? (
         <View
           pointerEvents="none"
           style={[styles.emptyOverlay, Elevation.e1, { backgroundColor: palette.surface }]}>

--- a/lib/map-markers.d.ts
+++ b/lib/map-markers.d.ts
@@ -16,3 +16,24 @@ export declare function buildCampusMarkerEntries<Location extends { locationId: 
   locations: readonly Location[] | null | undefined,
   options?: { canonicalize?: (locationId: string) => string }
 ): CampusMarkerEntry<Location>[];
+
+export declare function hiddenMarkerCoordinate(canonicalId: string): MapCoordinate;
+
+export type PlannedCampusMarker<Marker> = Marker & {
+  isVisible: boolean;
+  renderCoordinate: MapCoordinate;
+};
+
+export declare function planCampusMarkers<
+  Marker extends {
+    canonicalId: string;
+    coordinate: MapCoordinate;
+    location: { locationId: string };
+  },
+>(
+  markers: readonly Marker[] | null | undefined,
+  visibleLocationIds: ReadonlySet<string> | readonly string[] | null | undefined
+): {
+  fitCoordinates: MapCoordinate[];
+  markers: PlannedCampusMarker<Marker>[];
+};

--- a/lib/map-markers.d.ts
+++ b/lib/map-markers.d.ts
@@ -1,0 +1,18 @@
+export type MapCoordinate = {
+  latitude: number;
+  longitude: number;
+};
+
+export type CampusMarkerEntry<Location extends { locationId: string }> = {
+  canonicalId: string;
+  location: Location;
+};
+
+export declare function isRenderableCoordinate(
+  coordinate: unknown
+): coordinate is MapCoordinate;
+
+export declare function buildCampusMarkerEntries<Location extends { locationId: string }>(
+  locations: readonly Location[] | null | undefined,
+  options?: { canonicalize?: (locationId: string) => string }
+): CampusMarkerEntry<Location>[];

--- a/lib/map-markers.d.ts
+++ b/lib/map-markers.d.ts
@@ -19,6 +19,18 @@ export declare function buildCampusMarkerEntries<Location extends { locationId: 
 
 export declare function hiddenMarkerCoordinate(canonicalId: string): MapCoordinate;
 
+export declare const ANDROID_TRACK_REFRESH_MS: number;
+
+export declare function markerAppearanceSignature(parts: {
+  isSelected: boolean;
+  isVisible: boolean;
+  latitude: number;
+  longitude: number;
+  sessionCount: number;
+  theme: string;
+  timing: string;
+}): string;
+
 export type PlannedCampusMarker<Marker> = Marker & {
   isVisible: boolean;
   renderCoordinate: MapCoordinate;

--- a/lib/map-markers.js
+++ b/lib/map-markers.js
@@ -1,0 +1,74 @@
+// Pure helpers that make the map's marker set deterministic before it ever
+// reaches react-native-maps. AIRMap keeps its children in a mutable native
+// array, and under the New Architecture interop any duplicate key, unstable
+// key, or render-to-render reordering can push its child indexes out of
+// bounds (SIGABRT in `AIRMap insertReactSubview:atIndex:`). Everything the
+// map renders must therefore be deduplicated by canonical location id and
+// emitted in one stable order.
+//
+// Plain CommonJS (like functions/*.js) so `npm run test:map` can exercise it
+// without a transpile step; components import it through lib/map-markers.d.ts.
+
+function identity(locationId) {
+  return locationId;
+}
+
+function isRenderableCoordinate(coordinate) {
+  if (!coordinate || typeof coordinate !== "object") {
+    return false;
+  }
+
+  const { latitude, longitude } = coordinate;
+
+  return (
+    typeof latitude === "number" &&
+    typeof longitude === "number" &&
+    Number.isFinite(latitude) &&
+    Number.isFinite(longitude) &&
+    Math.abs(latitude) <= 90 &&
+    Math.abs(longitude) <= 180
+  );
+}
+
+/**
+ * Normalizes raw study locations into marker entries the map can render
+ * directly: one entry per canonical location id (first occurrence wins, so
+ * curated records beat later aliases), sorted by canonical id so the child
+ * order never depends on upstream fetch/sort order.
+ */
+function buildCampusMarkerEntries(locations, options) {
+  const canonicalize =
+    options && typeof options.canonicalize === "function" ? options.canonicalize : identity;
+  const entriesById = new Map();
+
+  for (const location of Array.isArray(locations) ? locations : []) {
+    if (!location || typeof location !== "object") {
+      continue;
+    }
+
+    const { locationId } = location;
+
+    if (typeof locationId !== "string" || locationId.trim() === "") {
+      continue;
+    }
+
+    const canonicalId = canonicalize(locationId);
+
+    if (typeof canonicalId !== "string" || canonicalId.trim() === "") {
+      continue;
+    }
+
+    if (!entriesById.has(canonicalId)) {
+      entriesById.set(canonicalId, { canonicalId, location });
+    }
+  }
+
+  return [...entriesById.values()].sort((first, second) =>
+    first.canonicalId < second.canonicalId ? -1 : first.canonicalId > second.canonicalId ? 1 : 0
+  );
+}
+
+module.exports = {
+  buildCampusMarkerEntries,
+  isRenderableCoordinate,
+};

--- a/lib/map-markers.js
+++ b/lib/map-markers.js
@@ -126,9 +126,42 @@ function planCampusMarkers(markers, visibleLocationIds) {
   return { fitCoordinates, markers: planned };
 }
 
+// Android's Google Maps provider registers markers with tracksViewChanges
+// in a ViewChangesTracker that redraws them roughly every 40 ms. Tracking
+// therefore only turns on for a short bounded window after a marker's
+// rendered appearance actually changes, then turns back off.
+const ANDROID_TRACK_REFRESH_MS = 400;
+
+/**
+ * Signature of everything that affects a marker's rendered appearance (or
+ * its native position). When this string is unchanged between renders, the
+ * marker does not need a tracksViewChanges refresh window.
+ */
+function markerAppearanceSignature({
+  isSelected,
+  isVisible,
+  latitude,
+  longitude,
+  sessionCount,
+  theme,
+  timing,
+}) {
+  return [
+    isSelected ? "selected" : "idle",
+    isVisible ? "visible" : "hidden",
+    String(timing),
+    String(sessionCount),
+    String(latitude),
+    String(longitude),
+    String(theme),
+  ].join("|");
+}
+
 module.exports = {
+  ANDROID_TRACK_REFRESH_MS,
   buildCampusMarkerEntries,
   hiddenMarkerCoordinate,
   isRenderableCoordinate,
+  markerAppearanceSignature,
   planCampusMarkers,
 };

--- a/lib/map-markers.js
+++ b/lib/map-markers.js
@@ -68,7 +68,67 @@ function buildCampusMarkerEntries(locations, options) {
   );
 }
 
+// Hidden markers stay mounted (stable child array) but are relocated to a
+// deterministic spot in a remote patch of the South Atlantic, far outside
+// the UW region. Even invisible (opacity 0) MapKit annotations participate
+// in coordinate-proximity selection, so being physically elsewhere is the
+// only hidden state that is guaranteed noninteractive on Apple Maps.
+const HIDDEN_MARKER_REGION = { latitude: -47.5, longitude: -38.7 };
+const HIDDEN_MARKER_GRID = 32;
+const HIDDEN_MARKER_SPACING = 0.001;
+
+/**
+ * Deterministic off-screen coordinate for a hidden marker. Derived from the
+ * canonical id so it never changes between renders, and spread over a small
+ * grid so hidden annotations do not stack at one native point.
+ */
+function hiddenMarkerCoordinate(canonicalId) {
+  const id = typeof canonicalId === "string" ? canonicalId : "";
+  let hash = 0;
+
+  for (let index = 0; index < id.length; index += 1) {
+    hash = (hash * 31 + id.charCodeAt(index)) % (HIDDEN_MARKER_GRID * HIDDEN_MARKER_GRID);
+  }
+
+  return {
+    latitude:
+      HIDDEN_MARKER_REGION.latitude +
+      Math.floor(hash / HIDDEN_MARKER_GRID) * HIDDEN_MARKER_SPACING,
+    longitude:
+      HIDDEN_MARKER_REGION.longitude + (hash % HIDDEN_MARKER_GRID) * HIDDEN_MARKER_SPACING,
+  };
+}
+
+/**
+ * Render plan for the native map: every marker keeps its key, order, and
+ * child position regardless of visibility. Hidden markers get an off-screen
+ * renderCoordinate; only visible markers contribute to camera fitting.
+ */
+function planCampusMarkers(markers, visibleLocationIds) {
+  const visibleIds =
+    visibleLocationIds instanceof Set ? visibleLocationIds : new Set(visibleLocationIds ?? []);
+  const fitCoordinates = [];
+
+  const planned = (Array.isArray(markers) ? markers : []).map((marker) => {
+    const isVisible = visibleIds.has(marker.location.locationId);
+
+    if (isVisible) {
+      fitCoordinates.push(marker.coordinate);
+    }
+
+    return {
+      ...marker,
+      isVisible,
+      renderCoordinate: isVisible ? marker.coordinate : hiddenMarkerCoordinate(marker.canonicalId),
+    };
+  });
+
+  return { fitCoordinates, markers: planned };
+}
+
 module.exports = {
   buildCampusMarkerEntries,
+  hiddenMarkerCoordinate,
   isRenderableCoordinate,
+  planCampusMarkers,
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "expo lint",
     "rules:test": "firebase emulators:exec --only firestore \"mocha tests/firestore-rules.test.mjs --timeout 10000\"",
     "test:notifications": "mocha tests/notification-validation.test.mjs",
-    "test:deletion": "mocha tests/account-deletion.test.mjs"
+    "test:deletion": "mocha tests/account-deletion.test.mjs",
+    "test:map": "mocha tests/map-markers.test.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/cormorant-garamond": "^0.4.1",

--- a/tests/map-markers.test.mjs
+++ b/tests/map-markers.test.mjs
@@ -3,9 +3,11 @@ import assert from "node:assert/strict";
 import mapMarkers from "../lib/map-markers.js";
 
 const {
+  ANDROID_TRACK_REFRESH_MS,
   buildCampusMarkerEntries,
   hiddenMarkerCoordinate,
   isRenderableCoordinate,
+  markerAppearanceSignature,
   planCampusMarkers,
 } = mapMarkers;
 
@@ -193,6 +195,50 @@ describe("campus marker render plan", () => {
     }
 
     assert.equal(isRenderableCoordinate(hiddenMarkerCoordinate(undefined)), true);
+  });
+});
+
+describe("marker appearance signature (Android tracking pulse)", () => {
+  const BASE = {
+    isSelected: false,
+    isVisible: true,
+    latitude: 43.0766969,
+    longitude: -89.4013466,
+    sessionCount: 2,
+    theme: "#FFFFFF|#E5DFD2|#C5050C|#6B6359",
+    timing: "live",
+  };
+
+  it("is stable for identical appearance inputs", () => {
+    assert.equal(markerAppearanceSignature(BASE), markerAppearanceSignature({ ...BASE }));
+  });
+
+  it("changes when any appearance-affecting field changes", () => {
+    const variants = [
+      { isSelected: true },
+      { isVisible: false },
+      { timing: "none" },
+      { sessionCount: 0 },
+      { latitude: -47.5 },
+      { longitude: -38.7 },
+      { theme: "#1F1B16|#3B342A|#E8B4B8|#8A8174" },
+    ];
+
+    const baseSignature = markerAppearanceSignature(BASE);
+
+    for (const change of variants) {
+      assert.notEqual(
+        markerAppearanceSignature({ ...BASE, ...change }),
+        baseSignature,
+        `expected signature to change for ${JSON.stringify(change)}`
+      );
+    }
+  });
+
+  it("keeps the refresh window short and bounded", () => {
+    assert.ok(Number.isInteger(ANDROID_TRACK_REFRESH_MS));
+    assert.ok(ANDROID_TRACK_REFRESH_MS >= 100);
+    assert.ok(ANDROID_TRACK_REFRESH_MS <= 1000);
   });
 });
 

--- a/tests/map-markers.test.mjs
+++ b/tests/map-markers.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+
+import mapMarkers from "../lib/map-markers.js";
+
+const { buildCampusMarkerEntries, isRenderableCoordinate } = mapMarkers;
+
+// Mirrors lib/catalog.ts alias behavior without importing TypeScript.
+const ALIASES = { morgridge: "discovery-building" };
+const canonicalize = (locationId) => ALIASES[locationId] ?? locationId;
+
+function location(locationId, extra = {}) {
+  return { locationId, name: locationId, ...extra };
+}
+
+describe("campus map marker entries", () => {
+  it("keys every entry by canonical location id", () => {
+    const entries = buildCampusMarkerEntries(
+      [location("morgridge"), location("college-library")],
+      { canonicalize }
+    );
+
+    assert.deepEqual(
+      entries.map((entry) => entry.canonicalId),
+      ["college-library", "discovery-building"]
+    );
+    assert.equal(entries[1].location.locationId, "morgridge");
+  });
+
+  it("deduplicates by canonical id, keeping the first occurrence", () => {
+    const curated = location("discovery-building", { name: "Discovery Building" });
+    const alias = location("morgridge", { name: "Morgridge Hall" });
+    const entries = buildCampusMarkerEntries([curated, alias, curated], { canonicalize });
+
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].canonicalId, "discovery-building");
+    assert.equal(entries[0].location, curated);
+  });
+
+  it("never emits duplicate keys even without a canonicalizer", () => {
+    const entries = buildCampusMarkerEntries([
+      location("college-library"),
+      location("college-library"),
+    ]);
+
+    assert.equal(entries.length, 1);
+  });
+
+  it("emits the same stable order regardless of input order", () => {
+    const spots = [location("steenbock"), location("college-library"), location("memorial-union")];
+    const forward = buildCampusMarkerEntries(spots);
+    const reversed = buildCampusMarkerEntries([...spots].reverse());
+    const shuffled = buildCampusMarkerEntries([spots[1], spots[2], spots[0]]);
+
+    const order = forward.map((entry) => entry.canonicalId);
+
+    assert.deepEqual(order, ["college-library", "memorial-union", "steenbock"]);
+    assert.deepEqual(reversed.map((entry) => entry.canonicalId), order);
+    assert.deepEqual(shuffled.map((entry) => entry.canonicalId), order);
+  });
+
+  it("drops entries without a usable location id", () => {
+    const entries = buildCampusMarkerEntries(
+      [
+        null,
+        undefined,
+        "college-library",
+        location(""),
+        location("   "),
+        { name: "no id at all" },
+        location(42),
+        location("memorial-union"),
+      ],
+      { canonicalize }
+    );
+
+    assert.deepEqual(
+      entries.map((entry) => entry.canonicalId),
+      ["memorial-union"]
+    );
+  });
+
+  it("drops entries whose canonical id is unusable", () => {
+    const entries = buildCampusMarkerEntries([location("ghost-spot")], {
+      canonicalize: () => "",
+    });
+
+    assert.equal(entries.length, 0);
+  });
+
+  it("tolerates a missing or non-array location list", () => {
+    assert.deepEqual(buildCampusMarkerEntries(null), []);
+    assert.deepEqual(buildCampusMarkerEntries(undefined), []);
+    assert.deepEqual(buildCampusMarkerEntries("college-library"), []);
+  });
+});
+
+describe("renderable coordinates", () => {
+  it("accepts finite in-range coordinates", () => {
+    assert.equal(isRenderableCoordinate({ latitude: 43.0747, longitude: -89.414 }), true);
+    assert.equal(isRenderableCoordinate({ latitude: -90, longitude: 180 }), true);
+  });
+
+  it("rejects missing, malformed, or out-of-range coordinates", () => {
+    assert.equal(isRenderableCoordinate(undefined), false);
+    assert.equal(isRenderableCoordinate(null), false);
+    assert.equal(isRenderableCoordinate({}), false);
+    assert.equal(isRenderableCoordinate({ latitude: 43.07 }), false);
+    assert.equal(isRenderableCoordinate({ latitude: "43.07", longitude: "-89.41" }), false);
+    assert.equal(isRenderableCoordinate({ latitude: Number.NaN, longitude: -89.41 }), false);
+    assert.equal(isRenderableCoordinate({ latitude: 43.07, longitude: Infinity }), false);
+    assert.equal(isRenderableCoordinate({ latitude: 90.1, longitude: -89.41 }), false);
+    assert.equal(isRenderableCoordinate({ latitude: 43.07, longitude: -180.5 }), false);
+  });
+});

--- a/tests/map-markers.test.mjs
+++ b/tests/map-markers.test.mjs
@@ -2,7 +2,28 @@ import assert from "node:assert/strict";
 
 import mapMarkers from "../lib/map-markers.js";
 
-const { buildCampusMarkerEntries, isRenderableCoordinate } = mapMarkers;
+const {
+  buildCampusMarkerEntries,
+  hiddenMarkerCoordinate,
+  isRenderableCoordinate,
+  planCampusMarkers,
+} = mapMarkers;
+
+const UW_CAMPUS = { latitude: 43.0747, longitude: -89.414 };
+
+function marker(canonicalId, latitude, longitude) {
+  return {
+    canonicalId,
+    coordinate: { latitude, longitude },
+    location: { locationId: canonicalId },
+  };
+}
+
+const CAMPUS_MARKERS = [
+  marker("college-library", 43.0766969, -89.4013466),
+  marker("memorial-union", 43.076421, -89.3999144),
+  marker("union-south", 43.0718561, -89.4080738),
+];
 
 // Mirrors lib/catalog.ts alias behavior without importing TypeScript.
 const ALIASES = { morgridge: "discovery-building" };
@@ -91,6 +112,87 @@ describe("campus map marker entries", () => {
     assert.deepEqual(buildCampusMarkerEntries(null), []);
     assert.deepEqual(buildCampusMarkerEntries(undefined), []);
     assert.deepEqual(buildCampusMarkerEntries("college-library"), []);
+  });
+});
+
+describe("campus marker render plan", () => {
+  it("keeps keys, order, and count identical across visibility changes", () => {
+    const allVisible = planCampusMarkers(CAMPUS_MARKERS, [
+      "college-library",
+      "memorial-union",
+      "union-south",
+    ]);
+    const oneVisible = planCampusMarkers(CAMPUS_MARKERS, ["memorial-union"]);
+    const noneVisible = planCampusMarkers(CAMPUS_MARKERS, []);
+
+    const keys = (plan) => plan.markers.map((entry) => entry.canonicalId);
+
+    assert.deepEqual(keys(allVisible), ["college-library", "memorial-union", "union-south"]);
+    assert.deepEqual(keys(oneVisible), keys(allVisible));
+    assert.deepEqual(keys(noneVisible), keys(allVisible));
+  });
+
+  it("renders visible markers at their original coordinates", () => {
+    const plan = planCampusMarkers(CAMPUS_MARKERS, ["college-library", "union-south"]);
+
+    for (const entry of plan.markers) {
+      if (entry.isVisible) {
+        assert.deepEqual(entry.renderCoordinate, entry.coordinate);
+      }
+    }
+
+    assert.equal(plan.markers.filter((entry) => entry.isVisible).length, 2);
+  });
+
+  it("relocates hidden markers to valid deterministic off-campus coordinates", () => {
+    const first = planCampusMarkers(CAMPUS_MARKERS, ["memorial-union"]);
+    const second = planCampusMarkers(CAMPUS_MARKERS, ["memorial-union"]);
+
+    const hiddenEntries = first.markers.filter((entry) => !entry.isVisible);
+
+    assert.equal(hiddenEntries.length, 2);
+
+    for (const [index, entry] of hiddenEntries.entries()) {
+      assert.equal(isRenderableCoordinate(entry.renderCoordinate), true);
+      // Far outside the UW region — nowhere near the campus viewport.
+      assert.ok(Math.abs(entry.renderCoordinate.latitude - UW_CAMPUS.latitude) > 30);
+      assert.ok(Math.abs(entry.renderCoordinate.longitude - UW_CAMPUS.longitude) > 30);
+      // Deterministic across renders.
+      const again = second.markers.filter((candidate) => !candidate.isVisible)[index];
+      assert.deepEqual(entry.renderCoordinate, again.renderCoordinate);
+    }
+
+    // Hidden annotations do not stack at one native point.
+    assert.notDeepEqual(hiddenEntries[0].renderCoordinate, hiddenEntries[1].renderCoordinate);
+  });
+
+  it("excludes hidden markers from camera fitting", () => {
+    const plan = planCampusMarkers(CAMPUS_MARKERS, ["memorial-union"]);
+
+    assert.deepEqual(plan.fitCoordinates, [{ latitude: 43.076421, longitude: -89.3999144 }]);
+
+    const empty = planCampusMarkers(CAMPUS_MARKERS, []);
+
+    assert.deepEqual(empty.fitCoordinates, []);
+  });
+
+  it("accepts a Set or an array of visible ids and tolerates null", () => {
+    const fromSet = planCampusMarkers(CAMPUS_MARKERS, new Set(["union-south"]));
+    const fromArray = planCampusMarkers(CAMPUS_MARKERS, ["union-south"]);
+
+    assert.deepEqual(fromSet, fromArray);
+    assert.deepEqual(planCampusMarkers(CAMPUS_MARKERS, null).fitCoordinates, []);
+    assert.deepEqual(planCampusMarkers(null, ["union-south"]).markers, []);
+  });
+
+  it("never emits an invalid hidden coordinate, even for odd ids", () => {
+    for (const id of ["", "x", "a-very-long-canonical-location-id-with-dashes", "ÜNÏCODE"]) {
+      const coordinate = hiddenMarkerCoordinate(id);
+
+      assert.equal(isRenderableCoordinate(coordinate), true);
+    }
+
+    assert.equal(isRenderableCoordinate(hiddenMarkerCoordinate(undefined)), true);
   });
 });
 


### PR DESCRIPTION


---

> **Rev 4** (`64d907f`): Android `tracksViewChanges` performance. Android's Google provider redraws tracked custom markers on a ~40 ms `ViewChangesTracker` loop, so the previous constant `true` meant sustained redraw work — including for hidden relocated markers. Now: a pure `markerAppearanceSignature()` helper (unit-tested) captures selected state, visible/hidden state, timing, session count, `renderCoordinate`, and theme colors; on **Android** each marker pulses `tracksViewChanges` to `true` for a bounded **400 ms** window (`ANDROID_TRACK_REFRESH_MS`) whenever that signature changes, then back to `false` — one cleanup-safe `setTimeout` per marker, cleared on re-run (rapid changes restart the window) and on unmount (no setState after unmount); hidden markers stop being tracked 400 ms after their relocation renders. On **iOS** the prop is now constant `false` — the Apple provider doesn't implement it and live marker views update without it (selection/live ring verified on-simulator). The toggle is a prop update only: keys, order, count, subtree shape, zIndex removal, hidden-marker relocation, and camera logic are untouched.
>
> **iOS crash regression (Expo Go 54.0.7, simulator, zero crashes — crash-file count flat at every checkpoint):** 14 pin taps across all distinguishable pins, rapid two-pin alternation ×6, 3 search type/clear cycles, 8 filter-toggle rounds, 5 map away/back cycles. Idle CPU on the Map tab: ~0.0%.
>
> **Android runtime QA pending:** no Android SDK/emulator on this machine. The bounded-window behavior is enforced by design (single timer, terminal `false` state) and by the helper tests, but the on-device checklist (idle 2–3 min after search/filter churn, confirm visuals update and redraw work settles) needs a pass on an Android device/emulator before merge.
>
> Validations: `test:map` **18 passing** ✅ · `tsc` ✅ · `lint` ✅ · `expo export` web ✅ · `expo-doctor` 18/18 ✅.
