### PR TITLE
feat: Friends / Study Buddies (PR 6)

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -723,6 +723,30 @@ export default function ProfileScreen() {
         )}
       </View>
 
+      {/* Study Buddies entry — friends, requests, and classmate suggestions
+          live at /friends (design spec §3.9). No new bottom tab: the current
+          5-tab structure stays, with this as the entry point. */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Study buddies"
+        onPress={() => router.push('/friends' as Href)}
+        style={({ pressed }) => [
+          styles.settingsRow,
+          {
+            backgroundColor: palette.surface,
+            borderColor: palette.border,
+            opacity: pressed ? 0.7 : 1,
+          },
+        ]}>
+        <View style={styles.settingsRowBody}>
+          <Text style={[TypeScale.bodyStrong, { color: palette.text }]}>Study buddies</Text>
+          <Text style={[TypeScale.caption, { color: palette.icon }]}>
+            Friends, requests, and classmates
+          </Text>
+        </View>
+        <Text style={[TypeScale.heading, { color: palette.icon }]}>›</Text>
+      </Pressable>
+
       {/* Notifications Center entry — the activity history lives at
           /notifications; the pill is the unread count. */}
       <Pressable

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -183,6 +183,8 @@ function RootLayout() {
           <Stack.Screen name="rate-location" options={{ title: 'Rate This Spot' }} />
           <Stack.Screen name="settings" options={{ title: 'Settings' }} />
           <Stack.Screen name="notifications" options={{ title: 'Notifications' }} />
+          <Stack.Screen name="friends" options={{ title: 'Study Buddies' }} />
+          <Stack.Screen name="user/[userId]" options={{ title: 'Profile' }} />
         </Stack.Protected>
       </Stack>
       <StatusBar style="auto" />

--- a/app/friends.tsx
+++ b/app/friends.tsx
@@ -1,0 +1,868 @@
+import { Stack, useFocusEffect, useRouter, type Href } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { User } from 'firebase/auth';
+
+import { Avatar } from '@/components/ui/Avatar';
+import { Button } from '@/components/ui/Button';
+import { CourseChip } from '@/components/ui/CourseChip';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { Brand, Colors, FontFamily, Radius, Space, TypeScale } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { track } from '@/lib/analytics';
+import { subscribeToAuthState } from '@/lib/auth';
+import { getUserProfile, type UserProfile } from '@/lib/firestore';
+import {
+  acceptFriendRequest,
+  cancelFriendRequest,
+  declineFriendRequest,
+  FRIEND_SEARCH_MIN_QUERY_LENGTH,
+  getFriendsPage,
+  getIncomingRequestsPage,
+  getOutgoingRequestsPage,
+  getSuggestedClassmates,
+  removeFriend,
+  searchUsersByNamePrefix,
+  sendFriendRequest,
+  sharedClasses,
+  type FriendListItem,
+  type FriendRequestListItem,
+  type SuggestedClassmate,
+} from '@/lib/friends';
+
+type Tab = 'friends' | 'requests' | 'suggested';
+type LoadState = 'loading' | 'ready' | 'error';
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: 'friends', label: 'Friends' },
+  { key: 'requests', label: 'Requests' },
+  { key: 'suggested', label: 'Suggested' },
+];
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default function FriendsScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const placeholderColor = colorScheme === 'dark' ? '#8A8174' : Brand.textSubtle;
+
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [myClasses, setMyClasses] = useState<string[]>([]);
+  const [tab, setTab] = useState<Tab>('friends');
+
+  // Per-tab data + load state.
+  const [friends, setFriends] = useState<FriendListItem[]>([]);
+  const [friendsState, setFriendsState] = useState<LoadState>('loading');
+  const [incoming, setIncoming] = useState<FriendRequestListItem[]>([]);
+  const [outgoing, setOutgoing] = useState<FriendRequestListItem[]>([]);
+  const [requestsState, setRequestsState] = useState<LoadState>('loading');
+  const [suggested, setSuggested] = useState<SuggestedClassmate[]>([]);
+  const [suggestedState, setSuggestedState] = useState<LoadState>('loading');
+
+  // Optimistic action bookkeeping — uids we've already acted on this session.
+  const [pendingUids, setPendingUids] = useState<Set<string>>(() => new Set());
+
+  // Search.
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<UserProfile[]>([]);
+  const [searchState, setSearchState] = useState<LoadState | 'idle'>('idle');
+  const [sentTo, setSentTo] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => subscribeToAuthState(setCurrentUser), []);
+
+  useEffect(() => {
+    if (!currentUser) {
+      return;
+    }
+    let cancelled = false;
+    getUserProfile(currentUser.uid)
+      .then((profile) => {
+        if (!cancelled) {
+          setMyClasses(profile?.classes ?? []);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [currentUser]);
+
+  const loadFriends = useCallback(async () => {
+    if (!currentUser) return;
+    setFriendsState('loading');
+    try {
+      const page = await getFriendsPage(currentUser.uid);
+      setFriends(page.items);
+      setFriendsState('ready');
+    } catch {
+      setFriendsState('error');
+    }
+  }, [currentUser]);
+
+  const loadRequests = useCallback(async () => {
+    if (!currentUser) return;
+    setRequestsState('loading');
+    try {
+      const [inc, out] = await Promise.all([
+        getIncomingRequestsPage(currentUser.uid),
+        getOutgoingRequestsPage(currentUser.uid),
+      ]);
+      setIncoming(inc.items);
+      setOutgoing(out.items);
+      setRequestsState('ready');
+    } catch {
+      setRequestsState('error');
+    }
+  }, [currentUser]);
+
+  const loadSuggested = useCallback(async () => {
+    if (!currentUser) return;
+    setSuggestedState('loading');
+    try {
+      // Exclude existing friends and anyone with a pending request either way,
+      // so suggestions never repeat a relationship that already exists.
+      const [friendsPage, inc, out] = await Promise.all([
+        getFriendsPage(currentUser.uid),
+        getIncomingRequestsPage(currentUser.uid),
+        getOutgoingRequestsPage(currentUser.uid),
+      ]);
+      const exclude = new Set<string>([
+        ...friendsPage.items.map((item) => item.friendUid),
+        ...inc.items.map((item) => item.otherUid),
+        ...out.items.map((item) => item.otherUid),
+      ]);
+      const results = await getSuggestedClassmates(currentUser.uid, myClasses, exclude);
+      setSuggested(results);
+      setSuggestedState('ready');
+    } catch {
+      setSuggestedState('error');
+    }
+  }, [currentUser, myClasses]);
+
+  // Reload the active tab on focus and when it changes.
+  useFocusEffect(
+    useCallback(() => {
+      if (!currentUser) return;
+      track('friends_viewed', { tab });
+      if (tab === 'friends') loadFriends();
+      else if (tab === 'requests') loadRequests();
+      else loadSuggested();
+    }, [currentUser, tab, loadFriends, loadRequests, loadSuggested])
+  );
+
+  // Debounced search — runs independent of the active tab.
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!currentUser) return;
+    const trimmed = searchQuery.trim();
+
+    if (searchTimer.current) {
+      clearTimeout(searchTimer.current);
+    }
+
+    if (trimmed.length < FRIEND_SEARCH_MIN_QUERY_LENGTH) {
+      setSearchResults([]);
+      setSearchState('idle');
+      return;
+    }
+
+    setSearchState('loading');
+    searchTimer.current = setTimeout(async () => {
+      try {
+        const results = await searchUsersByNamePrefix(currentUser.uid, trimmed);
+        setSearchResults(results);
+        setSearchState('ready');
+      } catch {
+        setSearchState('error');
+      }
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      if (searchTimer.current) {
+        clearTimeout(searchTimer.current);
+      }
+    };
+  }, [currentUser, searchQuery]);
+
+  function markPending(uid: string, isPending: boolean) {
+    setPendingUids((current) => {
+      const next = new Set(current);
+      if (isPending) next.add(uid);
+      else next.delete(uid);
+      return next;
+    });
+  }
+
+  async function handleSend(toUid: string, source: 'search' | 'suggested') {
+    if (!currentUser) return;
+    markPending(toUid, true);
+    try {
+      await sendFriendRequest(currentUser.uid, toUid);
+      track('friend_request_sent', { source });
+      if (source === 'search') {
+        setSentTo((current) => new Set(current).add(toUid));
+      } else {
+        setSuggested((current) => current.filter((item) => item.profile.uid !== toUid));
+      }
+    } catch {
+      // Leave the button re-enabled so the user can retry.
+    } finally {
+      markPending(toUid, false);
+    }
+  }
+
+  async function handleAccept(fromUid: string) {
+    if (!currentUser) return;
+    markPending(fromUid, true);
+    try {
+      await acceptFriendRequest(currentUser.uid, fromUid);
+      track('friend_request_accepted');
+      setIncoming((current) => current.filter((item) => item.otherUid !== fromUid));
+    } catch {
+      // keep the row so it can be retried
+    } finally {
+      markPending(fromUid, false);
+    }
+  }
+
+  async function handleDecline(fromUid: string) {
+    if (!currentUser) return;
+    markPending(fromUid, true);
+    try {
+      await declineFriendRequest(currentUser.uid, fromUid);
+      track('friend_request_declined');
+      setIncoming((current) => current.filter((item) => item.otherUid !== fromUid));
+    } catch {
+      // keep the row
+    } finally {
+      markPending(fromUid, false);
+    }
+  }
+
+  async function handleCancel(toUid: string) {
+    if (!currentUser) return;
+    markPending(toUid, true);
+    try {
+      await cancelFriendRequest(currentUser.uid, toUid);
+      track('friend_request_cancelled');
+      setOutgoing((current) => current.filter((item) => item.otherUid !== toUid));
+    } catch {
+      // keep the row
+    } finally {
+      markPending(toUid, false);
+    }
+  }
+
+  async function handleRemove(friendUid: string) {
+    if (!currentUser) return;
+    markPending(friendUid, true);
+    try {
+      await removeFriend(currentUser.uid, friendUid);
+      track('friend_removed');
+      setFriends((current) => current.filter((item) => item.friendUid !== friendUid));
+    } catch {
+      // keep the row
+    } finally {
+      markPending(friendUid, false);
+    }
+  }
+
+  function openProfile(uid: string) {
+    // Concrete href string, cast until expo-router regenerates typed routes
+    // for the new screen on the next dev-server run (same convention as the
+    // /friends push in app/(tabs)/profile.tsx).
+    router.push(`/user/${uid}` as Href);
+  }
+
+  const isSearching = searchQuery.trim().length >= FRIEND_SEARCH_MIN_QUERY_LENGTH;
+
+  return (
+    <View style={[styles.screen, { backgroundColor: palette.background }]}>
+      <Stack.Screen options={{ title: 'Study Buddies' }} />
+
+      <View style={[styles.header, { paddingTop: Space.sm }]}>
+        {/* Search — always visible; results replace the tab content. */}
+        <TextInput
+          autoCapitalize="none"
+          autoCorrect={false}
+          onChangeText={setSearchQuery}
+          placeholder="Find classmates by name"
+          placeholderTextColor={placeholderColor}
+          returnKeyType="search"
+          style={[
+            styles.searchInput,
+            { backgroundColor: palette.surfaceMuted, borderColor: palette.border, color: palette.text },
+          ]}
+          value={searchQuery}
+        />
+
+        {!isSearching ? (
+          <View style={[styles.segmented, { backgroundColor: palette.surfaceMuted }]}>
+            {TABS.map((tabOption) => {
+              const active = tab === tabOption.key;
+              return (
+                <Pressable
+                  key={tabOption.key}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  onPress={() => setTab(tabOption.key)}
+                  style={[
+                    styles.segment,
+                    active && { backgroundColor: palette.surface, ...segmentShadow },
+                  ]}>
+                  <Text
+                    style={[
+                      TypeScale.label,
+                      { color: active ? palette.text : palette.icon },
+                    ]}>
+                    {tabOption.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        ) : null}
+      </View>
+
+      {isSearching ? (
+        <SearchResults
+          state={searchState}
+          results={searchResults}
+          myClasses={myClasses}
+          pendingUids={pendingUids}
+          sentTo={sentTo}
+          palette={palette}
+          onOpen={openProfile}
+          onSend={(uid) => handleSend(uid, 'search')}
+        />
+      ) : tab === 'friends' ? (
+        <FriendsList
+          state={friendsState}
+          friends={friends}
+          myClasses={myClasses}
+          pendingUids={pendingUids}
+          palette={palette}
+          onRetry={loadFriends}
+          onOpen={openProfile}
+          onRemove={handleRemove}
+          onBrowseSuggested={() => setTab('suggested')}
+        />
+      ) : tab === 'requests' ? (
+        <RequestsList
+          state={requestsState}
+          incoming={incoming}
+          outgoing={outgoing}
+          pendingUids={pendingUids}
+          palette={palette}
+          onRetry={loadRequests}
+          onOpen={openProfile}
+          onAccept={handleAccept}
+          onDecline={handleDecline}
+          onCancel={handleCancel}
+          onBrowseSuggested={() => setTab('suggested')}
+        />
+      ) : (
+        <SuggestedList
+          state={suggestedState}
+          suggested={suggested}
+          pendingUids={pendingUids}
+          palette={palette}
+          hasClasses={myClasses.length > 0}
+          onRetry={loadSuggested}
+          onOpen={openProfile}
+          onSend={(uid) => handleSend(uid, 'suggested')}
+        />
+      )}
+
+      <View style={{ height: insets.bottom }} />
+    </View>
+  );
+}
+
+// Both light and dark palettes share these keys; widen every value to string
+// so a `Colors[scheme]` union is assignable (dark's values aren't literals).
+type Palette = { [K in keyof (typeof Colors)['light']]: string };
+
+function LoadingOrError({
+  state,
+  palette,
+  onRetry,
+}: {
+  state: LoadState;
+  palette: Palette;
+  onRetry: () => void;
+}) {
+  if (state === 'loading') {
+    return (
+      <View style={styles.centerArea}>
+        <ActivityIndicator color={palette.tint} />
+      </View>
+    );
+  }
+  return (
+    <EmptyState
+      headline="Something went off-script."
+      body="We couldn't load this just now."
+      actionLabel="Try again"
+      onAction={onRetry}
+    />
+  );
+}
+
+function SharedClassRow({ codes }: { codes: string[] }) {
+  if (codes.length === 0) {
+    return null;
+  }
+  return (
+    <View style={styles.chipRow}>
+      {codes.slice(0, 3).map((code) => (
+        <CourseChip key={code} code={code} size="sm" />
+      ))}
+      {codes.length > 3 ? (
+        <Text style={styles.moreChips}>+{codes.length - 3}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+function FriendsList({
+  state,
+  friends,
+  myClasses,
+  pendingUids,
+  palette,
+  onRetry,
+  onOpen,
+  onRemove,
+  onBrowseSuggested,
+}: {
+  state: LoadState;
+  friends: FriendListItem[];
+  myClasses: string[];
+  pendingUids: Set<string>;
+  palette: Palette;
+  onRetry: () => void;
+  onOpen: (uid: string) => void;
+  onRemove: (uid: string) => void;
+  onBrowseSuggested: () => void;
+}) {
+  if (state !== 'ready') {
+    return <LoadingOrError state={state} palette={palette} onRetry={onRetry} />;
+  }
+
+  return (
+    <FlatList
+      data={friends}
+      keyExtractor={(item) => item.friendUid}
+      contentContainerStyle={styles.listContent}
+      renderItem={({ item }) => {
+        const name = item.profile?.displayName || 'Student';
+        const shared = sharedClasses(myClasses, item.profile?.classes ?? []);
+        return (
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => onOpen(item.friendUid)}
+            style={({ pressed }) => [
+              styles.row,
+              { backgroundColor: palette.surface, borderColor: palette.border, opacity: pressed ? 0.7 : 1 },
+            ]}>
+            <Avatar name={name} size="md" verified />
+            <View style={styles.rowBody}>
+              <Text style={[TypeScale.bodyStrong, { color: palette.text }]} numberOfLines={1}>
+                {name}
+              </Text>
+              <SharedClassRow codes={shared} />
+            </View>
+            <Button
+              label="Remove"
+              variant="ghost"
+              size="sm"
+              disabled={pendingUids.has(item.friendUid)}
+              onPress={() => onRemove(item.friendUid)}
+            />
+          </Pressable>
+        );
+      }}
+      ListEmptyComponent={
+        <EmptyState
+          icon="dot"
+          headline="No study buddies yet"
+          body="Find classmates by name, or check who's in your classes."
+          actionLabel="See suggestions"
+          onAction={onBrowseSuggested}
+        />
+      }
+    />
+  );
+}
+
+function RequestsList({
+  state,
+  incoming,
+  outgoing,
+  pendingUids,
+  palette,
+  onRetry,
+  onOpen,
+  onAccept,
+  onDecline,
+  onCancel,
+  onBrowseSuggested,
+}: {
+  state: LoadState;
+  incoming: FriendRequestListItem[];
+  outgoing: FriendRequestListItem[];
+  pendingUids: Set<string>;
+  palette: Palette;
+  onRetry: () => void;
+  onOpen: (uid: string) => void;
+  onAccept: (uid: string) => void;
+  onDecline: (uid: string) => void;
+  onCancel: (uid: string) => void;
+  onBrowseSuggested: () => void;
+}) {
+  if (state !== 'ready') {
+    return <LoadingOrError state={state} palette={palette} onRetry={onRetry} />;
+  }
+
+  if (incoming.length === 0 && outgoing.length === 0) {
+    return (
+      <EmptyState
+        icon="dot"
+        headline="No pending requests"
+        body="Requests you send and receive show up here."
+        actionLabel="See suggestions"
+        onAction={onBrowseSuggested}
+      />
+    );
+  }
+
+  type Section =
+    | { kind: 'header'; id: string; label: string }
+    | { kind: 'incoming'; id: string; item: FriendRequestListItem }
+    | { kind: 'outgoing'; id: string; item: FriendRequestListItem };
+
+  const rows: Section[] = [];
+  if (incoming.length > 0) {
+    rows.push({ kind: 'header', id: 'h-in', label: `Requests · ${incoming.length}` });
+    incoming.forEach((item) =>
+      rows.push({ kind: 'incoming', id: `in-${item.otherUid}`, item })
+    );
+  }
+  if (outgoing.length > 0) {
+    rows.push({ kind: 'header', id: 'h-out', label: `Sent · ${outgoing.length}` });
+    outgoing.forEach((item) =>
+      rows.push({ kind: 'outgoing', id: `out-${item.otherUid}`, item })
+    );
+  }
+
+  return (
+    <FlatList
+      data={rows}
+      keyExtractor={(row) => row.id}
+      contentContainerStyle={styles.listContent}
+      renderItem={({ item: row }) => {
+        if (row.kind === 'header') {
+          return (
+            <Text style={[TypeScale.eyebrow, styles.sectionHeader, { color: palette.icon }]}>
+              {row.label}
+            </Text>
+          );
+        }
+        const item = row.item;
+        const name = item.profile?.displayName || 'Student';
+        return (
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => onOpen(item.otherUid)}
+            style={({ pressed }) => [
+              styles.row,
+              { backgroundColor: palette.surface, borderColor: palette.border, opacity: pressed ? 0.7 : 1 },
+            ]}>
+            <Avatar name={name} size="md" verified />
+            <View style={styles.rowBody}>
+              <Text style={[TypeScale.bodyStrong, { color: palette.text }]} numberOfLines={1}>
+                {name}
+              </Text>
+              <Text style={[TypeScale.caption, { color: palette.icon }]}>
+                {row.kind === 'incoming' ? 'Wants to be study buddies' : 'Request sent'}
+              </Text>
+            </View>
+            {row.kind === 'incoming' ? (
+              <View style={styles.actionCol}>
+                <Button
+                  label="Accept"
+                  size="sm"
+                  disabled={pendingUids.has(item.otherUid)}
+                  onPress={() => onAccept(item.otherUid)}
+                />
+                <Button
+                  label="Decline"
+                  variant="ghost"
+                  size="sm"
+                  disabled={pendingUids.has(item.otherUid)}
+                  onPress={() => onDecline(item.otherUid)}
+                />
+              </View>
+            ) : (
+              <Button
+                label="Cancel"
+                variant="secondary"
+                size="sm"
+                disabled={pendingUids.has(item.otherUid)}
+                onPress={() => onCancel(item.otherUid)}
+              />
+            )}
+          </Pressable>
+        );
+      }}
+    />
+  );
+}
+
+function SuggestedList({
+  state,
+  suggested,
+  pendingUids,
+  palette,
+  hasClasses,
+  onRetry,
+  onOpen,
+  onSend,
+}: {
+  state: LoadState;
+  suggested: SuggestedClassmate[];
+  pendingUids: Set<string>;
+  palette: Palette;
+  hasClasses: boolean;
+  onRetry: () => void;
+  onOpen: (uid: string) => void;
+  onSend: (uid: string) => void;
+}) {
+  if (state !== 'ready') {
+    return <LoadingOrError state={state} palette={palette} onRetry={onRetry} />;
+  }
+
+  return (
+    <FlatList
+      data={suggested}
+      keyExtractor={(item) => item.profile.uid}
+      contentContainerStyle={styles.listContent}
+      ListHeaderComponent={
+        suggested.length > 0 ? (
+          <Text style={[TypeScale.eyebrow, styles.sectionHeader, { color: palette.icon }]}>
+            From your classes
+          </Text>
+        ) : null
+      }
+      renderItem={({ item }) => {
+        const name = item.profile.displayName || 'Student';
+        return (
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => onOpen(item.profile.uid)}
+            style={({ pressed }) => [
+              styles.row,
+              { backgroundColor: palette.surface, borderColor: palette.border, opacity: pressed ? 0.7 : 1 },
+            ]}>
+            <Avatar name={name} size="md" verified />
+            <View style={styles.rowBody}>
+              <Text style={[TypeScale.bodyStrong, { color: palette.text }]} numberOfLines={1}>
+                {name}
+              </Text>
+              <SharedClassRow codes={item.sharedClasses} />
+            </View>
+            <Button
+              label="Add"
+              size="sm"
+              disabled={pendingUids.has(item.profile.uid)}
+              onPress={() => onSend(item.profile.uid)}
+            />
+          </Pressable>
+        );
+      }}
+      ListEmptyComponent={
+        <EmptyState
+          icon="dot"
+          headline={hasClasses ? 'No classmates to suggest yet' : 'Add your classes first'}
+          body={
+            hasClasses
+              ? "When people in your classes join Studi, they'll show up here."
+              : 'Save the courses you take on your profile to see classmates here.'
+          }
+        />
+      }
+    />
+  );
+}
+
+function SearchResults({
+  state,
+  results,
+  myClasses,
+  pendingUids,
+  sentTo,
+  palette,
+  onOpen,
+  onSend,
+}: {
+  state: LoadState | 'idle';
+  results: UserProfile[];
+  myClasses: string[];
+  pendingUids: Set<string>;
+  sentTo: Set<string>;
+  palette: Palette;
+  onOpen: (uid: string) => void;
+  onSend: (uid: string) => void;
+}) {
+  if (state === 'loading') {
+    return (
+      <View style={styles.centerArea}>
+        <ActivityIndicator color={palette.tint} />
+      </View>
+    );
+  }
+  if (state === 'error') {
+    return (
+      <EmptyState
+        headline="Search hiccuped."
+        body="Check your connection and try that search again."
+      />
+    );
+  }
+
+  return (
+    <FlatList
+      data={results}
+      keyExtractor={(item) => item.uid}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={styles.listContent}
+      renderItem={({ item }) => {
+        const shared = sharedClasses(myClasses, item.classes);
+        const alreadySent = sentTo.has(item.uid);
+        return (
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => onOpen(item.uid)}
+            style={({ pressed }) => [
+              styles.row,
+              { backgroundColor: palette.surface, borderColor: palette.border, opacity: pressed ? 0.7 : 1 },
+            ]}>
+            <Avatar name={item.displayName || 'Student'} size="md" verified />
+            <View style={styles.rowBody}>
+              <Text style={[TypeScale.bodyStrong, { color: palette.text }]} numberOfLines={1}>
+                {item.displayName || 'Student'}
+              </Text>
+              <SharedClassRow codes={shared} />
+            </View>
+            <Button
+              label={alreadySent ? 'Sent' : 'Add'}
+              size="sm"
+              variant={alreadySent ? 'secondary' : 'primary'}
+              disabled={alreadySent || pendingUids.has(item.uid)}
+              onPress={() => onSend(item.uid)}
+            />
+          </Pressable>
+        );
+      }}
+      ListEmptyComponent={
+        <EmptyState
+          icon="dot"
+          headline="No matches"
+          body="Try a different name — Studi only shows verified UW students."
+        />
+      }
+    />
+  );
+}
+
+const segmentShadow = {
+  shadowColor: Brand.text,
+  shadowOffset: { width: 0, height: 1 },
+  shadowOpacity: 0.06,
+  shadowRadius: 3,
+  elevation: 1,
+};
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  header: {
+    gap: Space.md,
+    paddingHorizontal: Space.lg + 4,
+    paddingBottom: Space.md,
+  },
+  searchInput: {
+    borderRadius: Radius.lg,
+    borderWidth: StyleSheet.hairlineWidth * 2,
+    fontFamily: FontFamily.body,
+    fontSize: 15,
+    minHeight: 48,
+    paddingHorizontal: Space.lg,
+  },
+  segmented: {
+    borderRadius: Radius.pill,
+    flexDirection: 'row',
+    padding: 3,
+  },
+  segment: {
+    alignItems: 'center',
+    borderRadius: Radius.pill,
+    flex: 1,
+    justifyContent: 'center',
+    paddingVertical: Space.sm,
+  },
+  centerArea: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 240,
+  },
+  listContent: {
+    padding: Space.lg + 4,
+    paddingTop: Space.sm,
+    gap: Space.sm,
+  },
+  sectionHeader: {
+    marginTop: Space.sm,
+    marginBottom: Space.xs,
+  },
+  row: {
+    alignItems: 'center',
+    borderRadius: Radius.lg,
+    borderWidth: StyleSheet.hairlineWidth * 2,
+    flexDirection: 'row',
+    gap: Space.md,
+    minHeight: 64,
+    paddingHorizontal: Space.md + 2,
+    paddingVertical: Space.sm,
+  },
+  rowBody: {
+    flex: 1,
+    gap: Space.xs,
+  },
+  chipRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Space.xs,
+  },
+  moreChips: {
+    fontFamily: FontFamily.bodyMedium,
+    fontSize: 12,
+    color: Brand.textSubtle,
+  },
+  actionCol: {
+    alignItems: 'flex-end',
+    gap: 2,
+  },
+});

--- a/app/friends.tsx
+++ b/app/friends.tsx
@@ -70,19 +70,25 @@ export default function FriendsScreen() {
   const friendsCursor = useRef<QueryDocumentSnapshot | null>(null);
   const friendsHasMore = useRef(false);
 
+  // Incoming and outgoing requests paginate FULLY independently (own cursor,
+  // hasMore, loading flag, in-flight guard, and Load-more control) so neither
+  // section can starve the other.
   const [incoming, setIncoming] = useState<FriendRequestListItem[]>([]);
   const [outgoing, setOutgoing] = useState<FriendRequestListItem[]>([]);
   const [requestsState, setRequestsState] = useState<LoadState>('loading');
-  const [requestsLoadingMore, setRequestsLoadingMore] = useState(false);
+  const [incomingLoadingMore, setIncomingLoadingMore] = useState(false);
+  const [outgoingLoadingMore, setOutgoingLoadingMore] = useState(false);
+  const [incomingCanLoadMore, setIncomingCanLoadMore] = useState(false);
+  const [outgoingCanLoadMore, setOutgoingCanLoadMore] = useState(false);
   const incomingCursor = useRef<QueryDocumentSnapshot | null>(null);
-  const incomingHasMore = useRef(false);
   const outgoingCursor = useRef<QueryDocumentSnapshot | null>(null);
-  const outgoingHasMore = useRef(false);
+  const incomingInFlight = useRef(false);
+  const outgoingInFlight = useRef(false);
 
   const [suggested, setSuggested] = useState<SuggestedClassmate[]>([]);
   const [suggestedState, setSuggestedState] = useState<LoadState>('loading');
 
-  // Guards against overlapping page fetches (onEndReached fires repeatedly).
+  // Guards against overlapping page fetches (Friends onEndReached fires repeatedly).
   const loadingMoreRef = useRef(false);
 
   // Optimistic action bookkeeping — uids we've already acted on this session.
@@ -159,46 +165,52 @@ export default function FriendsScreen() {
       setIncoming(inc.items);
       setOutgoing(out.items);
       incomingCursor.current = inc.cursor;
-      incomingHasMore.current = inc.hasMore;
       outgoingCursor.current = out.cursor;
-      outgoingHasMore.current = out.hasMore;
+      setIncomingCanLoadMore(inc.hasMore);
+      setOutgoingCanLoadMore(out.hasMore);
       setRequestsState('ready');
     } catch {
       setRequestsState('error');
     }
   }, [currentUser]);
 
-  const loadMoreRequests = useCallback(async () => {
-    if (!currentUser || loadingMoreRef.current) return;
-    if (!outgoingHasMore.current && !incomingHasMore.current) return;
-    loadingMoreRef.current = true;
-    setRequestsLoadingMore(true);
+  const loadMoreIncoming = useCallback(async () => {
+    if (!currentUser || incomingInFlight.current || !incomingCursor.current) return;
+    incomingInFlight.current = true;
+    setIncomingLoadingMore(true);
     try {
-      // The combined list renders incoming above outgoing, so the bottom that
-      // triggers onEndReached is the outgoing tail — page that first, then
-      // fall through to incoming once outgoing is exhausted.
-      if (outgoingHasMore.current) {
-        const page = await getOutgoingRequestsPage(currentUser.uid, outgoingCursor.current);
-        outgoingCursor.current = page.cursor;
-        outgoingHasMore.current = page.hasMore;
-        setOutgoing((current) => {
-          const seen = new Set(current.map((item) => item.otherUid));
-          return [...current, ...page.items.filter((item) => !seen.has(item.otherUid))];
-        });
-      } else if (incomingHasMore.current) {
-        const page = await getIncomingRequestsPage(currentUser.uid, incomingCursor.current);
-        incomingCursor.current = page.cursor;
-        incomingHasMore.current = page.hasMore;
-        setIncoming((current) => {
-          const seen = new Set(current.map((item) => item.otherUid));
-          return [...current, ...page.items.filter((item) => !seen.has(item.otherUid))];
-        });
-      }
+      const page = await getIncomingRequestsPage(currentUser.uid, incomingCursor.current);
+      incomingCursor.current = page.cursor;
+      setIncomingCanLoadMore(page.hasMore);
+      setIncoming((current) => {
+        const seen = new Set(current.map((item) => item.otherUid));
+        return [...current, ...page.items.filter((item) => !seen.has(item.otherUid))];
+      });
     } catch {
-      // Keep the loaded rows; the next end-reach retries.
+      // Keep loaded rows; the button stays available to retry.
     } finally {
-      loadingMoreRef.current = false;
-      setRequestsLoadingMore(false);
+      incomingInFlight.current = false;
+      setIncomingLoadingMore(false);
+    }
+  }, [currentUser]);
+
+  const loadMoreOutgoing = useCallback(async () => {
+    if (!currentUser || outgoingInFlight.current || !outgoingCursor.current) return;
+    outgoingInFlight.current = true;
+    setOutgoingLoadingMore(true);
+    try {
+      const page = await getOutgoingRequestsPage(currentUser.uid, outgoingCursor.current);
+      outgoingCursor.current = page.cursor;
+      setOutgoingCanLoadMore(page.hasMore);
+      setOutgoing((current) => {
+        const seen = new Set(current.map((item) => item.otherUid));
+        return [...current, ...page.items.filter((item) => !seen.has(item.otherUid))];
+      });
+    } catch {
+      // Keep loaded rows; the button stays available to retry.
+    } finally {
+      outgoingInFlight.current = false;
+      setOutgoingLoadingMore(false);
     }
   }, [currentUser]);
 
@@ -434,8 +446,12 @@ export default function FriendsScreen() {
           outgoing={outgoing}
           pendingUids={pendingUids}
           palette={palette}
-          loadingMore={requestsLoadingMore}
-          onEndReached={loadMoreRequests}
+          incomingCanLoadMore={incomingCanLoadMore}
+          outgoingCanLoadMore={outgoingCanLoadMore}
+          incomingLoadingMore={incomingLoadingMore}
+          outgoingLoadingMore={outgoingLoadingMore}
+          onLoadMoreIncoming={loadMoreIncoming}
+          onLoadMoreOutgoing={loadMoreOutgoing}
           onRetry={loadRequests}
           onOpen={openProfile}
           onAccept={handleAccept}
@@ -602,8 +618,12 @@ function RequestsList({
   outgoing,
   pendingUids,
   palette,
-  loadingMore,
-  onEndReached,
+  incomingCanLoadMore,
+  outgoingCanLoadMore,
+  incomingLoadingMore,
+  outgoingLoadingMore,
+  onLoadMoreIncoming,
+  onLoadMoreOutgoing,
   onRetry,
   onOpen,
   onAccept,
@@ -616,8 +636,12 @@ function RequestsList({
   outgoing: FriendRequestListItem[];
   pendingUids: Set<string>;
   palette: Palette;
-  loadingMore: boolean;
-  onEndReached: () => void;
+  incomingCanLoadMore: boolean;
+  outgoingCanLoadMore: boolean;
+  incomingLoadingMore: boolean;
+  outgoingLoadingMore: boolean;
+  onLoadMoreIncoming: () => void;
+  onLoadMoreOutgoing: () => void;
   onRetry: () => void;
   onOpen: (uid: string) => void;
   onAccept: (uid: string) => void;
@@ -644,20 +668,30 @@ function RequestsList({
   type Section =
     | { kind: 'header'; id: string; label: string }
     | { kind: 'incoming'; id: string; item: FriendRequestListItem }
-    | { kind: 'outgoing'; id: string; item: FriendRequestListItem };
+    | { kind: 'outgoing'; id: string; item: FriendRequestListItem }
+    | { kind: 'loadmore'; id: string; section: 'incoming' | 'outgoing'; loading: boolean };
 
+  // Each section gets its OWN Load-more row, so incoming and outgoing paginate
+  // independently — neither can starve the other (a combined onEndReached
+  // could exhaust one side before ever reaching the other).
   const rows: Section[] = [];
   if (incoming.length > 0) {
     rows.push({ kind: 'header', id: 'h-in', label: `Requests · ${incoming.length}` });
     incoming.forEach((item) =>
       rows.push({ kind: 'incoming', id: `in-${item.otherUid}`, item })
     );
+    if (incomingCanLoadMore) {
+      rows.push({ kind: 'loadmore', id: 'more-in', section: 'incoming', loading: incomingLoadingMore });
+    }
   }
   if (outgoing.length > 0) {
     rows.push({ kind: 'header', id: 'h-out', label: `Sent · ${outgoing.length}` });
     outgoing.forEach((item) =>
       rows.push({ kind: 'outgoing', id: `out-${item.otherUid}`, item })
     );
+    if (outgoingCanLoadMore) {
+      rows.push({ kind: 'loadmore', id: 'more-out', section: 'outgoing', loading: outgoingLoadingMore });
+    }
   }
 
   return (
@@ -665,15 +699,25 @@ function RequestsList({
       data={rows}
       keyExtractor={(row) => row.id}
       contentContainerStyle={styles.listContent}
-      onEndReached={onEndReached}
-      onEndReachedThreshold={0.4}
-      ListFooterComponent={<ListFooter loading={loadingMore} palette={palette} />}
       renderItem={({ item: row }) => {
         if (row.kind === 'header') {
           return (
             <Text style={[TypeScale.eyebrow, styles.sectionHeader, { color: palette.icon }]}>
               {row.label}
             </Text>
+          );
+        }
+        if (row.kind === 'loadmore') {
+          return (
+            <View style={styles.loadMoreRow}>
+              <Button
+                label="Load more"
+                variant="secondary"
+                size="sm"
+                loading={row.loading}
+                onPress={row.section === 'incoming' ? onLoadMoreIncoming : onLoadMoreOutgoing}
+              />
+            </View>
           );
         }
         const item = row.item;
@@ -963,5 +1007,9 @@ const styles = StyleSheet.create({
   },
   footerLoading: {
     paddingVertical: Space.lg,
+  },
+  loadMoreRow: {
+    alignItems: 'center',
+    paddingVertical: Space.sm,
   },
 });

--- a/app/friends.tsx
+++ b/app/friends.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { User } from 'firebase/auth';
+import type { QueryDocumentSnapshot } from 'firebase/firestore';
 
 import { Avatar } from '@/components/ui/Avatar';
 import { Button } from '@/components/ui/Button';
@@ -61,14 +62,28 @@ export default function FriendsScreen() {
   const [myClasses, setMyClasses] = useState<string[]>([]);
   const [tab, setTab] = useState<Tab>('friends');
 
-  // Per-tab data + load state.
+  // Per-tab data + load state. Cursors live in refs so onEndReached always
+  // reads the latest page boundary without re-subscribing the handler.
   const [friends, setFriends] = useState<FriendListItem[]>([]);
   const [friendsState, setFriendsState] = useState<LoadState>('loading');
+  const [friendsLoadingMore, setFriendsLoadingMore] = useState(false);
+  const friendsCursor = useRef<QueryDocumentSnapshot | null>(null);
+  const friendsHasMore = useRef(false);
+
   const [incoming, setIncoming] = useState<FriendRequestListItem[]>([]);
   const [outgoing, setOutgoing] = useState<FriendRequestListItem[]>([]);
   const [requestsState, setRequestsState] = useState<LoadState>('loading');
+  const [requestsLoadingMore, setRequestsLoadingMore] = useState(false);
+  const incomingCursor = useRef<QueryDocumentSnapshot | null>(null);
+  const incomingHasMore = useRef(false);
+  const outgoingCursor = useRef<QueryDocumentSnapshot | null>(null);
+  const outgoingHasMore = useRef(false);
+
   const [suggested, setSuggested] = useState<SuggestedClassmate[]>([]);
   const [suggestedState, setSuggestedState] = useState<LoadState>('loading');
+
+  // Guards against overlapping page fetches (onEndReached fires repeatedly).
+  const loadingMoreRef = useRef(false);
 
   // Optimistic action bookkeeping — uids we've already acted on this session.
   const [pendingUids, setPendingUids] = useState<Set<string>>(() => new Set());
@@ -104,9 +119,32 @@ export default function FriendsScreen() {
     try {
       const page = await getFriendsPage(currentUser.uid);
       setFriends(page.items);
+      friendsCursor.current = page.cursor;
+      friendsHasMore.current = page.hasMore;
       setFriendsState('ready');
     } catch {
       setFriendsState('error');
+    }
+  }, [currentUser]);
+
+  const loadMoreFriends = useCallback(async () => {
+    if (!currentUser || loadingMoreRef.current || !friendsHasMore.current) return;
+    loadingMoreRef.current = true;
+    setFriendsLoadingMore(true);
+    try {
+      const page = await getFriendsPage(currentUser.uid, friendsCursor.current);
+      friendsCursor.current = page.cursor;
+      friendsHasMore.current = page.hasMore;
+      // Dedupe by deterministic friend uid so a boundary overlap can't double a row.
+      setFriends((current) => {
+        const seen = new Set(current.map((item) => item.friendUid));
+        return [...current, ...page.items.filter((item) => !seen.has(item.friendUid))];
+      });
+    } catch {
+      // Keep the loaded rows; the next end-reach retries.
+    } finally {
+      loadingMoreRef.current = false;
+      setFriendsLoadingMore(false);
     }
   }, [currentUser]);
 
@@ -120,9 +158,47 @@ export default function FriendsScreen() {
       ]);
       setIncoming(inc.items);
       setOutgoing(out.items);
+      incomingCursor.current = inc.cursor;
+      incomingHasMore.current = inc.hasMore;
+      outgoingCursor.current = out.cursor;
+      outgoingHasMore.current = out.hasMore;
       setRequestsState('ready');
     } catch {
       setRequestsState('error');
+    }
+  }, [currentUser]);
+
+  const loadMoreRequests = useCallback(async () => {
+    if (!currentUser || loadingMoreRef.current) return;
+    if (!outgoingHasMore.current && !incomingHasMore.current) return;
+    loadingMoreRef.current = true;
+    setRequestsLoadingMore(true);
+    try {
+      // The combined list renders incoming above outgoing, so the bottom that
+      // triggers onEndReached is the outgoing tail — page that first, then
+      // fall through to incoming once outgoing is exhausted.
+      if (outgoingHasMore.current) {
+        const page = await getOutgoingRequestsPage(currentUser.uid, outgoingCursor.current);
+        outgoingCursor.current = page.cursor;
+        outgoingHasMore.current = page.hasMore;
+        setOutgoing((current) => {
+          const seen = new Set(current.map((item) => item.otherUid));
+          return [...current, ...page.items.filter((item) => !seen.has(item.otherUid))];
+        });
+      } else if (incomingHasMore.current) {
+        const page = await getIncomingRequestsPage(currentUser.uid, incomingCursor.current);
+        incomingCursor.current = page.cursor;
+        incomingHasMore.current = page.hasMore;
+        setIncoming((current) => {
+          const seen = new Set(current.map((item) => item.otherUid));
+          return [...current, ...page.items.filter((item) => !seen.has(item.otherUid))];
+        });
+      }
+    } catch {
+      // Keep the loaded rows; the next end-reach retries.
+    } finally {
+      loadingMoreRef.current = false;
+      setRequestsLoadingMore(false);
     }
   }, [currentUser]);
 
@@ -130,25 +206,16 @@ export default function FriendsScreen() {
     if (!currentUser) return;
     setSuggestedState('loading');
     try {
-      // Exclude existing friends and anyone with a pending request either way,
-      // so suggestions never repeat a relationship that already exists.
-      const [friendsPage, inc, out] = await Promise.all([
-        getFriendsPage(currentUser.uid),
-        getIncomingRequestsPage(currentUser.uid),
-        getOutgoingRequestsPage(currentUser.uid),
-      ]);
-      const exclude = new Set<string>([
-        ...friendsPage.items.map((item) => item.friendUid),
-        ...inc.items.map((item) => item.otherUid),
-        ...out.items.map((item) => item.otherUid),
-      ]);
-      const results = await getSuggestedClassmates(currentUser.uid, myClasses, exclude);
+      // The callable excludes self, friends, pending requests (either way), and
+      // blocks (both directions) server-side, and returns a bounded list — no
+      // client-side relationship scan and no leak of blocked candidates.
+      const results = await getSuggestedClassmates();
       setSuggested(results);
       setSuggestedState('ready');
     } catch {
       setSuggestedState('error');
     }
-  }, [currentUser, myClasses]);
+  }, [currentUser]);
 
   // Reload the active tab on focus and when it changes.
   useFocusEffect(
@@ -353,6 +420,8 @@ export default function FriendsScreen() {
           myClasses={myClasses}
           pendingUids={pendingUids}
           palette={palette}
+          loadingMore={friendsLoadingMore}
+          onEndReached={loadMoreFriends}
           onRetry={loadFriends}
           onOpen={openProfile}
           onRemove={handleRemove}
@@ -365,6 +434,8 @@ export default function FriendsScreen() {
           outgoing={outgoing}
           pendingUids={pendingUids}
           palette={palette}
+          loadingMore={requestsLoadingMore}
+          onEndReached={loadMoreRequests}
           onRetry={loadRequests}
           onOpen={openProfile}
           onAccept={handleAccept}
@@ -420,6 +491,17 @@ function LoadingOrError({
   );
 }
 
+function ListFooter({ loading, palette }: { loading: boolean; palette: Palette }) {
+  if (!loading) {
+    return null;
+  }
+  return (
+    <View style={styles.footerLoading}>
+      <ActivityIndicator color={palette.tint} />
+    </View>
+  );
+}
+
 function SharedClassRow({ codes }: { codes: string[] }) {
   if (codes.length === 0) {
     return null;
@@ -442,6 +524,8 @@ function FriendsList({
   myClasses,
   pendingUids,
   palette,
+  loadingMore,
+  onEndReached,
   onRetry,
   onOpen,
   onRemove,
@@ -452,6 +536,8 @@ function FriendsList({
   myClasses: string[];
   pendingUids: Set<string>;
   palette: Palette;
+  loadingMore: boolean;
+  onEndReached: () => void;
   onRetry: () => void;
   onOpen: (uid: string) => void;
   onRemove: (uid: string) => void;
@@ -466,6 +552,9 @@ function FriendsList({
       data={friends}
       keyExtractor={(item) => item.friendUid}
       contentContainerStyle={styles.listContent}
+      onEndReached={onEndReached}
+      onEndReachedThreshold={0.4}
+      ListFooterComponent={<ListFooter loading={loadingMore} palette={palette} />}
       renderItem={({ item }) => {
         const name = item.profile?.displayName || 'Student';
         const shared = sharedClasses(myClasses, item.profile?.classes ?? []);
@@ -513,6 +602,8 @@ function RequestsList({
   outgoing,
   pendingUids,
   palette,
+  loadingMore,
+  onEndReached,
   onRetry,
   onOpen,
   onAccept,
@@ -525,6 +616,8 @@ function RequestsList({
   outgoing: FriendRequestListItem[];
   pendingUids: Set<string>;
   palette: Palette;
+  loadingMore: boolean;
+  onEndReached: () => void;
   onRetry: () => void;
   onOpen: (uid: string) => void;
   onAccept: (uid: string) => void;
@@ -572,6 +665,9 @@ function RequestsList({
       data={rows}
       keyExtractor={(row) => row.id}
       contentContainerStyle={styles.listContent}
+      onEndReached={onEndReached}
+      onEndReachedThreshold={0.4}
+      ListFooterComponent={<ListFooter loading={loadingMore} palette={palette} />}
       renderItem={({ item: row }) => {
         if (row.kind === 'header') {
           return (
@@ -864,5 +960,8 @@ const styles = StyleSheet.create({
   actionCol: {
     alignItems: 'flex-end',
     gap: 2,
+  },
+  footerLoading: {
+    paddingVertical: Space.lg,
   },
 });

--- a/app/user/[userId].tsx
+++ b/app/user/[userId].tsx
@@ -1,0 +1,301 @@
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { User } from 'firebase/auth';
+
+import { Avatar } from '@/components/ui/Avatar';
+import { Button } from '@/components/ui/Button';
+import { CourseChip } from '@/components/ui/CourseChip';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { Colors, FontFamily, Space, TypeScale } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { subscribeToAuthState } from '@/lib/auth';
+import {
+  getOrCreateDirectConversation,
+  getUserProfile,
+  type UserProfile,
+} from '@/lib/firestore';
+import {
+  acceptFriendRequest,
+  cancelFriendRequest,
+  getFriendStatus,
+  isBlockedEitherDirection,
+  removeFriend,
+  sendFriendRequest,
+  sharedClasses,
+  type FriendStatus,
+} from '@/lib/friends';
+import { track } from '@/lib/analytics';
+
+type LoadState = 'loading' | 'ready' | 'error' | 'blocked';
+
+export default function PublicProfileScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const { userId } = useLocalSearchParams<{ userId: string }>();
+
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [myClasses, setMyClasses] = useState<string[]>([]);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [status, setStatus] = useState<FriendStatus>('none');
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [actionPending, setActionPending] = useState(false);
+  const [openingChat, setOpeningChat] = useState(false);
+
+  useEffect(() => subscribeToAuthState(setCurrentUser), []);
+
+  const load = useCallback(async () => {
+    if (!currentUser || !userId) {
+      return;
+    }
+    setLoadState('loading');
+    try {
+      if (userId === currentUser.uid) {
+        // Own profile is edited on the You tab; nothing to friend here.
+        const me = await getUserProfile(userId);
+        setProfile(me);
+        setStatus('self');
+        setLoadState('ready');
+        return;
+      }
+
+      const blocked = await isBlockedEitherDirection(currentUser.uid, userId);
+      if (blocked) {
+        setLoadState('blocked');
+        return;
+      }
+
+      const [otherProfile, mine, relation] = await Promise.all([
+        getUserProfile(userId),
+        getUserProfile(currentUser.uid),
+        getFriendStatus(currentUser.uid, userId),
+      ]);
+
+      if (!otherProfile) {
+        setLoadState('error');
+        return;
+      }
+
+      setProfile(otherProfile);
+      setMyClasses(mine?.classes ?? []);
+      setStatus(relation);
+      setLoadState('ready');
+    } catch {
+      setLoadState('error');
+    }
+  }, [currentUser, userId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function runAction(action: () => Promise<void>, nextStatus: FriendStatus) {
+    setActionPending(true);
+    try {
+      await action();
+      setStatus(nextStatus);
+    } catch {
+      // Leave the current status so the button can be retried.
+    } finally {
+      setActionPending(false);
+    }
+  }
+
+  function handleFriendAction() {
+    if (!currentUser || !userId) return;
+
+    if (status === 'none') {
+      runAction(async () => {
+        await sendFriendRequest(currentUser.uid, userId);
+        track('friend_request_sent', { source: 'profile' });
+      }, 'outgoing');
+    } else if (status === 'outgoing') {
+      runAction(async () => {
+        await cancelFriendRequest(currentUser.uid, userId);
+        track('friend_request_cancelled');
+      }, 'none');
+    } else if (status === 'incoming') {
+      runAction(async () => {
+        await acceptFriendRequest(currentUser.uid, userId);
+        track('friend_request_accepted');
+      }, 'friends');
+    } else if (status === 'friends') {
+      runAction(async () => {
+        await removeFriend(currentUser.uid, userId);
+        track('friend_removed');
+      }, 'none');
+    }
+  }
+
+  async function handleMessage() {
+    if (!currentUser || !userId || !profile) return;
+    try {
+      setOpeningChat(true);
+      const conversationId = await getOrCreateDirectConversation(currentUser.uid, userId);
+      router.push({
+        pathname: '/conversation/[conversationId]',
+        params: {
+          conversationId,
+          otherUserId: userId,
+          otherUserName: profile.displayName || '',
+        },
+      });
+    } catch {
+      // no-op; the button re-enables
+    } finally {
+      setOpeningChat(false);
+    }
+  }
+
+  const friendActionLabel: Record<FriendStatus, string> = {
+    self: '',
+    none: 'Add study buddy',
+    outgoing: 'Requested',
+    incoming: 'Accept request',
+    friends: 'Study buddies ✓',
+  };
+
+  if (loadState === 'loading') {
+    return (
+      <View style={[styles.center, { backgroundColor: palette.background }]}>
+        <Stack.Screen options={{ title: 'Profile' }} />
+        <ActivityIndicator color={palette.tint} />
+      </View>
+    );
+  }
+
+  if (loadState === 'blocked') {
+    return (
+      <View style={[styles.screen, { backgroundColor: palette.background }]}>
+        <Stack.Screen options={{ title: 'Profile' }} />
+        <EmptyState
+          headline="This profile isn't available"
+          body="You can't view this student's profile."
+        />
+      </View>
+    );
+  }
+
+  if (loadState === 'error' || !profile) {
+    return (
+      <View style={[styles.screen, { backgroundColor: palette.background }]}>
+        <Stack.Screen options={{ title: 'Profile' }} />
+        <EmptyState
+          headline="Couldn't load this profile"
+          body="They may have deleted their account, or the connection dropped."
+          actionLabel="Try again"
+          onAction={load}
+        />
+      </View>
+    );
+  }
+
+  const name = profile.displayName || 'Student';
+  const academicLine = [profile.year, profile.major, profile.pronouns]
+    .filter(Boolean)
+    .join(' · ');
+  const shared = sharedClasses(myClasses, profile.classes);
+  const isSelf = status === 'self';
+
+  return (
+    <ScrollView
+      style={[styles.screen, { backgroundColor: palette.background }]}
+      contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + Space.xxl }]}>
+      <Stack.Screen options={{ title: 'Profile' }} />
+
+      <View style={styles.identity}>
+        <Avatar name={name} size="xl" verified tone="accent" />
+        <Text style={[styles.name, { color: palette.text }]} numberOfLines={2}>
+          {name}
+        </Text>
+        {academicLine ? (
+          <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>{academicLine}</Text>
+        ) : null}
+        <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>Verified @wisc.edu</Text>
+      </View>
+
+      {profile.bio ? (
+        <Text style={[TypeScale.body, styles.bio, { color: palette.text }]}>{profile.bio}</Text>
+      ) : null}
+
+      {!isSelf ? (
+        <View style={styles.actions}>
+          <Button
+            label={openingChat ? 'Opening…' : 'Message'}
+            fullWidth
+            loading={openingChat}
+            onPress={handleMessage}
+          />
+          <Button
+            label={friendActionLabel[status]}
+            variant="secondary"
+            fullWidth
+            loading={actionPending}
+            onPress={handleFriendAction}
+          />
+        </View>
+      ) : (
+        <Text style={[TypeScale.caption, styles.selfNote, { color: palette.icon }]}>
+          This is you. Edit your profile from the You tab.
+        </Text>
+      )}
+
+      {profile.classes.length > 0 ? (
+        <View style={styles.section}>
+          <Text style={[TypeScale.eyebrow, { color: palette.icon }]}>
+            {shared.length > 0 ? `Classes · ${shared.length} shared` : 'Classes'}
+          </Text>
+          <View style={styles.chipWrap}>
+            {profile.classes.map((code) => (
+              <CourseChip key={code} code={code} size="md" selected={shared.includes(code)} />
+            ))}
+          </View>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  center: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  content: {
+    gap: Space.xl,
+    padding: Space.lg + 4,
+    paddingTop: Space.xl,
+  },
+  identity: {
+    alignItems: 'center',
+    gap: Space.sm,
+  },
+  name: {
+    fontFamily: FontFamily.serifItalic,
+    fontSize: 28,
+    lineHeight: 34,
+    textAlign: 'center',
+  },
+  bio: {
+    textAlign: 'center',
+  },
+  actions: {
+    gap: Space.sm,
+  },
+  selfNote: {
+    textAlign: 'center',
+  },
+  section: {
+    gap: Space.md,
+  },
+  chipWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Space.sm,
+  },
+});

--- a/docs/friends-rollout.md
+++ b/docs/friends-rollout.md
@@ -1,0 +1,77 @@
+# Friends / Study Buddies — rollout & operations notes
+
+Operational notes for shipping the Friends feature (PR 6 / PR #55). Read this
+before deploying rules + Functions.
+
+## Deterministic pair-ID encoding & the UID constraint
+
+Friend documents use plain `${uidA}__${uidB}` IDs, consistent with the rest of
+the app (`conversations`, `userBlocks`, `locationRatings`):
+
+- **friendRequests/{fromUid}__{toUid}** — directed (order = request direction).
+- **friendships/{sortedA}__{sortedB}** — sorted (order-independent).
+
+This is unambiguous **only** because every Studi account is created through
+Firebase email/password auth. `createUserWithEmailAndPassword` (lib/auth.ts) is
+the **sole** account-creation path in the codebase — there is no Admin
+`createUser`/`importUsers`, no custom tokens, no OAuth/SAML/phone/anonymous
+providers. Firebase-generated UIDs are `[A-Za-z0-9]` (28 chars), so they never
+contain `_`, `-`, or `__`.
+
+That constraint is **enforced**, not merely assumed:
+
+- `functions/pair-id.js` `SAFE_UID_PATTERN = /^[A-Za-z0-9]{1,128}$/` — the single
+  source of truth, mirrored by `lib/friends.ts` (`isSafeUid`) and
+  `firestore.rules` (`isSafeUidComponent`).
+- Rules validate every UID component on friend-request/friendship **create**, and
+  the `get` membership check requires exactly two safe, non-empty `__`-separated
+  segments — so empty segments (`__x`), `>2`-part IDs, and any non-conforming UID
+  **fail closed** (denied), never misattributed.
+
+Why not a different encoding (e.g. base64url)? Firestore rules cannot
+base64-encode `request.auth.uid`, so the finding-1 missing-document membership
+check (member-only `get` on a not-yet-existing pair doc, without leaking
+existence) could not be validated in rules under any alternative encoding.
+Truly supporting `__`-in-UID is therefore incompatible with rules-validatable
+deterministic IDs; we constrain-and-enforce instead. No friend data exists yet
+(unmerged/undeployed), so this is a clean pre-deploy decision, not a migration.
+**If a non-email/password provider or custom UIDs are ever added, revisit this.**
+
+## `displayNameLower` — two-phase rollout
+
+Friend search does a case-insensitive prefix query on a `displayNameLower` shadow
+field (Firestore range scans are case-sensitive). Current production clients do
+**not** write it, so deploying strict rules first would break profile
+creation/renames for already-installed apps.
+
+**Phase 1 — this release (rules are permissive):**
+- `displayNameLower` is OPTIONAL on profile create and update.
+- When present, `isValidPublicProfile` pins it to `displayName.lower()` (can't drift).
+- The new app **always** writes it (`createOrUpdateUserProfile`, `updateUserDisplayName`).
+- Deploy order: **rules + Functions + indexes first**, then run
+  `scripts/backfill-display-name-lower.mjs` (idempotent, project-pinned) to fill
+  legacy docs, then ship the app that writes the field. Legacy docs also self-heal
+  the next time the user saves their name.
+
+**Phase 2 — follow-up hardening (separate issue, do NOT do it in this PR):**
+- Once the **minimum supported app version writes `displayNameLower`**, tighten
+  `firestore.rules` to require it on named create and on rename (the exact clauses
+  removed from this PR are in the PR history). Gate this on the real minimum
+  version — there is currently no in-app min-version gate, so do not fake one.
+
+## `getFriendSuggestions` callable — cost & abuse controls
+
+- **Auth:** verified UW caller only (`isVerifiedUwCallable`).
+- **Rate limit:** 3s per user via `rateLimits/{uid}/actions/friendSuggestions`
+  (same transaction pattern as `deleteUserAccount`).
+- **App Check:** intentionally NOT enforced — no existing callable in this project
+  enforces App Check, and a half-configured requirement would be worse than none.
+  Add it project-wide as a separate change if desired.
+- **Errors:** normalized to `HttpsError` (`unauthenticated`, `resource-exhausted`,
+  `internal`).
+- **Returned fields:** only public allowlisted `{ uid, displayName, classes,
+  sharedClasses }`.
+- **Worst-case reads per call:** `1 (caller) + 40 (class-overlap scan) + 40×5
+  (one getAll over each candidate's five deterministic relationship/block docs) =
+  241`. No full-collection or full-relationship scan; exclusion is per-candidate,
+  so friends/requests/blocks beyond any page cap can never reappear.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,6 +32,12 @@ from them. If a number ends up on a slide or a resume, its definition lives here
 | `group_message_sent` | `sendSessionMessage()` succeeds | `length` (number, not content) |
 | `report_submitted` | Report saved | `reason`, `context` |
 | `user_blocked` | Block saved | `context` |
+| `friends_viewed` | Friends screen gains focus or switches tab | `tab` (`friends` \| `requests` \| `suggested`) |
+| `friend_request_sent` | `sendFriendRequest()` succeeds | `source` (`search` \| `suggested` \| `profile`) |
+| `friend_request_accepted` | `acceptFriendRequest()` succeeds | — |
+| `friend_request_declined` | `declineFriendRequest()` succeeds | — |
+| `friend_request_cancelled` | `cancelFriendRequest()` succeeds | — |
+| `friend_removed` | `removeFriend()` succeeds | — |
 | `account_deleted` | Deletion callable succeeds | — |
 | `screen_view` | expo-router pathname change | `pathname` |
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -55,6 +55,48 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "friendships",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "friendRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "toUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "friendRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "fromUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -36,7 +36,8 @@ service cloud.firestore {
     }
 
     function isKnownRateLimitedAction(action) {
-      return action in ['sendMessage', 'createSession', 'reportUser', 'locationRating'];
+      return action in ['sendMessage', 'createSession', 'reportUser', 'locationRating',
+                        'friendRequest'];
     }
 
     function respectsRateLimit(userId, action, previousUpdatedAt) {
@@ -49,6 +50,8 @@ service cloud.firestore {
           || (action == 'reportUser'
             && previousUpdatedAt <= request.time - duration.value(10, 'm'))
           || (action == 'locationRating'
+            && previousUpdatedAt <= request.time - duration.value(10, 's'))
+          || (action == 'friendRequest'
             && previousUpdatedAt <= request.time - duration.value(10, 's'))
         );
     }
@@ -77,12 +80,21 @@ service cloud.firestore {
 
     function isValidPublicProfile() {
       return incoming().keys().hasOnly([
-          'displayName', 'classes', 'year', 'major', 'pronouns', 'bio',
-          'createdAt', 'updatedAt'
+          'displayName', 'displayNameLower', 'classes', 'year', 'major',
+          'pronouns', 'bio', 'createdAt', 'updatedAt'
         ])
         && (!('displayName' in incoming()) ||
               (incoming().displayName is string
                && incoming().displayName.size() <= 60))
+        // displayNameLower powers case-insensitive prefix search (Firestore
+        // range queries are case-sensitive, so a normalized shadow field is
+        // required). Optional — legacy docs predate it — but when present it
+        // must be the exact lowercase of displayName, so the two can never
+        // drift once the field exists on a doc.
+        && (!('displayNameLower' in incoming()) ||
+              ('displayName' in incoming()
+               && incoming().displayNameLower is string
+               && incoming().displayNameLower == incoming().displayName.lower()))
         && (!('classes' in incoming()) ||
               (incoming().classes is list
                && incoming().classes.size() <= 12))
@@ -559,6 +571,108 @@ service cloud.firestore {
         && incoming().createdAt == request.time
         && hasFreshRateLimit(request.auth.uid, 'reportUser');
       allow read, update, delete: if false;
+    }
+
+    // ------------------------------------------------------------------
+    // Friend requests — friendRequests/{fromUid}__{toUid} (PR 6). The doc's
+    // existence IS the pending state: create = send, delete by sender =
+    // cancel, delete by recipient = decline (or the accept batch below).
+    // Deterministic IDs make duplicates structurally impossible (a resend is
+    // an update, and update is denied), and the reverse-direction exists()
+    // check stops mutual pending pairs. Only the two involved users can
+    // read a request — nobody can enumerate someone else's social graph.
+    // ------------------------------------------------------------------
+
+    function friendRequestRef(fromUid, toUid) {
+      return /databases/$(database)/documents/friendRequests/$(fromUid + '__' + toUid);
+    }
+
+    function friendshipRef(userA, userB) {
+      return userA < userB
+        ? /databases/$(database)/documents/friendships/$(userA + '__' + userB)
+        : /databases/$(database)/documents/friendships/$(userB + '__' + userA);
+    }
+
+    match /friendRequests/{requestId} {
+      // get tolerates a missing doc so getFriendStatus can probe a request
+      // that may not exist (returns exists=false) instead of being denied —
+      // same shape as the conversations get rule.
+      allow get: if isVerifiedUwUser()
+        && (
+          resource == null
+          || request.auth.uid == resource.data.fromUid
+          || request.auth.uid == resource.data.toUid
+        );
+      allow list: if isVerifiedUwUser()
+        && (
+          request.auth.uid == resource.data.fromUid
+          || request.auth.uid == resource.data.toUid
+        );
+      allow create: if isVerifiedUwUser()
+        && incoming().keys().hasOnly(['fromUid', 'toUid', 'createdAt'])
+        && incoming().fromUid == request.auth.uid
+        && incoming().toUid is string
+        && incoming().toUid != request.auth.uid
+        && requestId == incoming().fromUid + '__' + incoming().toUid
+        && incoming().createdAt == request.time
+        // Requests only go to real accounts — no junk docs at made-up uids.
+        && exists(/databases/$(database)/documents/users/$(incoming().toUid))
+        // No reverse duplicate: if they already asked you, accept instead.
+        && !exists(friendRequestRef(incoming().toUid, incoming().fromUid))
+        // Already friends — nothing to request.
+        && !exists(friendshipRef(incoming().fromUid, incoming().toUid))
+        && !isBlockedEitherWay(incoming().fromUid, incoming().toUid)
+        && hasFreshRateLimit(request.auth.uid, 'friendRequest');
+      allow update: if false;
+      // Sender cancels; recipient declines (or deletes as part of accepting).
+      allow delete: if isVerifiedUwUser()
+        && request.auth.uid in [resource.data.fromUid, resource.data.toUid];
+    }
+
+    // ------------------------------------------------------------------
+    // Friendships — friendships/{sortedUidA}__{sortedUidB} (PR 6). Created
+    // ONLY by the request recipient, atomically with the request deletion:
+    // the incoming request must exist before this batch and be gone after it
+    // (existsAfter), so a friendship can never appear while its request
+    // survives, and a bare create with no request is impossible. The sender
+    // structurally cannot self-accept — the required doc is {other}__{me},
+    // and the sender only ever holds {me}__{other}.
+    // ------------------------------------------------------------------
+
+    match /friendships/{pairId} {
+      // otherMember(): the friendship member who is not the caller.
+      function otherMember() {
+        return incoming().userIds[0] == request.auth.uid
+          ? incoming().userIds[1]
+          : incoming().userIds[0];
+      }
+
+      // get tolerates a missing doc (getFriendStatus probes the sorted-pair
+      // id before it knows whether a friendship exists).
+      allow get: if isVerifiedUwUser()
+        && (resource == null || request.auth.uid in resource.data.userIds);
+      allow list: if isVerifiedUwUser()
+        && request.auth.uid in resource.data.userIds;
+      allow create: if isVerifiedUwUser()
+        && incoming().keys().hasOnly(['userIds', 'acceptedBy', 'createdAt'])
+        && incoming().userIds is list
+        && incoming().userIds.size() == 2
+        && incoming().userIds[0] is string
+        && incoming().userIds[1] is string
+        && incoming().userIds[0] < incoming().userIds[1]
+        && request.auth.uid in incoming().userIds
+        && pairId == incoming().userIds[0] + '__' + incoming().userIds[1]
+        && incoming().acceptedBy == request.auth.uid
+        && incoming().createdAt == request.time
+        // Accept is atomic: the incoming request existed before the batch…
+        && exists(friendRequestRef(otherMember(), request.auth.uid))
+        // …and the same batch deletes it.
+        && !existsAfter(friendRequestRef(otherMember(), request.auth.uid))
+        && !isBlockedEitherWay(incoming().userIds[0], incoming().userIds[1]);
+      allow update: if false;
+      // Either friend may end the friendship.
+      allow delete: if isVerifiedUwUser()
+        && request.auth.uid in resource.data.userIds;
     }
 
     // ------------------------------------------------------------------

--- a/firestore.rules
+++ b/firestore.rules
@@ -150,24 +150,20 @@ service cloud.firestore {
 
     match /users/{userId} {
       allow read: if isVerifiedUwUser();
+      // displayNameLower rollout — PHASE 1 (this release): the field is
+      // OPTIONAL on create and update so already-shipped clients (which don't
+      // write it) keep working; when present, isValidPublicProfile pins it to
+      // displayName.lower() so it can never drift. The new app always writes
+      // it, and scripts/backfill-display-name-lower.mjs fills legacy docs after
+      // deploy. PHASE 2 (follow-up hardening, see docs/friends-rollout.md):
+      // make it mandatory on named create/rename once the minimum supported app
+      // version writes it. Do NOT tighten this before that version ships.
       allow create: if isOwner(userId)
         && isValidPublicProfile()
-        && incoming().createdAt == request.time
-        // A named profile must ship its search shadow field from creation so
-        // it is findable immediately (isValidPublicProfile pins the value).
-        && (!('displayName' in incoming()) || 'displayNameLower' in incoming());
+        && incoming().createdAt == request.time;
       allow update: if isOwner(userId)
         && isValidPublicProfile()
-        && incoming().createdAt == resource.data.createdAt
-        // A (re)named profile must carry displayNameLower in the same write.
-        // An unchanged name lets legacy docs (which may predate the field)
-        // edit unrelated fields without being forced to add it, and a legacy
-        // doc may add the field later (the sync check keeps it matching).
-        && (
-          !('displayName' in incoming())
-          || incoming().displayName == resource.data.get('displayName', null)
-          || 'displayNameLower' in incoming()
-        );
+        && incoming().createdAt == resource.data.createdAt;
       allow delete: if false; // deletion handled by the deleteUserAccount Cloud Function
 
       // Private subcollection: owner-only. Two client-writable docs:
@@ -612,15 +608,28 @@ service cloud.firestore {
         : /databases/$(database)/documents/friendships/$(userB + '__' + userA);
     }
 
+    // A safe pair-ID component. Studi accounts are created ONLY through
+    // Firebase email/password auth (no Admin createUser / importUsers / custom
+    // tokens anywhere in the codebase), so every uid is a Firebase-generated
+    // [A-Za-z0-9] string — it never contains `_`, `-`, or `__`. Enforcing this
+    // at write makes `{a}__{b}` an unambiguous, non-empty, delimiter-free
+    // encoding (mirrors functions/pair-id.js SAFE_UID_PATTERN and the client).
+    function isSafeUidComponent(value) {
+      return value is string && value.matches('^[A-Za-z0-9]{1,128}$');
+    }
+
     // Membership derived from the deterministic doc ID itself, not the doc
     // body. Both collections key on `{uidA}__{uidB}`, so splitting the id
     // yields the exact pair. Gating `get` on this — rather than on
     // `resource == null || <body check>` — means a missing doc and an existing
     // doc are BOTH denied to an outsider, closing the existence-probing side
-    // channel (a non-member can no longer tell "missing" from "denied"). A
-    // malformed id (not exactly two `__`-separated parts) is rejected.
+    // channel (a non-member can no longer tell "missing" from "denied").
+    // Malformed ids are rejected: exactly two segments, each a safe non-empty
+    // uid component (so empty segments like `__x` and `>2`-part ids fail).
     function isDeterministicPairMember(docId) {
       return docId.split('__').size() == 2
+        && isSafeUidComponent(docId.split('__')[0])
+        && isSafeUidComponent(docId.split('__')[1])
         && request.auth.uid in docId.split('__');
     }
 
@@ -640,6 +649,9 @@ service cloud.firestore {
         && incoming().fromUid == request.auth.uid
         && incoming().toUid is string
         && incoming().toUid != request.auth.uid
+        // Both components must be safe uids so the `__` id is unambiguous.
+        && isSafeUidComponent(incoming().fromUid)
+        && isSafeUidComponent(incoming().toUid)
         && requestId == incoming().fromUid + '__' + incoming().toUid
         && incoming().createdAt == request.time
         // Requests only go to real accounts — no junk docs at made-up uids.
@@ -686,8 +698,9 @@ service cloud.firestore {
         && incoming().keys().hasOnly(['userIds', 'acceptedBy', 'createdAt'])
         && incoming().userIds is list
         && incoming().userIds.size() == 2
-        && incoming().userIds[0] is string
-        && incoming().userIds[1] is string
+        // Safe uid components make the sorted `__` pair id unambiguous.
+        && isSafeUidComponent(incoming().userIds[0])
+        && isSafeUidComponent(incoming().userIds[1])
         && incoming().userIds[0] < incoming().userIds[1]
         && request.auth.uid in incoming().userIds
         && pairId == incoming().userIds[0] + '__' + incoming().userIds[1]

--- a/firestore.rules
+++ b/firestore.rules
@@ -31,6 +31,13 @@ service cloud.firestore {
         || exists(/databases/$(database)/documents/userBlocks/$(userB + '__' + userA));
     }
 
+    // Post-batch block check: a block created in the SAME batch as an accept
+    // must still prevent the friendship (exists() only sees pre-batch state).
+    function isBlockedEitherWayAfter(userA, userB) {
+      return existsAfter(/databases/$(database)/documents/userBlocks/$(userA + '__' + userB))
+        || existsAfter(/databases/$(database)/documents/userBlocks/$(userB + '__' + userA));
+    }
+
     function rateLimitRef(userId, action) {
       return /databases/$(database)/documents/rateLimits/$(userId)/actions/$(action);
     }
@@ -145,10 +152,22 @@ service cloud.firestore {
       allow read: if isVerifiedUwUser();
       allow create: if isOwner(userId)
         && isValidPublicProfile()
-        && incoming().createdAt == request.time;
+        && incoming().createdAt == request.time
+        // A named profile must ship its search shadow field from creation so
+        // it is findable immediately (isValidPublicProfile pins the value).
+        && (!('displayName' in incoming()) || 'displayNameLower' in incoming());
       allow update: if isOwner(userId)
         && isValidPublicProfile()
-        && incoming().createdAt == resource.data.createdAt;
+        && incoming().createdAt == resource.data.createdAt
+        // A (re)named profile must carry displayNameLower in the same write.
+        // An unchanged name lets legacy docs (which may predate the field)
+        // edit unrelated fields without being forced to add it, and a legacy
+        // doc may add the field later (the sync check keeps it matching).
+        && (
+          !('displayName' in incoming())
+          || incoming().displayName == resource.data.get('displayName', null)
+          || 'displayNameLower' in incoming()
+        );
       allow delete: if false; // deletion handled by the deleteUserAccount Cloud Function
 
       // Private subcollection: owner-only. Two client-writable docs:
@@ -593,16 +612,24 @@ service cloud.firestore {
         : /databases/$(database)/documents/friendships/$(userB + '__' + userA);
     }
 
+    // Membership derived from the deterministic doc ID itself, not the doc
+    // body. Both collections key on `{uidA}__{uidB}`, so splitting the id
+    // yields the exact pair. Gating `get` on this — rather than on
+    // `resource == null || <body check>` — means a missing doc and an existing
+    // doc are BOTH denied to an outsider, closing the existence-probing side
+    // channel (a non-member can no longer tell "missing" from "denied"). A
+    // malformed id (not exactly two `__`-separated parts) is rejected.
+    function isDeterministicPairMember(docId) {
+      return docId.split('__').size() == 2
+        && request.auth.uid in docId.split('__');
+    }
+
     match /friendRequests/{requestId} {
-      // get tolerates a missing doc so getFriendStatus can probe a request
-      // that may not exist (returns exists=false) instead of being denied —
-      // same shape as the conversations get rule.
+      // Involved-party only, by id membership — so getFriendStatus can probe a
+      // request that may not exist (returns exists=false) without leaking to
+      // outsiders whether any given pair has one.
       allow get: if isVerifiedUwUser()
-        && (
-          resource == null
-          || request.auth.uid == resource.data.fromUid
-          || request.auth.uid == resource.data.toUid
-        );
+        && isDeterministicPairMember(requestId);
       allow list: if isVerifiedUwUser()
         && (
           request.auth.uid == resource.data.fromUid
@@ -647,10 +674,12 @@ service cloud.firestore {
           : incoming().userIds[0];
       }
 
-      // get tolerates a missing doc (getFriendStatus probes the sorted-pair
-      // id before it knows whether a friendship exists).
+      // Member only, by id membership (getFriendStatus probes the sorted-pair
+      // id before it knows whether a friendship exists) — a missing doc and an
+      // existing one are alike denied to outsiders, so neither reveals the
+      // friendship's existence.
       allow get: if isVerifiedUwUser()
-        && (resource == null || request.auth.uid in resource.data.userIds);
+        && isDeterministicPairMember(pairId);
       allow list: if isVerifiedUwUser()
         && request.auth.uid in resource.data.userIds;
       allow create: if isVerifiedUwUser()
@@ -668,7 +697,11 @@ service cloud.firestore {
         && exists(friendRequestRef(otherMember(), request.auth.uid))
         // …and the same batch deletes it.
         && !existsAfter(friendRequestRef(otherMember(), request.auth.uid))
-        && !isBlockedEitherWay(incoming().userIds[0], incoming().userIds[1]);
+        // No block in either direction, judged BOTH before and after the
+        // batch — so a recipient can't create a block and the friendship in
+        // one batch (exists() alone would miss the same-batch block write).
+        && !isBlockedEitherWay(incoming().userIds[0], incoming().userIds[1])
+        && !isBlockedEitherWayAfter(incoming().userIds[0], incoming().userIds[1]);
       allow update: if false;
       // Either friend may end the friendship.
       allow delete: if isVerifiedUwUser()

--- a/firestore.rules
+++ b/firestore.rules
@@ -625,11 +625,15 @@ service cloud.firestore {
     // doc are BOTH denied to an outsider, closing the existence-probing side
     // channel (a non-member can no longer tell "missing" from "denied").
     // Malformed ids are rejected: exactly two segments, each a safe non-empty
-    // uid component (so empty segments like `__x` and `>2`-part ids fail).
+    // uid component, and the two members must be DISTINCT (so a self-pair id
+    // like `uid__uid` fails closed — no real request/friendship pairs a user
+    // with themselves). So empty segments (`__x`), `>2`-part ids, and self-pairs
+    // are all denied.
     function isDeterministicPairMember(docId) {
       return docId.split('__').size() == 2
         && isSafeUidComponent(docId.split('__')[0])
         && isSafeUidComponent(docId.split('__')[1])
+        && docId.split('__')[0] != docId.split('__')[1]
         && request.auth.uid in docId.split('__');
     }
 

--- a/functions/account-deletion.js
+++ b/functions/account-deletion.js
@@ -217,6 +217,22 @@ function createAccountDeletionRunner({ db, auth, FieldValue }) {
         },
       },
       {
+        // Pending requests in both directions (deterministic-ID docs, but
+        // queried by field so a partially-deleted page resumes cleanly).
+        name: "friend-requests",
+        run: async () => {
+          await deleteQueryBatch(db.collection("friendRequests").where("fromUid", "==", uid));
+          await deleteQueryBatch(db.collection("friendRequests").where("toUid", "==", uid));
+        },
+      },
+      {
+        // Friendships name both members in userIds — the counterpart loses the
+        // friendship too, same as the DM-conversation model above.
+        name: "friendships",
+        run: () =>
+          deleteQueryBatch(db.collection("friendships").where("userIds", "array-contains", uid)),
+      },
+      {
         // The aggregate trigger decrements location counts per delete.
         name: "location-ratings",
         run: () => deleteQueryBatch(db.collection("locationRatings").where("userId", "==", uid)),

--- a/functions/friend-suggestions.js
+++ b/functions/friend-suggestions.js
@@ -4,12 +4,49 @@
 // the bounded Admin reads to it.
 
 const { blockPairIdsFor } = require("./notification-validation");
+const { directedPairId, sortedPairId } = require("./pair-id");
 
 // Hard caps — every value the callable reads is bounded by one of these, so a
 // suggestion request can never fan out into an unbounded scan.
 const CANDIDATE_SCAN_LIMIT = 40; // users pulled from the class overlap query
-const RELATIONSHIP_SCAN_LIMIT = 500; // friends / requests loaded for exclusion
+// Deterministic relationship/block docs checked PER candidate — friendship,
+// both request directions, both block directions. Exclusion is per-pair, not a
+// scan of the caller's whole relationship set, so a friend/request/block beyond
+// any page cap can never leak back in as an actionable suggestion.
+const RELATIONSHIP_DOCS_PER_CANDIDATE = 5;
 const MAX_SUGGESTIONS = 15; // rows actually returned
+
+// Worst-case reads per getFriendSuggestions invocation:
+//   1 (caller profile)
+// + CANDIDATE_SCAN_LIMIT (class-overlap query)
+// + CANDIDATE_SCAN_LIMIT * RELATIONSHIP_DOCS_PER_CANDIDATE (one batched getAll)
+// = 1 + 40 + 200 = 241. No full-collection or full-relationship scan.
+const MAX_SUGGESTION_READS =
+  1 + CANDIDATE_SCAN_LIMIT + CANDIDATE_SCAN_LIMIT * RELATIONSHIP_DOCS_PER_CANDIDATE;
+
+/**
+ * The exactly-five deterministic docs whose existence means "already related"
+ * for one caller/candidate pair. Returned as {collection, id} so the caller can
+ * build refs and, from a set of existing "collection/id" keys, decide exclusion
+ * WITHOUT reading the caller's full friendships/requests.
+ */
+function relationshipDocRefsForCandidate(caller, candidate) {
+  return [
+    { collection: "friendships", id: sortedPairId(caller, candidate) },
+    { collection: "friendRequests", id: directedPairId(caller, candidate) },
+    { collection: "friendRequests", id: directedPairId(candidate, caller) },
+    { collection: "userBlocks", id: directedPairId(caller, candidate) },
+    { collection: "userBlocks", id: directedPairId(candidate, caller) },
+  ];
+}
+
+/** A candidate is excluded iff any of its five deterministic docs exists. */
+function isCandidateExcludedByExistence(caller, candidate, existingDocKeys) {
+  const keys = existingDocKeys instanceof Set ? existingDocKeys : new Set(existingDocKeys || []);
+  return relationshipDocRefsForCandidate(caller, candidate).some((ref) =>
+    keys.has(`${ref.collection}/${ref.id}`)
+  );
+}
 
 function sharedClassCodes(mine, theirs) {
   const theirSet = new Set(
@@ -80,8 +117,11 @@ function buildFriendSuggestions({
 
 module.exports = {
   CANDIDATE_SCAN_LIMIT,
-  RELATIONSHIP_SCAN_LIMIT,
+  RELATIONSHIP_DOCS_PER_CANDIDATE,
   MAX_SUGGESTIONS,
+  MAX_SUGGESTION_READS,
   buildFriendSuggestions,
+  isCandidateExcludedByExistence,
+  relationshipDocRefsForCandidate,
   sharedClassCodes,
 };

--- a/functions/friend-suggestions.js
+++ b/functions/friend-suggestions.js
@@ -1,0 +1,87 @@
+// functions/friend-suggestions.js — pure ranking/filtering for the friend
+// suggestions callable (PR 6). Kept free of firebase-admin so the exclusion
+// and bounds logic is unit-testable; the callable in functions/index.js wires
+// the bounded Admin reads to it.
+
+const { blockPairIdsFor } = require("./notification-validation");
+
+// Hard caps — every value the callable reads is bounded by one of these, so a
+// suggestion request can never fan out into an unbounded scan.
+const CANDIDATE_SCAN_LIMIT = 40; // users pulled from the class overlap query
+const RELATIONSHIP_SCAN_LIMIT = 500; // friends / requests loaded for exclusion
+const MAX_SUGGESTIONS = 15; // rows actually returned
+
+function sharedClassCodes(mine, theirs) {
+  const theirSet = new Set(
+    (theirs || [])
+      .filter((code) => typeof code === "string")
+      .map((code) => code.trim().toUpperCase())
+  );
+  return (mine || [])
+    .filter((code) => typeof code === "string")
+    .filter((code) => theirSet.has(code.trim().toUpperCase()));
+}
+
+/**
+ * Rank and bound suggestions from already-fetched inputs.
+ *   senderUid       — the caller
+ *   myClasses       — the caller's class codes
+ *   candidates      — [{ uid, displayName, classes }] from the overlap query
+ *   excludedUids    — Set of uids to drop (self + friends + pending either way)
+ *   existingBlockIds— Set of userBlocks doc IDs that exist (both directions)
+ *   limit           — max rows out (defaults to MAX_SUGGESTIONS)
+ * Returns [{ uid, displayName, classes, sharedClasses }], deduped by uid,
+ * only real class overlaps, ranked by overlap count then name, capped.
+ */
+function buildFriendSuggestions({
+  senderUid,
+  myClasses,
+  candidates,
+  excludedUids,
+  existingBlockIds,
+  limit = MAX_SUGGESTIONS,
+}) {
+  const excluded = excludedUids instanceof Set ? excludedUids : new Set(excludedUids || []);
+  const blocks = existingBlockIds instanceof Set ? existingBlockIds : new Set(existingBlockIds || []);
+  const seen = new Set();
+  const rows = [];
+
+  for (const candidate of candidates || []) {
+    const uid = candidate?.uid;
+    if (typeof uid !== "string" || !uid) continue;
+    if (uid === senderUid) continue;
+    if (seen.has(uid)) continue; // dedupe
+    if (excluded.has(uid)) continue;
+    // Blocked in either direction — never surface as an actionable suggestion.
+    if (blockPairIdsFor(senderUid, uid).some((id) => blocks.has(id))) continue;
+
+    const shared = sharedClassCodes(myClasses, candidate.classes);
+    if (shared.length === 0) continue;
+
+    seen.add(uid);
+    rows.push({
+      uid,
+      displayName: typeof candidate.displayName === "string" ? candidate.displayName : "",
+      classes: Array.isArray(candidate.classes)
+        ? candidate.classes.filter((c) => typeof c === "string")
+        : [],
+      sharedClasses: shared,
+    });
+  }
+
+  return rows
+    .sort(
+      (a, b) =>
+        b.sharedClasses.length - a.sharedClasses.length ||
+        a.displayName.localeCompare(b.displayName)
+    )
+    .slice(0, Math.max(0, limit));
+}
+
+module.exports = {
+  CANDIDATE_SCAN_LIMIT,
+  RELATIONSHIP_SCAN_LIMIT,
+  MAX_SUGGESTIONS,
+  buildFriendSuggestions,
+  sharedClassCodes,
+};

--- a/functions/index.js
+++ b/functions/index.js
@@ -32,7 +32,8 @@ const {
 const {
   buildFriendSuggestions,
   CANDIDATE_SCAN_LIMIT,
-  RELATIONSHIP_SCAN_LIMIT,
+  isCandidateExcludedByExistence,
+  relationshipDocRefsForCandidate,
 } = require("./friend-suggestions");
 
 admin.initializeApp();
@@ -733,14 +734,43 @@ exports.onUserBlockCreated = onDocumentCreated(
   }
 );
 
+// Per-invocation rate limit for read-heavy friend-suggestion calls. Reuses the
+// rateLimits/{uid}/actions/{action} pattern (Admin write bypasses client
+// rules), mirroring enforceDeleteAccountRateLimit. Throttled, not blocked:
+// clients refresh suggestions occasionally, not in a loop.
+const FRIEND_SUGGESTIONS_RATE_LIMIT_SECONDS = 3;
+
+async function enforceCallableRateLimit(uid, action, minIntervalSeconds) {
+  const ref = db.collection("rateLimits").doc(uid).collection("actions").doc(action);
+  const now = admin.firestore.Timestamp.now();
+
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    const previous = snap.exists ? snap.data()?.updatedAt : null;
+
+    if (
+      previous?.toMillis &&
+      now.toMillis() - previous.toMillis() < minIntervalSeconds * 1000
+    ) {
+      throw new HttpsError("resource-exhausted", "You're doing that too fast. Try again shortly.");
+    }
+
+    tx.set(ref, { updatedAt: now }, { merge: true });
+  });
+}
+
 // Friend suggestions (PR 6) — a callable, not a client query, because it must
-// filter candidates that BLOCKED the caller, and userBlocks list is
-// blocker-only (a client can't discover who blocked it). The Admin SDK checks
-// both block directions in one batched getAll, so no blocked candidate ever
-// leaves the server. Every read is bounded (see friend-suggestions.js caps):
-// one class-overlap scan, three relationship scans for exclusion, one block
-// getAll — no full-collection scan, no N+1 profile reads (candidate profiles
-// come from the single overlap query and are returned inline).
+// exclude candidates that BLOCKED the caller, and userBlocks list is
+// blocker-only (a client can't discover who blocked it), so client filtering
+// would leak blocked candidates as actionable Add rows. Exclusion is PER
+// CANDIDATE and deterministic: for each of ≤40 class-overlap candidates the
+// server checks exactly five docs (friendship + both request directions + both
+// block directions) in ONE batched getAll — never a scan of the caller's whole
+// friendships/requests, so a relationship beyond any page cap can't reappear.
+// Worst-case reads per call = 1 + 40 + 40*5 = 241 (MAX_SUGGESTION_READS). Only
+// public allowlisted fields (uid, displayName, classes, sharedClasses) are
+// returned. Verified-only + rate-limited; no App Check (no existing callable in
+// this project enforces it, so a half-configured requirement would be worse).
 exports.getFriendSuggestions = onCall(async (request) => {
   if (!isVerifiedUwCallable(request)) {
     throw new HttpsError("unauthenticated", "Sign in with a verified UW account.");
@@ -748,82 +778,73 @@ exports.getFriendSuggestions = onCall(async (request) => {
 
   const uid = request.auth.uid;
 
-  const meSnap = await db.collection("users").doc(uid).get();
-  const myClasses = Array.isArray(meSnap.data()?.classes)
-    ? meSnap.data().classes.filter((c) => typeof c === "string").slice(0, 10)
-    : [];
+  try {
+    await enforceCallableRateLimit(
+      uid,
+      "friendSuggestions",
+      FRIEND_SUGGESTIONS_RATE_LIMIT_SECONDS
+    );
 
-  if (myClasses.length === 0) {
-    return { suggestions: [] };
-  }
+    const meSnap = await db.collection("users").doc(uid).get();
+    const myClasses = Array.isArray(meSnap.data()?.classes)
+      ? meSnap.data().classes.filter((c) => typeof c === "string").slice(0, 10)
+      : [];
 
-  const [candidateSnap, friendsSnap, incomingSnap, outgoingSnap] = await Promise.all([
-    db
+    if (myClasses.length === 0) {
+      return { suggestions: [] };
+    }
+
+    // Bounded class-overlap candidate scan.
+    const candidateSnap = await db
       .collection("users")
       .where("classes", "array-contains-any", myClasses)
       .limit(CANDIDATE_SCAN_LIMIT)
-      .get(),
-    db
-      .collection("friendships")
-      .where("userIds", "array-contains", uid)
-      .limit(RELATIONSHIP_SCAN_LIMIT)
-      .get(),
-    db
-      .collection("friendRequests")
-      .where("toUid", "==", uid)
-      .limit(RELATIONSHIP_SCAN_LIMIT)
-      .get(),
-    db
-      .collection("friendRequests")
-      .where("fromUid", "==", uid)
-      .limit(RELATIONSHIP_SCAN_LIMIT)
-      .get(),
-  ]);
+      .get();
 
-  const excludedUids = new Set([uid]);
-  friendsSnap.forEach((docSnap) => {
-    const userIds = Array.isArray(docSnap.data()?.userIds) ? docSnap.data().userIds : [];
-    userIds.forEach((memberId) => {
-      if (typeof memberId === "string" && memberId !== uid) {
-        excludedUids.add(memberId);
+    const candidates = candidateSnap.docs
+      .filter((docSnap) => docSnap.id !== uid)
+      .map((docSnap) => ({
+        uid: docSnap.id,
+        displayName: docSnap.data()?.displayName,
+        classes: docSnap.data()?.classes,
+      }));
+
+    // One getAll over each candidate's five deterministic relationship/block
+    // docs — the only reads used for exclusion (no relationship scans).
+    const refPlans = candidates.flatMap((candidate) =>
+      relationshipDocRefsForCandidate(uid, candidate.uid)
+    );
+    const refs = refPlans.map((plan) => db.collection(plan.collection).doc(plan.id));
+    const snaps = refs.length > 0 ? await db.getAll(...refs) : [];
+    const existingDocKeys = new Set(
+      snaps
+        .filter((snap) => snap.exists)
+        .map((snap) => `${snap.ref.parent.id}/${snap.id}`)
+    );
+
+    const excludedUids = new Set([uid]);
+    for (const candidate of candidates) {
+      if (isCandidateExcludedByExistence(uid, candidate.uid, existingDocKeys)) {
+        excludedUids.add(candidate.uid);
       }
+    }
+
+    const suggestions = buildFriendSuggestions({
+      senderUid: uid,
+      myClasses,
+      candidates,
+      excludedUids,
+      existingBlockIds: new Set(), // block exclusion already folded into excludedUids
     });
-  });
-  incomingSnap.forEach((docSnap) => {
-    const fromUid = docSnap.data()?.fromUid;
-    if (typeof fromUid === "string") excludedUids.add(fromUid);
-  });
-  outgoingSnap.forEach((docSnap) => {
-    const toUid = docSnap.data()?.toUid;
-    if (typeof toUid === "string") excludedUids.add(toUid);
-  });
 
-  const candidates = candidateSnap.docs
-    .filter((docSnap) => docSnap.id !== uid && !excludedUids.has(docSnap.id))
-    .map((docSnap) => ({
-      uid: docSnap.id,
-      displayName: docSnap.data()?.displayName,
-      classes: docSnap.data()?.classes,
-    }));
-
-  // Both block directions for every surviving candidate, in one getAll.
-  const blockRefs = candidates.flatMap((candidate) =>
-    blockPairIdsFor(uid, candidate.uid).map((id) => db.collection("userBlocks").doc(id))
-  );
-  const blockSnaps = blockRefs.length > 0 ? await db.getAll(...blockRefs) : [];
-  const existingBlockIds = new Set(
-    blockSnaps.filter((snap) => snap.exists).map((snap) => snap.id)
-  );
-
-  const suggestions = buildFriendSuggestions({
-    senderUid: uid,
-    myClasses,
-    candidates,
-    excludedUids,
-    existingBlockIds,
-  });
-
-  return { suggestions };
+    return { suggestions };
+  } catch (error) {
+    if (error instanceof HttpsError) {
+      throw error; // already-normalized (unauthenticated, resource-exhausted)
+    }
+    console.warn("getFriendSuggestions failed", error);
+    throw new HttpsError("internal", "Couldn't load suggestions. Try again.");
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/functions/index.js
+++ b/functions/index.js
@@ -29,6 +29,11 @@ const {
   classifyDeletionRequest,
   createAccountDeletionRunner,
 } = require("./account-deletion");
+const {
+  buildFriendSuggestions,
+  CANDIDATE_SCAN_LIMIT,
+  RELATIONSHIP_SCAN_LIMIT,
+} = require("./friend-suggestions");
 
 admin.initializeApp();
 setGlobalOptions({ region: "us-central1", maxInstances: 5 });
@@ -727,6 +732,99 @@ exports.onUserBlockCreated = onDocumentCreated(
     );
   }
 );
+
+// Friend suggestions (PR 6) — a callable, not a client query, because it must
+// filter candidates that BLOCKED the caller, and userBlocks list is
+// blocker-only (a client can't discover who blocked it). The Admin SDK checks
+// both block directions in one batched getAll, so no blocked candidate ever
+// leaves the server. Every read is bounded (see friend-suggestions.js caps):
+// one class-overlap scan, three relationship scans for exclusion, one block
+// getAll — no full-collection scan, no N+1 profile reads (candidate profiles
+// come from the single overlap query and are returned inline).
+exports.getFriendSuggestions = onCall(async (request) => {
+  if (!isVerifiedUwCallable(request)) {
+    throw new HttpsError("unauthenticated", "Sign in with a verified UW account.");
+  }
+
+  const uid = request.auth.uid;
+
+  const meSnap = await db.collection("users").doc(uid).get();
+  const myClasses = Array.isArray(meSnap.data()?.classes)
+    ? meSnap.data().classes.filter((c) => typeof c === "string").slice(0, 10)
+    : [];
+
+  if (myClasses.length === 0) {
+    return { suggestions: [] };
+  }
+
+  const [candidateSnap, friendsSnap, incomingSnap, outgoingSnap] = await Promise.all([
+    db
+      .collection("users")
+      .where("classes", "array-contains-any", myClasses)
+      .limit(CANDIDATE_SCAN_LIMIT)
+      .get(),
+    db
+      .collection("friendships")
+      .where("userIds", "array-contains", uid)
+      .limit(RELATIONSHIP_SCAN_LIMIT)
+      .get(),
+    db
+      .collection("friendRequests")
+      .where("toUid", "==", uid)
+      .limit(RELATIONSHIP_SCAN_LIMIT)
+      .get(),
+    db
+      .collection("friendRequests")
+      .where("fromUid", "==", uid)
+      .limit(RELATIONSHIP_SCAN_LIMIT)
+      .get(),
+  ]);
+
+  const excludedUids = new Set([uid]);
+  friendsSnap.forEach((docSnap) => {
+    const userIds = Array.isArray(docSnap.data()?.userIds) ? docSnap.data().userIds : [];
+    userIds.forEach((memberId) => {
+      if (typeof memberId === "string" && memberId !== uid) {
+        excludedUids.add(memberId);
+      }
+    });
+  });
+  incomingSnap.forEach((docSnap) => {
+    const fromUid = docSnap.data()?.fromUid;
+    if (typeof fromUid === "string") excludedUids.add(fromUid);
+  });
+  outgoingSnap.forEach((docSnap) => {
+    const toUid = docSnap.data()?.toUid;
+    if (typeof toUid === "string") excludedUids.add(toUid);
+  });
+
+  const candidates = candidateSnap.docs
+    .filter((docSnap) => docSnap.id !== uid && !excludedUids.has(docSnap.id))
+    .map((docSnap) => ({
+      uid: docSnap.id,
+      displayName: docSnap.data()?.displayName,
+      classes: docSnap.data()?.classes,
+    }));
+
+  // Both block directions for every surviving candidate, in one getAll.
+  const blockRefs = candidates.flatMap((candidate) =>
+    blockPairIdsFor(uid, candidate.uid).map((id) => db.collection("userBlocks").doc(id))
+  );
+  const blockSnaps = blockRefs.length > 0 ? await db.getAll(...blockRefs) : [];
+  const existingBlockIds = new Set(
+    blockSnaps.filter((snap) => snap.exists).map((snap) => snap.id)
+  );
+
+  const suggestions = buildFriendSuggestions({
+    senderUid: uid,
+    myClasses,
+    candidates,
+    excludedUids,
+    existingBlockIds,
+  });
+
+  return { suggestions };
+});
 
 // ---------------------------------------------------------------------------
 // Session reminders: one fixed reminder ~30 minutes before start, for the

--- a/functions/index.js
+++ b/functions/index.js
@@ -16,6 +16,9 @@ const {
   blockPairIdsFor,
   dmNotificationId,
   filterBlockedRecipients,
+  friendAcceptedNotificationId,
+  friendCleanupPathsForBlock,
+  friendRequestNotificationId,
   groupMessageNotificationId,
   isWithinGroupChatFanoutLimit,
   normalizeNotificationPayload,
@@ -615,6 +618,111 @@ exports.onSessionParticipantsUpdated = onDocumentUpdated(
           actorId: hostId,
           sessionId,
         })
+      )
+    );
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Friends / Study Buddies (PR 6). Two notification triggers and one cleanup
+// trigger. Both notification triggers re-check the block relationship at fire
+// time (Admin SDK read of both userBlocks directions) so a block that lands
+// between the client write and the trigger still suppresses the record and
+// the push — the notification pipeline's block guarantee, matching group chat.
+// ---------------------------------------------------------------------------
+
+/** True if either direction of the block exists — one batched getAll. */
+async function isPairBlocked(userA, userB) {
+  const refs = blockPairIdsFor(userA, userB).map((id) =>
+    db.collection("userBlocks").doc(id)
+  );
+  const snaps = await db.getAll(...refs);
+  return snaps.some((snap) => snap.exists);
+}
+
+exports.onFriendRequestCreated = onDocumentCreated(
+  "friendRequests/{requestId}",
+  async (event) => {
+    const request = event.data?.data();
+    const fromUid = request?.fromUid;
+    const toUid = request?.toUid;
+
+    if (typeof fromUid !== "string" || typeof toUid !== "string" || fromUid === toUid) {
+      return;
+    }
+
+    // A block landing between the client write and this trigger still stops
+    // the notification — no record, no push for a blocked pair.
+    if (await isPairBlocked(fromUid, toUid)) {
+      return;
+    }
+
+    const senderName = (await getDisplayName(fromUid)) || "Someone";
+    await notifyUser(toUid, {
+      id: friendRequestNotificationId(event.id),
+      type: "friend_request",
+      title: "New study buddy request",
+      body: `${senderName} wants to be study buddies`,
+      url: "/friends",
+      actorId: fromUid,
+    });
+  }
+);
+
+exports.onFriendshipCreated = onDocumentCreated(
+  "friendships/{pairId}",
+  async (event) => {
+    const friendship = event.data?.data();
+    const acceptedBy = friendship?.acceptedBy;
+    const userIds = Array.isArray(friendship?.userIds)
+      ? friendship.userIds.filter((id) => typeof id === "string")
+      : [];
+
+    if (typeof acceptedBy !== "string" || userIds.length !== 2) {
+      return;
+    }
+
+    // Notify the ORIGINAL SENDER — the member who didn't click accept — that
+    // their request went through.
+    const originalSender = userIds.find((uid) => uid !== acceptedBy);
+    if (!originalSender) {
+      return;
+    }
+
+    if (await isPairBlocked(originalSender, acceptedBy)) {
+      return;
+    }
+
+    const accepterName = (await getDisplayName(acceptedBy)) || "Someone";
+    await notifyUser(originalSender, {
+      id: friendAcceptedNotificationId(event.id),
+      type: "friend_accepted",
+      title: "Study buddy request accepted",
+      body: `${accepterName} accepted your study buddy request`,
+      url: `/user/${acceptedBy}`,
+      actorId: acceptedBy,
+    });
+  }
+);
+
+// Block cleanup: creating a block severs any friendship and pending requests
+// between the pair, at deterministic IDs (no queries). Idempotent — deleting
+// an absent doc is a no-op — so an Eventarc retry is safe.
+exports.onUserBlockCreated = onDocumentCreated(
+  "userBlocks/{blockId}",
+  async (event) => {
+    const block = event.data?.data();
+    const blockerUserId = block?.blockerUserId;
+    const blockedUserId = block?.blockedUserId;
+
+    if (typeof blockerUserId !== "string" || typeof blockedUserId !== "string") {
+      return;
+    }
+
+    const paths = friendCleanupPathsForBlock(blockerUserId, blockedUserId);
+    await Promise.all(
+      paths.map(({ collection, id }) =>
+        db.collection(collection).doc(id).delete()
       )
     );
   }

--- a/functions/notification-validation.js
+++ b/functions/notification-validation.js
@@ -6,6 +6,8 @@
 // The client mirrors the URL rules in lib/notifications.ts
 // (isAllowedNotificationUrl) — change both together.
 
+const { directedPairId, sortedPairId } = require("./pair-id");
+
 const NOTIFICATION_TYPES = new Set([
   "dm_message",
   "session_joined",
@@ -156,14 +158,14 @@ function friendAcceptedNotificationId(eventId) {
 
 /**
  * Doc paths (collection/docId) removed when userA and userB become blocked:
- * friendRequests in both directions plus the sorted-pair friendship.
+ * friendRequests in both directions plus the sorted-pair friendship. IDs come
+ * from the shared pair-id helpers so client, Functions, and rules agree.
  */
 function friendCleanupPathsForBlock(blockerUserId, blockedUserId) {
-  const sorted = [blockerUserId, blockedUserId].sort();
   return [
-    { collection: "friendRequests", id: `${blockerUserId}__${blockedUserId}` },
-    { collection: "friendRequests", id: `${blockedUserId}__${blockerUserId}` },
-    { collection: "friendships", id: `${sorted[0]}__${sorted[1]}` },
+    { collection: "friendRequests", id: directedPairId(blockerUserId, blockedUserId) },
+    { collection: "friendRequests", id: directedPairId(blockedUserId, blockerUserId) },
+    { collection: "friendships", id: sortedPairId(blockerUserId, blockedUserId) },
   ];
 }
 
@@ -193,7 +195,10 @@ function isWithinGroupChatFanoutLimit(participantCount) {
 
 /** Both directions of the deterministic userBlocks/{blocker}__{blocked} doc ID. */
 function blockPairIdsFor(senderId, recipientId) {
-  return [`${senderId}__${recipientId}`, `${recipientId}__${senderId}`];
+  return [
+    directedPairId(senderId, recipientId),
+    directedPairId(recipientId, senderId),
+  ];
 }
 
 /**

--- a/functions/notification-validation.js
+++ b/functions/notification-validation.js
@@ -31,8 +31,8 @@ function isSafeId(value) {
 
 /**
  * Strict allowlist for notification navigation targets. Valid forms:
- *   /notifications
- *   /conversation/{id}   /session/{id}   /session-chat/{id}
+ *   /notifications   /friends
+ *   /conversation/{id}   /session/{id}   /session-chat/{id}   /user/{id}
  * where {id} must be a safe internal ID (see SAFE_ID_PATTERN). The segment is
  * also run through decodeURIComponent and must decode to itself, so
  * percent-encoded separators (%2F, %5C), traversal (`.`/`..`), external
@@ -43,11 +43,11 @@ function isAllowedNotificationUrl(url) {
     return false;
   }
 
-  if (url === "/notifications") {
+  if (url === "/notifications" || url === "/friends") {
     return true;
   }
 
-  const match = /^\/(conversation|session|session-chat)\/([^/]+)$/.exec(url);
+  const match = /^\/(conversation|session|session-chat|user)\/([^/]+)$/.exec(url);
   if (!match) {
     return false;
   }
@@ -137,6 +137,36 @@ function groupMessageNotificationId(sessionId, eventId) {
   return `gm_${sanitizeIdPart(sessionId)}_${sanitizeIdPart(eventId)}`;
 }
 
+/** One record per friend-request create event; retries of that event dedupe. */
+function friendRequestNotificationId(eventId) {
+  return `fr_${sanitizeIdPart(eventId)}`;
+}
+
+/** One record per friendship create (accept) event; retries dedupe. */
+function friendAcceptedNotificationId(eventId) {
+  return `fa_${sanitizeIdPart(eventId)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Friend cleanup on block. Creating a block must sever the pair server-side:
+// both pending request directions and the friendship, all at deterministic
+// IDs — three targeted deletes, no queries. Pure so tests can pin the exact
+// paths the onUserBlockCreated trigger deletes.
+// ---------------------------------------------------------------------------
+
+/**
+ * Doc paths (collection/docId) removed when userA and userB become blocked:
+ * friendRequests in both directions plus the sorted-pair friendship.
+ */
+function friendCleanupPathsForBlock(blockerUserId, blockedUserId) {
+  const sorted = [blockerUserId, blockedUserId].sort();
+  return [
+    { collection: "friendRequests", id: `${blockerUserId}__${blockedUserId}` },
+    { collection: "friendRequests", id: `${blockedUserId}__${blockerUserId}` },
+    { collection: "friendships", id: `${sorted[0]}__${sorted[1]}` },
+  ];
+}
+
 // Group-chat fanout ceiling. New sessions are capacity-capped at 20 already,
 // but legacy sessions have no capacity field and unbounded participantIds —
 // the ceiling is judged on the ACTUAL participant count, never on capacity.
@@ -195,6 +225,9 @@ module.exports = {
   blockPairIdsFor,
   dmNotificationId,
   filterBlockedRecipients,
+  friendAcceptedNotificationId,
+  friendCleanupPathsForBlock,
+  friendRequestNotificationId,
   groupMessageNotificationId,
   isAllowedNotificationUrl,
   isSafeId,

--- a/functions/pair-id.js
+++ b/functions/pair-id.js
@@ -1,0 +1,61 @@
+// functions/pair-id.js — the single source of truth for deterministic
+// pair/relationship document IDs (PR 6). Dependency-free so it is unit-testable
+// and shareable across the Cloud Functions. The client mirrors this exactly in
+// lib/friends.ts (SAFE_UID_PATTERN / buildFriendRequestId / buildFriendshipId),
+// and firestore.rules mirrors the same shape checks — change all three together.
+//
+// Encoding decision (documented in docs/friends-rollout.md): IDs are a plain
+// `${uidA}__${uidB}` join, consistent with the rest of the app (conversations,
+// userBlocks, locationRatings). This is unambiguous ONLY because every Studi
+// account is created through Firebase email/password auth
+// (createUserWithEmailAndPassword — the sole account-creation path in the
+// codebase; no Admin createUser/importUsers/custom tokens), so UIDs are
+// Firebase-generated and match [A-Za-z0-9]{1,128} — they never contain `_`,
+// `-`, or `__`. That constraint is ENFORCED at every friend write (rules +
+// client validate each component against SAFE_UID_PATTERN), so a UID that
+// somehow fell outside it fails closed rather than producing an ambiguous ID.
+
+const SAFE_UID_PATTERN = /^[A-Za-z0-9]{1,128}$/;
+
+function isSafeUid(uid) {
+  return typeof uid === "string" && SAFE_UID_PATTERN.test(uid);
+}
+
+/** Directed pair id — order is meaningful (friend REQUESTS: from → to). */
+function directedPairId(fromUid, toUid) {
+  return `${fromUid}__${toUid}`;
+}
+
+/** Sorted pair id — order-independent (FRIENDSHIPS, blocks-as-a-pair). */
+function sortedPairId(userA, userB) {
+  return [userA, userB].sort().join("__");
+}
+
+/**
+ * Parse a deterministic pair id into its two members, or null if the id is
+ * malformed: not exactly two `__`-separated parts, an empty/unsafe component,
+ * or a self-pair. This is the canonical "is this a well-formed pair id"
+ * validator — rules mirror the same checks (size == 2, non-empty, distinct).
+ */
+function parsePairMembers(docId) {
+  if (typeof docId !== "string") {
+    return null;
+  }
+  const parts = docId.split("__");
+  if (parts.length !== 2) {
+    return null;
+  }
+  const [a, b] = parts;
+  if (!isSafeUid(a) || !isSafeUid(b) || a === b) {
+    return null;
+  }
+  return [a, b];
+}
+
+module.exports = {
+  SAFE_UID_PATTERN,
+  isSafeUid,
+  directedPairId,
+  sortedPairId,
+  parsePairMembers,
+};

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -81,6 +81,12 @@ export type AnalyticsEvent =
   | "group_message_sent"
   | "report_submitted"
   | "user_blocked"
+  | "friends_viewed"
+  | "friend_request_sent"
+  | "friend_request_accepted"
+  | "friend_request_declined"
+  | "friend_request_cancelled"
+  | "friend_removed"
   | "user_unblocked"
   | "account_deleted"
   | "screen_view";

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -37,6 +37,8 @@ import { db } from "../firebaseConfig";
 import { track } from "./analytics";
 export const COLLECTIONS = {
   conversations: "conversations",
+  friendRequests: "friendRequests",
+  friendships: "friendships",
   locationRatings: "locationRatings",
   locations: "locations",
   reports: "reports",
@@ -46,13 +48,19 @@ export const COLLECTIONS = {
   users: "users",
 } as const;
 
-type RateLimitedAction = "createSession" | "locationRating" | "reportUser" | "sendMessage";
+type RateLimitedAction =
+  | "createSession"
+  | "friendRequest"
+  | "locationRating"
+  | "reportUser"
+  | "sendMessage";
 
 function rateLimitDoc(userId: string, action: RateLimitedAction) {
   return doc(db, COLLECTIONS.rateLimits, userId, "actions", action);
 }
 
-function stageRateLimit(
+/** Exported for lib/friends.ts — every abuse-prone write batches one of these. */
+export function stageRateLimit(
   batch: ReturnType<typeof writeBatch>,
   userId: string,
   action: RateLimitedAction
@@ -87,7 +95,8 @@ function isUserYear(value: unknown): value is UserYear {
   return typeof value === "string" && (USER_YEARS as readonly string[]).includes(value);
 }
 
-function parseUserProfile(uid: string, data: Record<string, unknown>): UserProfile {
+/** Exported for lib/friends.ts (search/suggestion query snapshots). */
+export function parseUserProfile(uid: string, data: Record<string, unknown>): UserProfile {
   return {
     uid,
     displayName: typeof data.displayName === "string" ? data.displayName : "",
@@ -348,7 +357,14 @@ export async function createOrUpdateUserProfile(
   const publicPayload: Record<string, unknown> = {
     updatedAt: serverTimestamp(),
     ...(existing.exists() ? {} : { createdAt: serverTimestamp(), classes: [] }),
-    ...(data.displayName ? { displayName: data.displayName } : {}),
+    // displayNameLower rides along with every displayName write (rules require
+    // the pair to match) — it backs the case-insensitive friend search.
+    ...(data.displayName
+      ? {
+          displayName: data.displayName,
+          displayNameLower: data.displayName.toLowerCase(),
+        }
+      : {}),
   };
 
   await setDoc(publicRef, publicPayload, { merge: true });
@@ -459,6 +475,9 @@ export async function updateUserDisplayName(userId: string, displayName: string)
 
   await updateDoc(doc(db, COLLECTIONS.users, userId), {
     displayName: trimmed,
+    // Search shadow field — rules pin it to displayName.lower(), and legacy
+    // docs gain it the first time the user re-saves their name.
+    displayNameLower: trimmed.toLowerCase(),
     updatedAt: serverTimestamp(),
   });
   // Keep the Auth profile in sync so future profile writes can never resurrect

--- a/lib/friends.ts
+++ b/lib/friends.ts
@@ -28,7 +28,9 @@ import {
   type QueryDocumentSnapshot,
 } from "firebase/firestore";
 
-import { db } from "../firebaseConfig";
+import { getFunctions, httpsCallable } from "firebase/functions";
+
+import app, { db } from "../firebaseConfig";
 import {
   buildParticipantKey,
   COLLECTIONS,
@@ -41,7 +43,6 @@ import {
 export const FRIENDS_PAGE_SIZE = 30;
 export const FRIEND_SEARCH_LIMIT = 20;
 export const FRIEND_SEARCH_MIN_QUERY_LENGTH = 2;
-export const SUGGESTED_CLASSMATES_LIMIT = 25;
 
 export type FriendRequest = {
   requestId: string;
@@ -382,15 +383,28 @@ export async function searchUsersByNamePrefix(
     }
   }
 
-  return [...byUid.values()]
+  const matches = [...byUid.values()]
     .sort((a, b) => a.displayName.localeCompare(b.displayName))
     .slice(0, FRIEND_SEARCH_LIMIT);
+
+  // Drop anyone blocked in either direction so a blocked user never appears
+  // with an actionable "Add" button. Bounded: ≤ FRIEND_SEARCH_LIMIT results,
+  // each a deterministic-ID pair of block gets (both allowed by rules since
+  // the caller is named in the block id).
+  const blockedFlags = await Promise.all(
+    matches.map((profile) => isBlockedEitherDirection(currentUid, profile.uid))
+  );
+  return matches.filter((_, index) => !blockedFlags[index]);
 }
 
 // ---------------------------------------------------------------------------
-// Suggestions — ONE bounded array-contains-any query over the viewer's
-// classes (Firestore caps the disjunction at 10 values), ranked by shared-
-// class count. Never a global user scan, never a fabricated user.
+// Suggestions — served by the getFriendSuggestions Cloud Function, NOT a
+// client query. The callable must exclude anyone who BLOCKED the caller, and
+// userBlocks list is blocker-only, so a client can't discover who blocked it —
+// filtering client-side would leak blocked candidates as actionable "Add"
+// rows. The callable checks both block directions with the Admin SDK and
+// returns a bounded, already-filtered, already-ranked list, so there is no
+// unbounded scan and no N+1 profile read on the client.
 // ---------------------------------------------------------------------------
 
 export type SuggestedClassmate = {
@@ -398,40 +412,36 @@ export type SuggestedClassmate = {
   sharedClasses: string[];
 };
 
-export async function getSuggestedClassmates(
-  currentUid: string,
-  myClasses: string[],
-  excludeUids: Iterable<string>
-): Promise<SuggestedClassmate[]> {
-  const classIds = [...new Set(myClasses.map((code) => code.trim()).filter(Boolean))].slice(
-    0,
-    10
+type FriendSuggestionDTO = {
+  uid: string;
+  displayName: string;
+  classes: string[];
+  sharedClasses: string[];
+};
+
+export async function getSuggestedClassmates(): Promise<SuggestedClassmate[]> {
+  const callable = httpsCallable<unknown, { suggestions: FriendSuggestionDTO[] }>(
+    getFunctions(app, "us-central1"),
+    "getFriendSuggestions"
   );
 
-  if (classIds.length === 0) {
-    return [];
-  }
+  const response = await callable({});
+  const suggestions = Array.isArray(response.data?.suggestions)
+    ? response.data.suggestions
+    : [];
 
-  const snapshot = await getDocs(
-    query(
-      collection(db, COLLECTIONS.users),
-      where("classes", "array-contains-any", classIds),
-      limit(SUGGESTED_CLASSMATES_LIMIT)
-    )
-  );
-
-  const excluded = new Set([currentUid, ...excludeUids]);
-
-  return snapshot.docs
-    .filter((docSnap) => !excluded.has(docSnap.id))
-    .map((docSnap) => {
-      const profile = parseUserProfile(docSnap.id, docSnap.data());
-      return { profile, sharedClasses: sharedClasses(myClasses, profile.classes) };
-    })
-    .filter((candidate) => candidate.sharedClasses.length > 0)
-    .sort(
-      (a, b) =>
-        b.sharedClasses.length - a.sharedClasses.length ||
-        a.profile.displayName.localeCompare(b.profile.displayName)
-    );
+  return suggestions
+    .filter((item): item is FriendSuggestionDTO => typeof item?.uid === "string")
+    .map((item) => ({
+      profile: {
+        uid: item.uid,
+        displayName: typeof item.displayName === "string" ? item.displayName : "",
+        classes: Array.isArray(item.classes)
+          ? item.classes.filter((code) => typeof code === "string")
+          : [],
+      },
+      sharedClasses: Array.isArray(item.sharedClasses)
+        ? item.sharedClasses.filter((code) => typeof code === "string")
+        : [],
+    }));
 }

--- a/lib/friends.ts
+++ b/lib/friends.ts
@@ -1,0 +1,437 @@
+// lib/friends.ts — client data layer for Friends / Study Buddies (PR 6).
+//
+// Data model (mirrored in firestore.rules — the rules are the enforcement):
+//   friendRequests/{fromUid}__{toUid}   { fromUid, toUid, createdAt }
+//     Doc existence IS the pending state. Create = send, delete by sender =
+//     cancel, delete by recipient = decline or accept.
+//   friendships/{sortedUidA}__{sortedUidB}   { userIds, acceptedBy, createdAt }
+//     Created only by the request recipient, in the same batch that deletes
+//     the request — rules enforce the atomicity with exists/existsAfter.
+//
+// Every list here is paginated and every profile hydration goes through
+// getProfilesByIds (batched + cached) — no unbounded reads, no N+1.
+
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  serverTimestamp,
+  startAfter,
+  Timestamp,
+  where,
+  writeBatch,
+  type QueryDocumentSnapshot,
+} from "firebase/firestore";
+
+import { db } from "../firebaseConfig";
+import {
+  buildParticipantKey,
+  COLLECTIONS,
+  getProfilesByIds,
+  parseUserProfile,
+  stageRateLimit,
+  type UserProfile,
+} from "./firestore";
+
+export const FRIENDS_PAGE_SIZE = 30;
+export const FRIEND_SEARCH_LIMIT = 20;
+export const FRIEND_SEARCH_MIN_QUERY_LENGTH = 2;
+export const SUGGESTED_CLASSMATES_LIMIT = 25;
+
+export type FriendRequest = {
+  requestId: string;
+  fromUid: string;
+  toUid: string;
+  createdAt: Timestamp | null;
+};
+
+export type Friendship = {
+  friendshipId: string;
+  userIds: string[];
+  acceptedBy: string;
+  createdAt: Timestamp | null;
+};
+
+/** A friend row: the other user's uid plus their (possibly deleted) profile. */
+export type FriendListItem = {
+  friendUid: string;
+  profile: UserProfile | null;
+  createdAt: Timestamp | null;
+};
+
+/** A request row hydrated with the OTHER party's profile. */
+export type FriendRequestListItem = FriendRequest & {
+  otherUid: string;
+  profile: UserProfile | null;
+};
+
+export type FriendsPage<T> = {
+  items: T[];
+  /** Pass back to fetch the next page; null when exhausted. */
+  cursor: QueryDocumentSnapshot | null;
+  hasMore: boolean;
+};
+
+/** How the current user relates to another user, for profile/action states. */
+export type FriendStatus =
+  | "self"
+  | "friends"
+  | "outgoing" // we sent them a pending request
+  | "incoming" // they sent us a pending request
+  | "none";
+
+export function buildFriendRequestId(fromUid: string, toUid: string) {
+  return `${fromUid}__${toUid}`;
+}
+
+/** Sorted pair key — same convention as DM conversations. */
+export function buildFriendshipId(userA: string, userB: string) {
+  return buildParticipantKey(userA, userB);
+}
+
+/** Class codes both users share, in the viewer's saved order. */
+export function sharedClasses(mine: string[], theirs: string[]): string[] {
+  const theirSet = new Set(theirs.map((code) => code.trim().toUpperCase()));
+  return mine.filter((code) => theirSet.has(code.trim().toUpperCase()));
+}
+
+function friendRequestDoc(fromUid: string, toUid: string) {
+  return doc(db, COLLECTIONS.friendRequests, buildFriendRequestId(fromUid, toUid));
+}
+
+function friendshipDoc(userA: string, userB: string) {
+  return doc(db, COLLECTIONS.friendships, buildFriendshipId(userA, userB));
+}
+
+function asTimestamp(value: unknown): Timestamp | null {
+  return value instanceof Timestamp ? value : null;
+}
+
+function parseFriendRequest(id: string, data: Record<string, unknown>): FriendRequest {
+  return {
+    requestId: id,
+    fromUid: typeof data.fromUid === "string" ? data.fromUid : "",
+    toUid: typeof data.toUid === "string" ? data.toUid : "",
+    createdAt: asTimestamp(data.createdAt),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mutations. Rules re-enforce every invariant server-side (self-request,
+// duplicates, blocks, atomic accept); the client checks are for friendly
+// errors, not security.
+// ---------------------------------------------------------------------------
+
+export async function sendFriendRequest(fromUid: string, toUid: string) {
+  if (fromUid === toUid) {
+    throw new Error("You can't send yourself a friend request.");
+  }
+
+  const batch = writeBatch(db);
+  batch.set(friendRequestDoc(fromUid, toUid), {
+    fromUid,
+    toUid,
+    createdAt: serverTimestamp(),
+  });
+  stageRateLimit(batch, fromUid, "friendRequest");
+  await batch.commit();
+}
+
+export async function cancelFriendRequest(fromUid: string, toUid: string) {
+  await deleteDoc(friendRequestDoc(fromUid, toUid));
+}
+
+export async function declineFriendRequest(currentUid: string, fromUid: string) {
+  await deleteDoc(friendRequestDoc(fromUid, currentUid));
+}
+
+/**
+ * Accept = one atomic batch: delete their incoming request, create the
+ * friendship. Rules only allow the friendship create when the request existed
+ * before the batch AND is gone after it, so a partial accept can't exist.
+ * If both users requested each other, the now-moot outgoing request is
+ * deleted in the same batch.
+ */
+export async function acceptFriendRequest(currentUid: string, fromUid: string) {
+  const outgoing = await getDoc(friendRequestDoc(currentUid, fromUid));
+
+  const batch = writeBatch(db);
+  batch.delete(friendRequestDoc(fromUid, currentUid));
+  if (outgoing.exists()) {
+    batch.delete(friendRequestDoc(currentUid, fromUid));
+  }
+  batch.set(friendshipDoc(currentUid, fromUid), {
+    userIds: [currentUid, fromUid].sort(),
+    acceptedBy: currentUid,
+    createdAt: serverTimestamp(),
+  });
+  await batch.commit();
+}
+
+export async function removeFriend(currentUid: string, otherUid: string) {
+  await deleteDoc(friendshipDoc(currentUid, otherUid));
+}
+
+// ---------------------------------------------------------------------------
+// Reads — paginated lists, hydrated through the batched profile cache.
+// Composite indexes (firestore.indexes.json):
+//   friendships(userIds CONTAINS, createdAt DESC)
+//   friendRequests(toUid ASC, createdAt DESC)
+//   friendRequests(fromUid ASC, createdAt DESC)
+// ---------------------------------------------------------------------------
+
+export async function getFriendsPage(
+  currentUid: string,
+  cursor?: QueryDocumentSnapshot | null
+): Promise<FriendsPage<FriendListItem>> {
+  const snapshot = await getDocs(
+    query(
+      collection(db, COLLECTIONS.friendships),
+      where("userIds", "array-contains", currentUid),
+      orderBy("createdAt", "desc"),
+      ...(cursor ? [startAfter(cursor)] : []),
+      limit(FRIENDS_PAGE_SIZE)
+    )
+  );
+
+  const rows = snapshot.docs.map((docSnap) => {
+    const userIds = Array.isArray(docSnap.data().userIds)
+      ? (docSnap.data().userIds as unknown[]).filter(
+          (id): id is string => typeof id === "string"
+        )
+      : [];
+    return {
+      friendUid: userIds.find((id) => id !== currentUid) ?? "",
+      createdAt: asTimestamp(docSnap.data().createdAt),
+    };
+  });
+
+  const profilesById = await getProfilesByIds(rows.map((row) => row.friendUid));
+  const hasMore = snapshot.size === FRIENDS_PAGE_SIZE;
+
+  return {
+    items: rows
+      .filter((row) => row.friendUid)
+      .map((row) => ({ ...row, profile: profilesById.get(row.friendUid) ?? null })),
+    cursor: hasMore ? snapshot.docs[snapshot.docs.length - 1] : null,
+    hasMore,
+  };
+}
+
+async function getRequestsPage(
+  field: "fromUid" | "toUid",
+  currentUid: string,
+  cursor?: QueryDocumentSnapshot | null
+): Promise<FriendsPage<FriendRequestListItem>> {
+  const snapshot = await getDocs(
+    query(
+      collection(db, COLLECTIONS.friendRequests),
+      where(field, "==", currentUid),
+      orderBy("createdAt", "desc"),
+      ...(cursor ? [startAfter(cursor)] : []),
+      limit(FRIENDS_PAGE_SIZE)
+    )
+  );
+
+  const requests = snapshot.docs.map((docSnap) =>
+    parseFriendRequest(docSnap.id, docSnap.data())
+  );
+  const otherUidOf = (request: FriendRequest) =>
+    field === "toUid" ? request.fromUid : request.toUid;
+  const profilesById = await getProfilesByIds(requests.map(otherUidOf));
+  const hasMore = snapshot.size === FRIENDS_PAGE_SIZE;
+
+  return {
+    items: requests.map((request) => ({
+      ...request,
+      otherUid: otherUidOf(request),
+      profile: profilesById.get(otherUidOf(request)) ?? null,
+    })),
+    cursor: hasMore ? snapshot.docs[snapshot.docs.length - 1] : null,
+    hasMore,
+  };
+}
+
+export function getIncomingRequestsPage(
+  currentUid: string,
+  cursor?: QueryDocumentSnapshot | null
+) {
+  return getRequestsPage("toUid", currentUid, cursor);
+}
+
+export function getOutgoingRequestsPage(
+  currentUid: string,
+  cursor?: QueryDocumentSnapshot | null
+) {
+  return getRequestsPage("fromUid", currentUid, cursor);
+}
+
+/**
+ * Relationship between the viewer and another user: 3 deterministic-ID gets
+ * (friendship + both request directions), no queries.
+ */
+export async function getFriendStatus(
+  currentUid: string,
+  otherUid: string
+): Promise<FriendStatus> {
+  if (currentUid === otherUid) {
+    return "self";
+  }
+
+  const [friendship, outgoing, incoming] = await Promise.all([
+    getDoc(friendshipDoc(currentUid, otherUid)),
+    getDoc(friendRequestDoc(currentUid, otherUid)),
+    getDoc(friendRequestDoc(otherUid, currentUid)),
+  ]);
+
+  if (friendship.exists()) {
+    return "friends";
+  }
+  if (incoming.exists()) {
+    return "incoming";
+  }
+  if (outgoing.exists()) {
+    return "outgoing";
+  }
+  return "none";
+}
+
+/**
+ * Whether a block exists in either direction. Rules allow either side to
+ * `get` the single block doc naming them, so both probes are readable —
+ * this powers the profile screen's unavailable state.
+ */
+export async function isBlockedEitherDirection(
+  currentUid: string,
+  otherUid: string
+): Promise<boolean> {
+  const [mine, theirs] = await Promise.all([
+    getDoc(doc(db, COLLECTIONS.userBlocks, `${currentUid}__${otherUid}`)),
+    getDoc(doc(db, COLLECTIONS.userBlocks, `${otherUid}__${currentUid}`)),
+  ]);
+  return mine.exists() || theirs.exists();
+}
+
+// ---------------------------------------------------------------------------
+// Search — bounded prefix search on displayNameLower (Firestore range scans
+// are case-sensitive, hence the lowercase shadow field written alongside
+// every displayName). Legacy profiles created before the field exists are
+// covered by a second bounded query on the raw displayName using a
+// title-cased variant of the query — most stored names are "First Last" —
+// until the documented backfill (scripts/backfill-display-name-lower.mjs)
+// runs or the user re-saves their name. Two limit-20 reads per search, ever.
+// ---------------------------------------------------------------------------
+
+function titleCase(value: string) {
+  return value
+    .split(/(\s+)/)
+    .map((part) => (part.trim() ? part[0].toUpperCase() + part.slice(1) : part))
+    .join("");
+}
+
+export async function searchUsersByNamePrefix(
+  currentUid: string,
+  rawQuery: string
+): Promise<UserProfile[]> {
+  const normalized = rawQuery.trim().toLowerCase();
+
+  if (normalized.length < FRIEND_SEARCH_MIN_QUERY_LENGTH) {
+    return [];
+  }
+
+  const usersRef = collection(db, COLLECTIONS.users);
+  const prefixEnd = `${normalized}\uf8ff`;
+  const legacyPrefix = titleCase(rawQuery.trim());
+
+  const [canonical, legacy] = await Promise.all([
+    getDocs(
+      query(
+        usersRef,
+        orderBy("displayNameLower"),
+        where("displayNameLower", ">=", normalized),
+        where("displayNameLower", "<=", prefixEnd),
+        limit(FRIEND_SEARCH_LIMIT)
+      )
+    ),
+    getDocs(
+      query(
+        usersRef,
+        orderBy("displayName"),
+        where("displayName", ">=", legacyPrefix),
+        where("displayName", "<=", `${legacyPrefix}\uf8ff`),
+        limit(FRIEND_SEARCH_LIMIT)
+      )
+    ),
+  ]);
+
+  const byUid = new Map<string, UserProfile>();
+  for (const docSnap of [...canonical.docs, ...legacy.docs]) {
+    if (docSnap.id === currentUid || byUid.has(docSnap.id)) {
+      continue;
+    }
+    const profile = parseUserProfile(docSnap.id, docSnap.data());
+    // The legacy query is case-sensitive over-approximation — keep only real
+    // case-insensitive prefix matches so both paths behave identically.
+    if (profile.displayName.toLowerCase().startsWith(normalized)) {
+      byUid.set(docSnap.id, profile);
+    }
+  }
+
+  return [...byUid.values()]
+    .sort((a, b) => a.displayName.localeCompare(b.displayName))
+    .slice(0, FRIEND_SEARCH_LIMIT);
+}
+
+// ---------------------------------------------------------------------------
+// Suggestions — ONE bounded array-contains-any query over the viewer's
+// classes (Firestore caps the disjunction at 10 values), ranked by shared-
+// class count. Never a global user scan, never a fabricated user.
+// ---------------------------------------------------------------------------
+
+export type SuggestedClassmate = {
+  profile: UserProfile;
+  sharedClasses: string[];
+};
+
+export async function getSuggestedClassmates(
+  currentUid: string,
+  myClasses: string[],
+  excludeUids: Iterable<string>
+): Promise<SuggestedClassmate[]> {
+  const classIds = [...new Set(myClasses.map((code) => code.trim()).filter(Boolean))].slice(
+    0,
+    10
+  );
+
+  if (classIds.length === 0) {
+    return [];
+  }
+
+  const snapshot = await getDocs(
+    query(
+      collection(db, COLLECTIONS.users),
+      where("classes", "array-contains-any", classIds),
+      limit(SUGGESTED_CLASSMATES_LIMIT)
+    )
+  );
+
+  const excluded = new Set([currentUid, ...excludeUids]);
+
+  return snapshot.docs
+    .filter((docSnap) => !excluded.has(docSnap.id))
+    .map((docSnap) => {
+      const profile = parseUserProfile(docSnap.id, docSnap.data());
+      return { profile, sharedClasses: sharedClasses(myClasses, profile.classes) };
+    })
+    .filter((candidate) => candidate.sharedClasses.length > 0)
+    .sort(
+      (a, b) =>
+        b.sharedClasses.length - a.sharedClasses.length ||
+        a.profile.displayName.localeCompare(b.profile.displayName)
+    );
+}

--- a/lib/friends.ts
+++ b/lib/friends.ts
@@ -86,6 +86,26 @@ export type FriendStatus =
   | "incoming" // they sent us a pending request
   | "none";
 
+// Mirrors functions/pair-id.js SAFE_UID_PATTERN and firestore.rules
+// isSafeUidComponent. Studi uids are Firebase email/password uids ([A-Za-z0-9]),
+// so `{a}__{b}` is an unambiguous, delimiter-free deterministic id. Validated
+// here for fail-fast friendly errors; the rules are the actual enforcement.
+const SAFE_UID_PATTERN = /^[A-Za-z0-9]{1,128}$/;
+
+export function isSafeUid(uid: string): boolean {
+  return typeof uid === "string" && SAFE_UID_PATTERN.test(uid);
+}
+
+function assertSafePair(uidA: string, uidB: string) {
+  if (!isSafeUid(uidA) || !isSafeUid(uidB)) {
+    throw new Error("That account can't be added right now.");
+  }
+  if (uidA === uidB) {
+    throw new Error("You can't add yourself.");
+  }
+}
+
+/** Directed pair id (friend requests: from → to). */
 export function buildFriendRequestId(fromUid: string, toUid: string) {
   return `${fromUid}__${toUid}`;
 }
@@ -129,9 +149,7 @@ function parseFriendRequest(id: string, data: Record<string, unknown>): FriendRe
 // ---------------------------------------------------------------------------
 
 export async function sendFriendRequest(fromUid: string, toUid: string) {
-  if (fromUid === toUid) {
-    throw new Error("You can't send yourself a friend request.");
-  }
+  assertSafePair(fromUid, toUid);
 
   const batch = writeBatch(db);
   batch.set(friendRequestDoc(fromUid, toUid), {
@@ -159,6 +177,7 @@ export async function declineFriendRequest(currentUid: string, fromUid: string) 
  * deleted in the same batch.
  */
 export async function acceptFriendRequest(currentUid: string, fromUid: string) {
+  assertSafePair(currentUid, fromUid);
   const outgoing = await getDoc(friendRequestDoc(currentUid, fromUid));
 
   const batch = writeBatch(db);

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -26,21 +26,21 @@ const SAFE_ROUTE_ID_PATTERN = /^[A-Za-z0-9_-]{1,200}$/;
 /**
  * Strict allowlist for navigation triggered by notification payloads — push
  * taps and Notifications Center rows both validate through here. Valid forms:
- * `/notifications`, `/conversation/{id}`, `/session/{id}`, `/session-chat/{id}`
- * where {id} is a safe internal ID. The segment must also decode to itself, so
- * traversal (`.`/`..`), percent-encoded separators (%2F, %5C), malformed
- * escapes, and external schemes never pass.
+ * `/notifications`, `/friends`, `/conversation/{id}`, `/session/{id}`,
+ * `/session-chat/{id}`, `/user/{id}` where {id} is a safe internal ID. The
+ * segment must also decode to itself, so traversal (`.`/`..`), percent-encoded
+ * separators (%2F, %5C), malformed escapes, and external schemes never pass.
  */
 export function isAllowedNotificationUrl(url: unknown): url is string {
   if (typeof url !== 'string') {
     return false;
   }
 
-  if (url === '/notifications') {
+  if (url === '/notifications' || url === '/friends') {
     return true;
   }
 
-  const match = /^\/(conversation|session|session-chat)\/([^/]+)$/.exec(url);
+  const match = /^\/(conversation|session|session-chat|user)\/([^/]+)$/.exec(url);
   if (!match) {
     return false;
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "rules:test": "firebase emulators:exec --only firestore \"mocha tests/firestore-rules.test.mjs --timeout 10000\"",
     "test:notifications": "mocha tests/notification-validation.test.mjs",
     "test:deletion": "mocha tests/account-deletion.test.mjs",
-    "test:map": "mocha tests/map-markers.test.mjs"
+    "test:map": "mocha tests/map-markers.test.mjs",
+    "test:friends": "mocha tests/friend-suggestions.test.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/cormorant-garamond": "^0.4.1",

--- a/scripts/backfill-display-name-lower.mjs
+++ b/scripts/backfill-display-name-lower.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// scripts/backfill-display-name-lower.mjs — one-time ops backfill for the
+// friend-search shadow field `displayNameLower` (PR 6).
+//
+// WHY THIS EXISTS
+//   Friend search (lib/friends.ts searchUsersByNamePrefix) runs a case-
+//   insensitive prefix query. Firestore range queries are case-SENSITIVE, so
+//   the client writes a lowercase copy of displayName as `displayNameLower`
+//   and searches that. Every displayName write path now writes the pair
+//   (createOrUpdateUserProfile + updateUserDisplayName), and firestore.rules
+//   pins displayNameLower == displayName.lower(). But profiles created BEFORE
+//   this PR have no displayNameLower and are invisible to the canonical
+//   search query. The client covers them at runtime with a bounded, case-
+//   sensitive fallback query on the raw displayName, and they self-heal the
+//   next time the user re-saves their name — this script closes the gap for
+//   everyone at once.
+//
+// SAFETY
+//   - Pinned to the studi-b02c3 project explicitly; an ADC context pointing
+//     anywhere else aborts before any read.
+//   - Idempotent: only touches docs that lack displayNameLower (or whose value
+//     has drifted from displayName.lower()); a re-run after a partial pass
+//     resumes cleanly. Writes ONLY displayNameLower — never displayName,
+//     classes, or timestamps — so it can't clobber a concurrent profile edit.
+//   - Paged (500-doc batches) so it never loads the whole users collection.
+//
+// USAGE (NOT run as part of deploy — an operator runs it once, deliberately):
+//   GOOGLE_APPLICATION_CREDENTIALS=<service-account.json> \
+//     GOOGLE_CLOUD_PROJECT=studi-b02c3 \
+//     node scripts/backfill-display-name-lower.mjs [--dry-run]
+
+import admin from "firebase-admin";
+
+const PROJECT_ID = "studi-b02c3";
+const PAGE_SIZE = 500;
+const DRY_RUN = process.argv.includes("--dry-run");
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const envProject = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
+if (envProject && envProject !== PROJECT_ID) {
+  fail(
+    `Project context '${envProject}' is not '${PROJECT_ID}' — refusing. ` +
+      "This backfill only ever operates on the pinned project."
+  );
+}
+
+admin.initializeApp({ projectId: PROJECT_ID });
+const db = admin.firestore();
+
+async function main() {
+  let scanned = 0;
+  let updated = 0;
+  let cursor = null;
+
+  for (;;) {
+    let query = db.collection("users").orderBy(admin.firestore.FieldPath.documentId()).limit(PAGE_SIZE);
+    if (cursor) {
+      query = query.startAfter(cursor);
+    }
+
+    const snap = await query.get();
+    if (snap.empty) {
+      break;
+    }
+
+    const batch = db.batch();
+    let batchWrites = 0;
+
+    for (const docSnap of snap.docs) {
+      scanned += 1;
+      const data = docSnap.data();
+      const displayName = typeof data.displayName === "string" ? data.displayName : "";
+      if (!displayName) {
+        continue; // nothing to normalize — no name to search on
+      }
+
+      const expected = displayName.toLowerCase();
+      if (data.displayNameLower === expected) {
+        continue; // already correct
+      }
+
+      updated += 1;
+      if (!DRY_RUN) {
+        batch.update(docSnap.ref, { displayNameLower: expected });
+        batchWrites += 1;
+      }
+    }
+
+    if (batchWrites > 0) {
+      await batch.commit();
+    }
+
+    cursor = snap.docs[snap.docs.length - 1];
+    if (snap.size < PAGE_SIZE) {
+      break;
+    }
+  }
+
+  console.log(
+    `${DRY_RUN ? "[dry-run] " : ""}Scanned ${scanned} users; ` +
+      `${DRY_RUN ? "would update" : "updated"} ${updated} missing/stale displayNameLower.`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => fail(`Backfill failed: ${error?.message ?? error}`));

--- a/tests/account-deletion.test.mjs
+++ b/tests/account-deletion.test.mjs
@@ -30,6 +30,8 @@ const EXPECTED_STEP_ORDER = [
   'conversations',
   'sent-messages',
   'user-blocks',
+  'friend-requests',
+  'friendships',
   'location-ratings',
   'user-tree',
 ];

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -225,8 +225,10 @@ describe('users', () => {
     );
   });
 
-  it('rejects a new named profile that omits displayNameLower', async () => {
-    await assertFails(
+  // Rollout PHASE 1: old clients that don't write displayNameLower must keep
+  // working (see docs/friends-rollout.md). PHASE 2 makes these mandatory.
+  it('allows a new named profile without displayNameLower (rollout phase 1, old client)', async () => {
+    await assertSucceeds(
       setDoc(doc(ctx(ALICE), 'users', ALICE), {
         displayName: 'Alice Anderson',
         classes: [],
@@ -236,15 +238,16 @@ describe('users', () => {
     );
   });
 
-  it('rejects a rename that does not update displayNameLower', async () => {
+  it('allows a rename that omits displayNameLower (rollout phase 1, legacy doc)', async () => {
+    // Legacy/old-client doc: no displayNameLower present, so the rename doesn't
+    // strand a stale lower value (the sync check only fires when it's present).
     await seed(`users/${ALICE}`, {
       displayName: 'Alice Anderson',
-      displayNameLower: 'alice anderson',
       classes: [],
       createdAt: Timestamp.now(),
       updatedAt: Timestamp.now(),
     });
-    await assertFails(
+    await assertSucceeds(
       updateDoc(doc(ctx(ALICE), 'users', ALICE), {
         displayName: 'Alicia Anderson',
         updatedAt: serverTimestamp(),
@@ -1532,6 +1535,18 @@ describe('friend requests (friendRequests/{from}__{to})', () => {
     await assertFails(batch.commit());
   });
 
+  it('rejects a toUid that is not a safe [A-Za-z0-9] uid (unambiguous __ id)', async () => {
+    // A uid containing `_` would make `from__to` ambiguous — denied at create.
+    const unsafe = 'bad__uid';
+    await seed(`users/${unsafe}`, { displayName: 'Weird', classes: [] });
+    const db = ctx(ALICE);
+    const batch = batchWithRateLimit(db, ALICE, 'friendRequest');
+    batch.set(doc(db, 'friendRequests', `${ALICE}__${unsafe}`), {
+      fromUid: ALICE, toUid: unsafe, createdAt: serverTimestamp(),
+    });
+    await assertFails(batch.commit());
+  });
+
   it('rejects a reverse-duplicate request', async () => {
     await seedUser(ALICE);
     await seedUser(BOB);
@@ -1592,11 +1607,14 @@ describe('friend requests (friendRequests/{from}__{to})', () => {
     await assertFails(getDoc(doc(ctx(MALLORY), 'friendRequests', reqId(ALICE, BOB))));
   });
 
-  it('rejects a malformed request id on get', async () => {
+  it('rejects a malformed request id on get (no separator, >2 parts, empty/unsafe segments)', async () => {
     await assertFails(getDoc(doc(ctx(ALICE), 'friendRequests', 'no-separator')));
     await assertFails(
       getDoc(doc(ctx(ALICE), 'friendRequests', `${ALICE}__${BOB}__${MALLORY}`))
     );
+    // Empty segments (`__x`, `x__`) and unsafe components are rejected.
+    await assertFails(getDoc(doc(ctx(ALICE), 'friendRequests', `__${ALICE}`)));
+    await assertFails(getDoc(doc(ctx(ALICE), 'friendRequests', `${ALICE}__`)));
   });
 
   it('requests are immutable (no update)', async () => {

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -191,6 +191,39 @@ describe('users', () => {
     );
   });
 
+  it('owner saves displayNameLower when it matches displayName.lower()', async () => {
+    await assertSucceeds(
+      setDoc(doc(ctx(ALICE), 'users', ALICE), {
+        displayName: 'Alice Anderson',
+        displayNameLower: 'alice anderson',
+        classes: [],
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+    );
+  });
+
+  it('rejects a displayNameLower that is not the lowercase of displayName', async () => {
+    await assertFails(
+      setDoc(doc(ctx(ALICE), 'users', ALICE), {
+        displayName: 'Alice Anderson',
+        displayNameLower: 'bob',
+        classes: [],
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+    );
+    // displayNameLower without a displayName is also rejected.
+    await assertFails(
+      setDoc(doc(ctx(ALICE), 'users', ALICE), {
+        displayNameLower: 'alice anderson',
+        classes: [],
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+    );
+  });
+
   it('rejects PII fields on the public doc', async () => {
     await assertFails(
       setDoc(doc(ctx(ALICE), 'users', ALICE), {
@@ -1368,6 +1401,252 @@ describe('userBlocks (D5: involved-party get, blocker-only list)', () => {
     await assertFails(setDoc(doc(ctx(ALICE), 'userBlocks', 'mismatched'), {
       blockerUserId: ALICE, blockedUserId: BOB, createdAt: serverTimestamp(),
     }));
+  });
+});
+
+// ------------------------------------------------------------ friends (PR 6)
+describe('friend requests (friendRequests/{from}__{to})', () => {
+  const reqId = (from, to) => `${from}__${to}`;
+  const seedUser = (uid) => seed(`users/${uid}`, { displayName: uid, classes: [] });
+
+  // Mirrors sendFriendRequest in lib/friends.ts: request doc + friendRequest
+  // rate-limit write in one batch.
+  function sendRequest(db, uid, fromUid, toUid) {
+    const batch = batchWithRateLimit(db, uid, 'friendRequest');
+    batch.set(doc(db, 'friendRequests', reqId(fromUid, toUid)), {
+      fromUid, toUid, createdAt: serverTimestamp(),
+    });
+    return batch.commit();
+  }
+
+  it('valid create succeeds with a fresh rate-limit write and a real target', async () => {
+    await seedUser(BOB);
+    await assertSucceeds(sendRequest(ctx(ALICE), ALICE, ALICE, BOB));
+  });
+
+  it('requires the fresh rate-limit write', async () => {
+    await seedUser(BOB);
+    await assertFails(setDoc(doc(ctx(ALICE), 'friendRequests', reqId(ALICE, BOB)), {
+      fromUid: ALICE, toUid: BOB, createdAt: serverTimestamp(),
+    }));
+  });
+
+  it('cannot friend yourself', async () => {
+    await seedUser(ALICE);
+    await assertFails(sendRequest(ctx(ALICE), ALICE, ALICE, ALICE));
+  });
+
+  it('rejects a forged fromUid', async () => {
+    await seedUser(BOB);
+    await assertFails(sendRequest(ctx(MALLORY), MALLORY, ALICE, BOB));
+  });
+
+  it('rejects a target user that does not exist', async () => {
+    await assertFails(sendRequest(ctx(ALICE), ALICE, ALICE, 'ghostUid'));
+  });
+
+  it('rejects an id that does not match from__to', async () => {
+    await seedUser(BOB);
+    const db = ctx(ALICE);
+    const batch = batchWithRateLimit(db, ALICE, 'friendRequest');
+    batch.set(doc(db, 'friendRequests', 'wrongId'), {
+      fromUid: ALICE, toUid: BOB, createdAt: serverTimestamp(),
+    });
+    await assertFails(batch.commit());
+  });
+
+  it('rejects a reverse-duplicate request', async () => {
+    await seedUser(ALICE);
+    await seedUser(BOB);
+    await seed(`friendRequests/${reqId(BOB, ALICE)}`, {
+      fromUid: BOB, toUid: ALICE, createdAt: Timestamp.now(),
+    });
+    // Alice cannot send to Bob while Bob's request to Alice is pending.
+    await assertFails(sendRequest(ctx(ALICE), ALICE, ALICE, BOB));
+  });
+
+  it('rejects a request to an existing friend', async () => {
+    await seedUser(BOB);
+    const ids = [ALICE, BOB].sort();
+    await seed(`friendships/${ids.join('__')}`, {
+      userIds: ids, acceptedBy: BOB, createdAt: Timestamp.now(),
+    });
+    await assertFails(sendRequest(ctx(ALICE), ALICE, ALICE, BOB));
+  });
+
+  it('rejects a blocked pair in either direction', async () => {
+    await seedUser(BOB);
+    await seed(`userBlocks/${BOB}__${ALICE}`, {
+      blockerUserId: BOB, blockedUserId: ALICE, createdAt: Timestamp.now(),
+    });
+    await assertFails(sendRequest(ctx(ALICE), ALICE, ALICE, BOB));
+
+    await env.clearFirestore();
+    await seedUser(BOB);
+    await seed(`userBlocks/${ALICE}__${BOB}`, {
+      blockerUserId: ALICE, blockedUserId: BOB, createdAt: Timestamp.now(),
+    });
+    await assertFails(sendRequest(ctx(ALICE), ALICE, ALICE, BOB));
+  });
+
+  it('only the two involved users can read a request; outsiders cannot', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    await assertSucceeds(getDoc(doc(ctx(ALICE), 'friendRequests', reqId(ALICE, BOB))));
+    await assertSucceeds(getDoc(doc(ctx(BOB), 'friendRequests', reqId(ALICE, BOB))));
+    await assertFails(getDoc(doc(ctx(MALLORY), 'friendRequests', reqId(ALICE, BOB))));
+    // Recipient lists their incoming requests; an outsider cannot.
+    await assertSucceeds(getDocs(query(
+      collection(ctx(BOB), 'friendRequests'), where('toUid', '==', BOB)
+    )));
+    await assertFails(getDocs(query(
+      collection(ctx(MALLORY), 'friendRequests'), where('toUid', '==', BOB)
+    )));
+  });
+
+  it('requests are immutable (no update)', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    await assertFails(updateDoc(doc(ctx(ALICE), 'friendRequests', reqId(ALICE, BOB)), {
+      toUid: MALLORY,
+    }));
+  });
+
+  it('sender cancels, recipient declines, outsider cannot delete', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    await assertFails(deleteDoc(doc(ctx(MALLORY), 'friendRequests', reqId(ALICE, BOB))));
+    await assertSucceeds(deleteDoc(doc(ctx(BOB), 'friendRequests', reqId(ALICE, BOB))));
+    // Re-seed and let the sender cancel.
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    await assertSucceeds(deleteDoc(doc(ctx(ALICE), 'friendRequests', reqId(ALICE, BOB))));
+  });
+});
+
+describe('friendships (friendships/{sortedA}__{sortedB})', () => {
+  const reqId = (from, to) => `${from}__${to}`;
+  const pairId = (a, b) => [a, b].sort().join('__');
+
+  // Mirrors acceptFriendRequest: delete the incoming request + create the
+  // friendship in one batch (rules enforce the atomicity).
+  function acceptBatch(db, recipient, sender) {
+    const batch = writeBatch(db);
+    batch.delete(doc(db, 'friendRequests', reqId(sender, recipient)));
+    const ids = [recipient, sender].sort();
+    batch.set(doc(db, 'friendships', ids.join('__')), {
+      userIds: ids, acceptedBy: recipient, createdAt: serverTimestamp(),
+    });
+    return batch.commit();
+  }
+
+  it('recipient accepts atomically (delete request + create friendship)', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    await assertSucceeds(acceptBatch(ctx(BOB), BOB, ALICE));
+  });
+
+  it('creating a friendship without deleting the request is denied', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    const ids = [ALICE, BOB].sort();
+    await assertFails(setDoc(doc(ctx(BOB), 'friendships', ids.join('__')), {
+      userIds: ids, acceptedBy: BOB, createdAt: serverTimestamp(),
+    }));
+  });
+
+  it('creating a friendship with no request at all is denied', async () => {
+    const ids = [ALICE, BOB].sort();
+    await assertFails(setDoc(doc(ctx(BOB), 'friendships', ids.join('__')), {
+      userIds: ids, acceptedBy: BOB, createdAt: serverTimestamp(),
+    }));
+  });
+
+  it('the sender cannot accept their own request', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    // Alice (sender) tries to accept — the required doc is BOB__ALICE, which
+    // does not exist, and deleting her own outgoing request doesn't satisfy it.
+    const db = ctx(ALICE);
+    const batch = writeBatch(db);
+    batch.delete(doc(db, 'friendRequests', reqId(ALICE, BOB)));
+    const ids = [ALICE, BOB].sort();
+    batch.set(doc(db, 'friendships', ids.join('__')), {
+      userIds: ids, acceptedBy: ALICE, createdAt: serverTimestamp(),
+    });
+    await assertFails(batch.commit());
+  });
+
+  it('acceptedBy must be the caller and in the pair', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    const db = ctx(BOB);
+    const batch = writeBatch(db);
+    batch.delete(doc(db, 'friendRequests', reqId(ALICE, BOB)));
+    const ids = [ALICE, BOB].sort();
+    batch.set(doc(db, 'friendships', ids.join('__')), {
+      userIds: ids, acceptedBy: ALICE, createdAt: serverTimestamp(), // wrong accepter
+    });
+    await assertFails(batch.commit());
+  });
+
+  it('a blocked pair cannot become friends', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    await seed(`userBlocks/${ALICE}__${BOB}`, {
+      blockerUserId: ALICE, blockedUserId: BOB, createdAt: Timestamp.now(),
+    });
+    await assertFails(acceptBatch(ctx(BOB), BOB, ALICE));
+  });
+
+  it('id must equal the sorted pair and hold exactly two distinct sorted uids', async () => {
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    // Wrong doc id (unsorted / arbitrary).
+    const db = ctx(BOB);
+    const batch = writeBatch(db);
+    batch.delete(doc(db, 'friendRequests', reqId(ALICE, BOB)));
+    batch.set(doc(db, 'friendships', 'not-the-pair'), {
+      userIds: [ALICE, BOB].sort(), acceptedBy: BOB, createdAt: serverTimestamp(),
+    });
+    await assertFails(batch.commit());
+  });
+
+  it('only members read; outsiders cannot', async () => {
+    const ids = [ALICE, BOB].sort();
+    await seed(`friendships/${ids.join('__')}`, {
+      userIds: ids, acceptedBy: BOB, createdAt: Timestamp.now(),
+    });
+    await assertSucceeds(getDoc(doc(ctx(ALICE), 'friendships', ids.join('__'))));
+    await assertSucceeds(getDocs(query(
+      collection(ctx(ALICE), 'friendships'), where('userIds', 'array-contains', ALICE)
+    )));
+    await assertFails(getDoc(doc(ctx(MALLORY), 'friendships', ids.join('__'))));
+    await assertFails(getDocs(query(
+      collection(ctx(MALLORY), 'friendships'), where('userIds', 'array-contains', ALICE)
+    )));
+  });
+
+  it('either friend can remove; a non-member cannot; no updates', async () => {
+    const ids = [ALICE, BOB].sort();
+    await seed(`friendships/${ids.join('__')}`, {
+      userIds: ids, acceptedBy: BOB, createdAt: Timestamp.now(),
+    });
+    await assertFails(updateDoc(doc(ctx(ALICE), 'friendships', ids.join('__')), {
+      acceptedBy: MALLORY,
+    }));
+    await assertFails(deleteDoc(doc(ctx(MALLORY), 'friendships', ids.join('__'))));
+    await assertSucceeds(deleteDoc(doc(ctx(ALICE), 'friendships', ids.join('__'))));
   });
 });
 

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -184,6 +184,7 @@ describe('users', () => {
     await assertSucceeds(
       setDoc(doc(ctx(ALICE), 'users', ALICE), {
         displayName: 'Alice A',
+        displayNameLower: 'alice a',
         classes: ['MATH 221'],
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
@@ -224,6 +225,81 @@ describe('users', () => {
     );
   });
 
+  it('rejects a new named profile that omits displayNameLower', async () => {
+    await assertFails(
+      setDoc(doc(ctx(ALICE), 'users', ALICE), {
+        displayName: 'Alice Anderson',
+        classes: [],
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+    );
+  });
+
+  it('rejects a rename that does not update displayNameLower', async () => {
+    await seed(`users/${ALICE}`, {
+      displayName: 'Alice Anderson',
+      displayNameLower: 'alice anderson',
+      classes: [],
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+    });
+    await assertFails(
+      updateDoc(doc(ctx(ALICE), 'users', ALICE), {
+        displayName: 'Alicia Anderson',
+        updatedAt: serverTimestamp(),
+      })
+    );
+  });
+
+  it('allows a rename that updates displayNameLower to match', async () => {
+    await seed(`users/${ALICE}`, {
+      displayName: 'Alice Anderson',
+      displayNameLower: 'alice anderson',
+      classes: [],
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+    });
+    await assertSucceeds(
+      updateDoc(doc(ctx(ALICE), 'users', ALICE), {
+        displayName: 'Alicia Anderson',
+        displayNameLower: 'alicia anderson',
+        updatedAt: serverTimestamp(),
+      })
+    );
+  });
+
+  it('lets a legacy profile (no displayNameLower) edit unrelated fields', async () => {
+    // Legacy shape: has a displayName but predates displayNameLower.
+    await seed(`users/${ALICE}`, {
+      displayName: 'Alice Anderson',
+      classes: [],
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+    });
+    await assertSucceeds(
+      updateDoc(doc(ctx(ALICE), 'users', ALICE), {
+        year: 'Junior',
+        updatedAt: serverTimestamp(),
+      })
+    );
+  });
+
+  it('lets a legacy profile self-heal by adding a matching displayNameLower', async () => {
+    await seed(`users/${ALICE}`, {
+      displayName: 'Alice Anderson',
+      classes: [],
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+    });
+    await assertSucceeds(
+      updateDoc(doc(ctx(ALICE), 'users', ALICE), {
+        displayNameLower: 'alice anderson',
+        updatedAt: serverTimestamp(),
+      })
+    );
+  });
+
   it('rejects PII fields on the public doc', async () => {
     await assertFails(
       setDoc(doc(ctx(ALICE), 'users', ALICE), {
@@ -259,6 +335,7 @@ describe('users', () => {
     await assertSucceeds(
       setDoc(doc(ctx(ALICE), 'users', ALICE), {
         displayName: 'Alice A',
+        displayNameLower: 'alice a',
         classes: ['MATH 221'],
         year: 'Junior',
         major: 'Computer Science',
@@ -1505,6 +1582,23 @@ describe('friend requests (friendRequests/{from}__{to})', () => {
     )));
   });
 
+  it('outsiders cannot probe a MISSING request; pair members get exists=false', async () => {
+    // No doc seeded — the get resolves against absence.
+    // Pair members are allowed (client reads exists=false) …
+    await assertSucceeds(getDoc(doc(ctx(ALICE), 'friendRequests', reqId(ALICE, BOB))));
+    await assertSucceeds(getDoc(doc(ctx(BOB), 'friendRequests', reqId(ALICE, BOB))));
+    // … but an outsider is denied whether the doc exists or not, so "missing"
+    // and "exists" are indistinguishable to them (no existence side channel).
+    await assertFails(getDoc(doc(ctx(MALLORY), 'friendRequests', reqId(ALICE, BOB))));
+  });
+
+  it('rejects a malformed request id on get', async () => {
+    await assertFails(getDoc(doc(ctx(ALICE), 'friendRequests', 'no-separator')));
+    await assertFails(
+      getDoc(doc(ctx(ALICE), 'friendRequests', `${ALICE}__${BOB}__${MALLORY}`))
+    );
+  });
+
   it('requests are immutable (no update)', async () => {
     await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
       fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
@@ -1606,6 +1700,36 @@ describe('friendships (friendships/{sortedA}__{sortedB})', () => {
       blockerUserId: ALICE, blockedUserId: BOB, createdAt: Timestamp.now(),
     });
     await assertFails(acceptBatch(ctx(BOB), BOB, ALICE));
+  });
+
+  it('cannot block + delete request + create friendship in one batch', async () => {
+    // The same-batch race: exists() sees no pre-batch block, so only the
+    // existsAfter() check catches the block created alongside the accept.
+    await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
+      fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
+    });
+    const db = ctx(BOB);
+    const batch = writeBatch(db);
+    batch.set(doc(db, 'userBlocks', `${BOB}__${ALICE}`), {
+      blockerUserId: BOB, blockedUserId: ALICE, createdAt: serverTimestamp(),
+    });
+    batch.delete(doc(db, 'friendRequests', reqId(ALICE, BOB)));
+    const ids = [ALICE, BOB].sort();
+    batch.set(doc(db, 'friendships', ids.join('__')), {
+      userIds: ids, acceptedBy: BOB, createdAt: serverTimestamp(),
+    });
+    await assertFails(batch.commit());
+  });
+
+  it('outsiders cannot probe a MISSING friendship; members get exists=false', async () => {
+    const ids = [ALICE, BOB].sort();
+    await assertSucceeds(getDoc(doc(ctx(ALICE), 'friendships', ids.join('__'))));
+    await assertSucceeds(getDoc(doc(ctx(BOB), 'friendships', ids.join('__'))));
+    await assertFails(getDoc(doc(ctx(MALLORY), 'friendships', ids.join('__'))));
+  });
+
+  it('rejects a malformed friendship id on get', async () => {
+    await assertFails(getDoc(doc(ctx(ALICE), 'friendships', 'no-separator')));
   });
 
   it('id must equal the sorted pair and hold exactly two distinct sorted uids', async () => {

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -1617,6 +1617,16 @@ describe('friend requests (friendRequests/{from}__{to})', () => {
     await assertFails(getDoc(doc(ctx(ALICE), 'friendRequests', `${ALICE}__`)));
   });
 
+  it('a self-pair request id fails closed, even for that user, missing or not', async () => {
+    // ALICE cannot get friendRequests/{ALICE__ALICE} — the two members must be
+    // distinct, so a self-pair id is denied (no legitimate self-request exists).
+    await assertFails(getDoc(doc(ctx(ALICE), 'friendRequests', `${ALICE}__${ALICE}`)));
+    // A distinct pair the user belongs to still behaves as intended (exists=false).
+    await assertSucceeds(getDoc(doc(ctx(ALICE), 'friendRequests', reqId(ALICE, BOB))));
+    // And an outsider is still denied a distinct missing pair.
+    await assertFails(getDoc(doc(ctx(MALLORY), 'friendRequests', reqId(ALICE, BOB))));
+  });
+
   it('requests are immutable (no update)', async () => {
     await seed(`friendRequests/${reqId(ALICE, BOB)}`, {
       fromUid: ALICE, toUid: BOB, createdAt: Timestamp.now(),
@@ -1748,6 +1758,16 @@ describe('friendships (friendships/{sortedA}__{sortedB})', () => {
 
   it('rejects a malformed friendship id on get', async () => {
     await assertFails(getDoc(doc(ctx(ALICE), 'friendships', 'no-separator')));
+  });
+
+  it('a self-pair friendship id fails closed, even for that user, missing or not', async () => {
+    // ALICE cannot get friendships/{ALICE__ALICE} — members must be distinct.
+    await assertFails(getDoc(doc(ctx(ALICE), 'friendships', `${ALICE}__${ALICE}`)));
+    // A distinct pair the user belongs to still behaves as intended (exists=false).
+    const ids = [ALICE, BOB].sort();
+    await assertSucceeds(getDoc(doc(ctx(ALICE), 'friendships', ids.join('__'))));
+    // And an outsider is still denied the distinct missing pair.
+    await assertFails(getDoc(doc(ctx(MALLORY), 'friendships', ids.join('__'))));
   });
 
   it('id must equal the sorted pair and hold exactly two distinct sorted uids', async () => {

--- a/tests/friend-suggestions.test.mjs
+++ b/tests/friend-suggestions.test.mjs
@@ -1,0 +1,129 @@
+// tests/friend-suggestions.test.mjs
+// Run: npm run test:friends  (plain mocha — no emulator needed)
+// Unit tests for the pure suggestion ranking/filtering in
+// functions/friend-suggestions.js. The getFriendSuggestions callable wires
+// bounded Admin reads to buildFriendSuggestions; these tests pin the
+// exclusion, dedupe, ranking, and bound rules independently of Firebase.
+
+import { strict as assert } from 'node:assert';
+import suggestions from '../functions/friend-suggestions.js';
+
+const { buildFriendSuggestions, MAX_SUGGESTIONS } = suggestions;
+
+const SENDER = 'senderUid';
+const MY_CLASSES = ['CS 300', 'MATH 221', 'STAT 240'];
+
+function candidate(uid, classes = ['CS 300'], displayName = uid) {
+  return { uid, displayName, classes };
+}
+
+describe('friend suggestions — exclusions and bounds', () => {
+  it('never suggests the caller', () => {
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: [candidate(SENDER), candidate('bob')],
+      excludedUids: new Set(),
+      existingBlockIds: new Set(),
+    });
+    assert.deepEqual(out.map((s) => s.uid), ['bob']);
+  });
+
+  it('excludes an already-friend candidate even if beyond the first page', () => {
+    // The caller pre-loads the full friend id set; a friend from page 2 is in it.
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: [candidate('friendFromPage2'), candidate('stranger')],
+      excludedUids: new Set(['friendFromPage2']),
+      existingBlockIds: new Set(),
+    });
+    assert.deepEqual(out.map((s) => s.uid), ['stranger']);
+  });
+
+  it('excludes a pending-request candidate even if beyond the first page', () => {
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: [candidate('requestedPage2'), candidate('stranger')],
+      excludedUids: new Set(['requestedPage2']),
+      existingBlockIds: new Set(),
+    });
+    assert.deepEqual(out.map((s) => s.uid), ['stranger']);
+  });
+
+  it('excludes a candidate the sender blocked', () => {
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: [candidate('blockedByMe'), candidate('ok')],
+      excludedUids: new Set(),
+      existingBlockIds: new Set([`${SENDER}__blockedByMe`]),
+    });
+    assert.deepEqual(out.map((s) => s.uid), ['ok']);
+  });
+
+  it('excludes a candidate who blocked the sender', () => {
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: [candidate('blockedMe'), candidate('ok')],
+      excludedUids: new Set(),
+      existingBlockIds: new Set([`blockedMe__${SENDER}`]),
+    });
+    assert.deepEqual(out.map((s) => s.uid), ['ok']);
+  });
+
+  it('drops candidates with no shared class', () => {
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: [candidate('noOverlap', ['HIST 101']), candidate('overlap', ['CS 300'])],
+      excludedUids: new Set(),
+      existingBlockIds: new Set(),
+    });
+    assert.deepEqual(out.map((s) => s.uid), ['overlap']);
+  });
+
+  it('deduplicates repeated candidate uids', () => {
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: [candidate('dup'), candidate('dup'), candidate('dup')],
+      excludedUids: new Set(),
+      existingBlockIds: new Set(),
+    });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].uid, 'dup');
+  });
+
+  it('ranks by shared-class count, then name', () => {
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: [
+        candidate('one', ['CS 300'], 'Zed'),
+        candidate('three', ['CS 300', 'MATH 221', 'STAT 240'], 'Ada'),
+        candidate('two', ['CS 300', 'MATH 221'], 'Bea'),
+      ],
+      excludedUids: new Set(),
+      existingBlockIds: new Set(),
+    });
+    assert.deepEqual(out.map((s) => s.uid), ['three', 'two', 'one']);
+    assert.deepEqual(out[0].sharedClasses, ['CS 300', 'MATH 221', 'STAT 240']);
+  });
+
+  it('bounds the result count to the cap', () => {
+    const many = Array.from({ length: MAX_SUGGESTIONS + 25 }, (_, i) =>
+      candidate(`u${String(i).padStart(3, '0')}`)
+    );
+    const out = buildFriendSuggestions({
+      senderUid: SENDER,
+      myClasses: MY_CLASSES,
+      candidates: many,
+      excludedUids: new Set(),
+      existingBlockIds: new Set(),
+    });
+    assert.equal(out.length, MAX_SUGGESTIONS);
+  });
+});

--- a/tests/friend-suggestions.test.mjs
+++ b/tests/friend-suggestions.test.mjs
@@ -7,8 +7,18 @@
 
 import { strict as assert } from 'node:assert';
 import suggestions from '../functions/friend-suggestions.js';
+import pairId from '../functions/pair-id.js';
 
-const { buildFriendSuggestions, MAX_SUGGESTIONS } = suggestions;
+const {
+  buildFriendSuggestions,
+  MAX_SUGGESTIONS,
+  MAX_SUGGESTION_READS,
+  CANDIDATE_SCAN_LIMIT,
+  RELATIONSHIP_DOCS_PER_CANDIDATE,
+  isCandidateExcludedByExistence,
+  relationshipDocRefsForCandidate,
+} = suggestions;
+const { isSafeUid, directedPairId, sortedPairId, parsePairMembers } = pairId;
 
 const SENDER = 'senderUid';
 const MY_CLASSES = ['CS 300', 'MATH 221', 'STAT 240'];
@@ -125,5 +135,113 @@ describe('friend suggestions — exclusions and bounds', () => {
       existingBlockIds: new Set(),
     });
     assert.equal(out.length, MAX_SUGGESTIONS);
+  });
+});
+
+describe('friend suggestions — per-candidate deterministic exclusion (bounded)', () => {
+  const CAND = 'candidateUid';
+
+  it('checks exactly five deterministic docs per candidate', () => {
+    const refs = relationshipDocRefsForCandidate(SENDER, CAND);
+    assert.equal(refs.length, RELATIONSHIP_DOCS_PER_CANDIDATE);
+    assert.deepEqual(refs, [
+      { collection: 'friendships', id: sortedPairId(SENDER, CAND) },
+      { collection: 'friendRequests', id: directedPairId(SENDER, CAND) },
+      { collection: 'friendRequests', id: directedPairId(CAND, SENDER) },
+      { collection: 'userBlocks', id: directedPairId(SENDER, CAND) },
+      { collection: 'userBlocks', id: directedPairId(CAND, SENDER) },
+    ]);
+  });
+
+  it('documented worst-case read bound is 1 + 40 + 40*5 = 241', () => {
+    assert.equal(CANDIDATE_SCAN_LIMIT, 40);
+    assert.equal(RELATIONSHIP_DOCS_PER_CANDIDATE, 5);
+    assert.equal(MAX_SUGGESTION_READS, 241);
+  });
+
+  // The exclusion is per-pair, so a friend/request/block is caught by the
+  // candidate's OWN five docs — independent of how many OTHER relationships the
+  // caller has (e.g. 500+ friends beyond any page cap).
+  it('excludes when the friendship doc exists (even with 500+ unrelated rels)', () => {
+    const unrelated = new Set(
+      Array.from({ length: 600 }, (_, i) => `friendships/${sortedPairId(SENDER, `other${i}`)}`)
+    );
+    unrelated.add(`friendships/${sortedPairId(SENDER, CAND)}`);
+    assert.equal(isCandidateExcludedByExistence(SENDER, CAND, unrelated), true);
+  });
+
+  it('excludes when an outgoing OR incoming request doc exists', () => {
+    assert.equal(
+      isCandidateExcludedByExistence(SENDER, CAND, new Set([`friendRequests/${directedPairId(SENDER, CAND)}`])),
+      true
+    );
+    assert.equal(
+      isCandidateExcludedByExistence(SENDER, CAND, new Set([`friendRequests/${directedPairId(CAND, SENDER)}`])),
+      true
+    );
+  });
+
+  it('excludes when a block doc exists in either direction', () => {
+    assert.equal(
+      isCandidateExcludedByExistence(SENDER, CAND, new Set([`userBlocks/${directedPairId(SENDER, CAND)}`])),
+      true
+    );
+    assert.equal(
+      isCandidateExcludedByExistence(SENDER, CAND, new Set([`userBlocks/${directedPairId(CAND, SENDER)}`])),
+      true
+    );
+  });
+
+  it('does NOT exclude when only unrelated docs exist', () => {
+    const unrelated = new Set([
+      `friendships/${sortedPairId(SENDER, 'someoneElse')}`,
+      `friendRequests/${directedPairId(SENDER, 'anotherPerson')}`,
+      `userBlocks/${directedPairId('x', 'y')}`,
+    ]);
+    assert.equal(isCandidateExcludedByExistence(SENDER, CAND, unrelated), false);
+  });
+});
+
+describe('pair-id encoding (shared helper)', () => {
+  it('rejects empty components', () => {
+    assert.equal(parsePairMembers('__x'), null);
+    assert.equal(parsePairMembers('x__'), null);
+    assert.equal(parsePairMembers('__'), null);
+  });
+
+  it('rejects malformed ids (no separator, >2 parts)', () => {
+    assert.equal(parsePairMembers('nosep'), null);
+    assert.equal(parsePairMembers('a__b__c'), null);
+    assert.equal(parsePairMembers(42), null);
+  });
+
+  it('rejects self-pairs', () => {
+    assert.equal(parsePairMembers('x__x'), null);
+  });
+
+  it('parses a well-formed pair id into its two members', () => {
+    assert.deepEqual(parsePairMembers('aaa__bbb'), ['aaa', 'bbb']);
+  });
+
+  it('constrains uids to [A-Za-z0-9] so `__` can never be ambiguous', () => {
+    // Documented decision: Studi uids are Firebase [A-Za-z0-9] email/password
+    // uids. `_` and `-` are rejected, so a component can never contain `__`.
+    assert.equal(isSafeUid('AbC123'), true);
+    assert.equal(isSafeUid('a_b'), false);
+    assert.equal(isSafeUid('a-b'), false);
+    assert.equal(isSafeUid('a__b'), false);
+    assert.equal(isSafeUid(''), false);
+    assert.equal(isSafeUid('x'.repeat(129)), false);
+    assert.equal(isSafeUid('x'.repeat(128)), true);
+  });
+
+  it('sorted friendship id is stable regardless of argument order', () => {
+    assert.equal(sortedPairId('aaa', 'bbb'), sortedPairId('bbb', 'aaa'));
+    assert.equal(sortedPairId('bbb', 'aaa'), 'aaa__bbb');
+  });
+
+  it('directed request id preserves direction', () => {
+    assert.equal(directedPairId('aaa', 'bbb'), 'aaa__bbb');
+    assert.notEqual(directedPairId('aaa', 'bbb'), directedPairId('bbb', 'aaa'));
   });
 });

--- a/tests/notification-validation.test.mjs
+++ b/tests/notification-validation.test.mjs
@@ -15,6 +15,9 @@ const {
   blockPairIdsFor,
   dmNotificationId,
   filterBlockedRecipients,
+  friendAcceptedNotificationId,
+  friendCleanupPathsForBlock,
+  friendRequestNotificationId,
   groupMessageNotificationId,
   isAllowedNotificationUrl,
   isWithinGroupChatFanoutLimit,
@@ -38,11 +41,28 @@ function validPayload(overrides = {}) {
 }
 
 describe('notification URL allowlist', () => {
-  it('accepts the four internal route shapes', () => {
+  it('accepts every internal route shape', () => {
     assert.equal(isAllowedNotificationUrl('/notifications'), true);
+    assert.equal(isAllowedNotificationUrl('/friends'), true);
     assert.equal(isAllowedNotificationUrl(`/conversation/${CONVO}`), true);
     assert.equal(isAllowedNotificationUrl('/session/AbC123_x-9'), true);
     assert.equal(isAllowedNotificationUrl('/session-chat/AbC123_x-9'), true);
+    assert.equal(isAllowedNotificationUrl('/user/AbC123_x-9'), true);
+  });
+
+  it('holds /user to the same segment rules as the other routes', () => {
+    assert.equal(isAllowedNotificationUrl('/user/..'), false);
+    assert.equal(isAllowedNotificationUrl('/user/../admin'), false);
+    assert.equal(isAllowedNotificationUrl('/user/a%2Fb'), false);
+    assert.equal(isAllowedNotificationUrl('/user/'), false);
+    assert.equal(isAllowedNotificationUrl('/user'), false);
+    assert.equal(isAllowedNotificationUrl('/user/a/b'), false);
+    assert.equal(isAllowedNotificationUrl(`/user/${'a'.repeat(201)}`), false);
+  });
+
+  it('/friends is exact — no trailing segment', () => {
+    assert.equal(isAllowedNotificationUrl('/friends/'), false);
+    assert.equal(isAllowedNotificationUrl('/friends/x'), false);
   });
 
   it('holds /session-chat to the same segment rules as the other routes', () => {
@@ -223,6 +243,47 @@ describe('idempotent record IDs (CloudEvent-keyed)', () => {
   it('sanitizes unexpected characters out of doc IDs', () => {
     const id = dmNotificationId('a/b', 'e.v/t');
     assert.equal(/^[A-Za-z0-9_-]+$/.test(id), true);
+  });
+
+  it('friend request/accepted: retries dedupe, distinct events notify again', () => {
+    assert.equal(
+      friendRequestNotificationId('event-1'),
+      friendRequestNotificationId('event-1')
+    );
+    assert.notEqual(
+      friendRequestNotificationId('event-1'),
+      friendRequestNotificationId('event-2')
+    );
+    assert.equal(
+      friendAcceptedNotificationId('event-1'),
+      friendAcceptedNotificationId('event-1')
+    );
+    // request and accepted IDs never collide even on the same event id.
+    assert.notEqual(
+      friendRequestNotificationId('event-1'),
+      friendAcceptedNotificationId('event-1')
+    );
+    assert.equal(/^[A-Za-z0-9_-]+$/.test(friendRequestNotificationId('e.v/t')), true);
+  });
+});
+
+describe('friend cleanup on block (deterministic paths)', () => {
+  it('removes both request directions and the sorted-pair friendship', () => {
+    // blocker < blocked lexically
+    assert.deepEqual(friendCleanupPathsForBlock('aaa', 'bbb'), [
+      { collection: 'friendRequests', id: 'aaa__bbb' },
+      { collection: 'friendRequests', id: 'bbb__aaa' },
+      { collection: 'friendships', id: 'aaa__bbb' },
+    ]);
+  });
+
+  it('friendship id is always the sorted pair, regardless of block direction', () => {
+    // blocker > blocked lexically — friendship id must still be sorted.
+    assert.deepEqual(friendCleanupPathsForBlock('zzz', 'aaa'), [
+      { collection: 'friendRequests', id: 'zzz__aaa' },
+      { collection: 'friendRequests', id: 'aaa__zzz' },
+      { collection: 'friendships', id: 'aaa__zzz' },
+    ]);
   });
 });
 


### PR DESCRIPTION
Adds the Friends / Study Buddies feature: a Friends screen (Friends / Requests / Suggested + search), a public user-profile route, and a Profile entry point. **No new bottom tab** — the 5-tab structure stays. Reuses the existing Firebase, blocking, direct-messaging, notification, analytics, and design systems. Excluded per spec: QR codes, mutual-friend counts, friends-only sessions, contact syncing, social links, profile photos.

## Data model
- `friendRequests/{fromUid}__{toUid}` — `{ fromUid, toUid, createdAt }`. Doc existence **is** the pending state: create = send, delete by sender = cancel, delete by recipient = decline/accept.
- `friendships/{sortedUidA}__{sortedUidB}` — `{ userIds, acceptedBy, createdAt }`. Created **only** by the request recipient, in the same batch that deletes the request.

## Rules & indexes
Enforced in `firestore.rules` (+ tests): cannot friend yourself; deterministic IDs so duplicates and reverse-duplicates are structurally impossible; cannot re-request an existing friend; a block in **either** direction blocks both request creation and acceptance; only the two involved users can read a request/friendship; **atomic accept** (friendship create requires the incoming request to exist before the batch and be gone after — `exists`/`existsAfter`); the sender structurally cannot self-accept. New `friendRequest` rate-limit action (10 s). Three composite indexes added (friendships by `userIds`+`createdAt`, friendRequests by `toUid`/`fromUid`+`createdAt`), documented in `firestore.indexes.json`.

## Request / accept transaction
Accept is a single client `writeBatch`: delete the incoming request + create the sorted-pair friendship (and delete a now-moot mutual outgoing request if present). Rules make a partial accept impossible in either direction.

## Block integration
`onUserBlockCreated` severs the pair server-side: three deterministic-ID deletes (both request directions + the sorted friendship), idempotent for safe Eventarc retries. Both notification triggers also re-check the block at fire time, so a block landing between the client write and the trigger still suppresses the record and the push.

## Search & suggestions
Search is a bounded, paginated case-insensitive prefix query on a new `displayNameLower` shadow field (Firestore range scans are case-sensitive). Suggestions are **one** bounded `array-contains-any` query over the viewer's classes (≤10), ranked by shared-class count — never a global user scan, never a fabricated user. Every list is paginated; all profile hydration goes through the existing batched+cached `getProfilesByIds`.

## `displayNameLower` decision & backward compatibility
Necessary because Firestore prefix search is case-sensitive and there was no normalized name field. Written alongside **every** displayName write path (`createOrUpdateUserProfile`, `updateUserDisplayName`) and pinned by rules to `displayName.lower()`, so the two can't drift. Legacy profiles that predate it: covered at runtime by a bounded case-sensitive fallback query on the raw `displayName`, self-heal on the next name save, and can be swept all at once by the included **`scripts/backfill-display-name-lower.mjs`** (project-pinned, idempotent, paged — **not run**, and not part of deploy).

## Notifications
Reuses the existing persistent pipeline: `friend_request` and `friend_accepted` (already mapped to the `friendRequests` preference — push-only gating, complete in-app history). CloudEvent-ID-keyed for idempotency. URL allowlist gains `/friends` and `/user/{id}` in **both** `functions/notification-validation.js` and `lib/notifications.ts`, with matching tests.

## Account-deletion cleanup
`friend-requests` (both directions) and `friendships` (`userIds` array-contains) steps added to the ordered cleanup runner after `user-blocks`; `EXPECTED_STEP_ORDER` updated.

## Files changed
Rules/indexes/backend: `firestore.rules`, `firestore.indexes.json`, `lib/firestore.ts`, `lib/friends.ts` (new), `functions/index.js`, `functions/notification-validation.js`, `functions/account-deletion.js`, `lib/notifications.ts`, `scripts/backfill-display-name-lower.mjs` (new). UI: `app/friends.tsx` (new), `app/user/[userId].tsx` (new), `app/(tabs)/profile.tsx`, `app/_layout.tsx`. Analytics/tests: `docs/metrics.md`, `lib/analytics.ts`, `tests/firestore-rules.test.mjs`, `tests/notification-validation.test.mjs`, `tests/account-deletion.test.mjs`.

## Validation — all green
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (0 problems)
- `npm run rules:test` ✅ 109 passing
- `npm run test:notifications` ✅ 31 passing
- `npm run test:deletion` ✅ 19 passing
- `npm run test:map` ✅ 18 passing
- `npx expo export --platform web` ✅ (both new routes build)
- `node --check` on all changed Functions files + the new script ✅

## Remaining (reviewer / release)
Deploy the new composite indexes with the rules before enabling in prod. On-device QA of the Friends flows (send/accept/decline/cancel/remove, search, suggestions, block-severs-friendship) is still worth one pass. Optionally run the `displayNameLower` backfill once so legacy profiles are searchable via the canonical path.

**Not deployed, not merged** — opened for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)