### PR TITLE
fix: Sessions card footer overlap + abbreviation-friendly search

### DIFF
--- a/app/(tabs)/sessions.tsx
+++ b/app/(tabs)/sessions.tsx
@@ -33,6 +33,7 @@ import {
     type StudySession,
 } from '@/lib/firestore';
 import { getStudyLocationDisplayName } from '@/lib/catalog';
+import { matchesSessionSearch } from '@/lib/session-search';
 import type { User } from 'firebase/auth';
 
 type SessionListEntry = StudySession & {
@@ -77,16 +78,16 @@ export default function SessionsScreen() {
 
   // All filtering is client-side over the already-fetched list.
   const visibleSessions = useMemo(() => {
-    const normalizedQuery = searchQuery.trim().toLowerCase();
     const todayString = new Date().toDateString();
 
     return sessions.filter((session) => {
-      if (normalizedQuery) {
-        const searchText =
-          `${session.classId} ${session.title} ${session.locationName} ${session.hostName}`.toLowerCase();
-        if (!searchText.includes(normalizedQuery)) {
-          return false;
-        }
+      if (
+        !matchesSessionSearch(
+          [session.classId, session.title, session.locationName, session.hostName],
+          searchQuery
+        )
+      ) {
+        return false;
       }
       if (
         selectedDept &&

--- a/components/session-card.tsx
+++ b/components/session-card.tsx
@@ -318,24 +318,30 @@ export function SessionCard({
             {metaLine}
           </Text>
           <View style={styles.heroFooter}>
-            {attendeeNames && attendeeNames.length > 0 ? (
-              <AvatarStack names={attendeeNames} totalCount={going} size="sm" />
-            ) : hostFirstName ? (
-              <View style={styles.hostRow}>
-                <Avatar name={hostName ?? 'Student'} size="sm" verified />
-                <Text style={[TypeScale.meta, { color: palette.icon }]} numberOfLines={1}>
-                  Hosted by{' '}
-                  <Text style={{ color: palette.text, fontFamily: FontFamily.bodySemiBold }}>
-                    {hostFirstName}
+            <View style={styles.footerMeta}>
+              {attendeeNames && attendeeNames.length > 0 ? (
+                <AvatarStack names={attendeeNames} totalCount={going} size="sm" />
+              ) : hostFirstName ? (
+                <View style={styles.hostRow}>
+                  <Avatar name={hostName ?? 'Student'} size="sm" verified />
+                  <Text
+                    style={[TypeScale.meta, styles.hostText, { color: palette.icon }]}
+                    numberOfLines={1}>
+                    Hosted by{' '}
+                    <Text style={{ color: palette.text, fontFamily: FontFamily.bodySemiBold }}>
+                      {hostFirstName}
+                    </Text>
                   </Text>
-                </Text>
-              </View>
-            ) : (
-              <SeatPips going={going} capacity={capacity} />
-            )}
-            {joinAction ?? (
-              <Text style={[TypeScale.meta, { color: palette.icon }]}>{goingLabel}</Text>
-            )}
+                </View>
+              ) : (
+                <SeatPips going={going} capacity={capacity} />
+              )}
+            </View>
+            <View style={styles.actionSlot}>
+              {joinAction ?? (
+                <Text style={[TypeScale.meta, { color: palette.icon }]}>{goingLabel}</Text>
+              )}
+            </View>
           </View>
         </View>
       </Pressable>
@@ -380,13 +386,15 @@ export function SessionCard({
           {hostFirstName ? (
             <View style={styles.hostRow}>
               <Avatar name={hostName ?? 'Student'} size="xs" />
-              <Text style={[TypeScale.caption, { color: palette.icon }]} numberOfLines={1}>
+              <Text
+                style={[TypeScale.caption, styles.hostText, { color: palette.icon }]}
+                numberOfLines={1}>
                 Hosted by {hostFirstName}
               </Text>
             </View>
           ) : null}
         </View>
-        {joinAction}
+        {joinAction ? <View style={styles.actionSlot}>{joinAction}</View> : null}
       </View>
     </Pressable>
   );
@@ -458,13 +466,24 @@ const styles = StyleSheet.create({
     gap: Space.md,
   },
   peopleBlock: {
-    flexShrink: 1,
+    flex: 1,
+    minWidth: 0,
     gap: Space.xs + 1,
+  },
+  footerMeta: {
+    flex: 1,
+    minWidth: 0,
+  },
+  actionSlot: {
+    flexShrink: 0,
   },
   hostRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: Space.sm,
+  },
+  hostText: {
+    flexShrink: 1,
   },
   listRow: {
     flexDirection: 'row',
@@ -495,6 +514,7 @@ const styles = StyleSheet.create({
   },
   listBody: {
     flex: 1,
+    minWidth: 0,
     gap: 2,
   },
   compactTitle: {

--- a/components/ui/SeatPips.tsx
+++ b/components/ui/SeatPips.tsx
@@ -61,7 +61,7 @@ export function SeatPips({ going, capacity, showLabel = true, style }: SeatPipsP
         </View>
       ) : null}
       {showLabel ? (
-        <Text style={[TypeScale.caption, { color: palette.icon }]} numberOfLines={1}>
+        <Text style={[TypeScale.caption, styles.label, { color: palette.icon }]}>
           <Text style={[styles.count, { color: palette.text }]}>{countLabel}</Text>
           {suffix}
         </Text>
@@ -74,7 +74,13 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
+    // Long labels ("19 of 20 going · 1 spot left") wrap below the pips
+    // instead of overflowing into whatever sits beside the component.
+    flexWrap: 'wrap',
     gap: Space.sm,
+  },
+  label: {
+    flexShrink: 1,
   },
   pips: {
     flexDirection: 'row',

--- a/lib/session-search.d.ts
+++ b/lib/session-search.d.ts
@@ -1,0 +1,2 @@
+export function matchesSessionSearch(fields: string | string[], query: string): boolean;
+export function normalizeSearchValue(value: string): string;

--- a/lib/session-search.js
+++ b/lib/session-search.js
@@ -1,0 +1,45 @@
+/**
+ * Shared normalization for the Sessions-screen search (plain CommonJS +
+ * session-search.d.ts so both the app and the mocha tests can load it,
+ * same pattern as catalog-search.js / map-markers.js).
+ *
+ * Matching is comparison-only — displayed text is never normalized here.
+ *
+ * normalizeSearchValue lowercases and strips every non-alphanumeric
+ * character (spaces, hyphens, underscores, slashes, punctuation), so
+ * "stat240", "stat 240", "STAT-240" all become "stat240", and cross-listed
+ * codes like "ENTOM/ENVIR ST 201" match "entom-envir st 201",
+ * "entom envir st 201", or "entomenvirst201" without the exact formatting.
+ */
+function normalizeSearchValue(value) {
+  return value == null
+    ? ''
+    : String(value)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
+}
+
+/**
+ * True when the normalized query occurs in the normalized haystack built
+ * from the given fields. Fields are concatenated before matching — the
+ * pre-normalization behavior joined fields with spaces and did a substring
+ * check, so queries that spanned a boundary (e.g. "stat 240 study" across
+ * classId + title) keep matching.
+ */
+function matchesSessionSearch(fields, query) {
+  const normalizedQuery = normalizeSearchValue(query);
+
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  const fieldList = Array.isArray(fields) ? fields : [fields];
+  const haystack = fieldList.map(normalizeSearchValue).join('');
+
+  return haystack.includes(normalizedQuery);
+}
+
+module.exports = {
+  matchesSessionSearch,
+  normalizeSearchValue,
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:notifications": "mocha tests/notification-validation.test.mjs",
     "test:deletion": "mocha tests/account-deletion.test.mjs",
     "test:map": "mocha tests/map-markers.test.mjs",
-    "test:friends": "mocha tests/friend-suggestions.test.mjs"
+    "test:friends": "mocha tests/friend-suggestions.test.mjs",
+    "test:search": "mocha tests/session-search.test.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/cormorant-garamond": "^0.4.1",

--- a/tests/session-search.test.mjs
+++ b/tests/session-search.test.mjs
@@ -1,0 +1,94 @@
+import { strict as assert } from 'node:assert';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { matchesSessionSearch, normalizeSearchValue } = require('../lib/session-search.js');
+
+/** Fields in the order the Sessions screen passes them. */
+function sessionFields({
+  classId = 'STAT 240',
+  title = 'STAT 240 Study Session',
+  locationName = 'College Library',
+  hostName = 'Maya Patel',
+} = {}) {
+  return [classId, title, locationName, hostName];
+}
+
+describe('normalizeSearchValue', () => {
+  it('lowercases and strips whitespace, hyphens, and underscores', () => {
+    assert.equal(normalizeSearchValue('  STAT 240  '), 'stat240');
+    assert.equal(normalizeSearchValue('STAT-240'), 'stat240');
+    assert.equal(normalizeSearchValue('stat_240'), 'stat240');
+    assert.equal(normalizeSearchValue('StAt 240'), 'stat240');
+  });
+
+  it('strips slashes and other punctuation (cross-listed codes)', () => {
+    assert.equal(normalizeSearchValue('ENTOM/ENVIR ST 201'), 'entomenvirst201');
+    assert.equal(normalizeSearchValue('entom-envir st 201'), 'entomenvirst201');
+    assert.equal(normalizeSearchValue('★ College Library!'), 'collegelibrary');
+  });
+
+  it('returns an empty string for null-ish input', () => {
+    assert.equal(normalizeSearchValue(null), '');
+    assert.equal(normalizeSearchValue(undefined), '');
+    assert.equal(normalizeSearchValue(''), '');
+  });
+});
+
+describe('matchesSessionSearch', () => {
+  it('matches course codes with and without spaces', () => {
+    assert.equal(matchesSessionSearch(sessionFields(), 'stat 240'), true);
+    assert.equal(matchesSessionSearch(sessionFields(), 'stat240'), true);
+    assert.equal(matchesSessionSearch(sessionFields({ classId: 'CS 300' }), 'cs300'), true);
+    assert.equal(matchesSessionSearch(sessionFields({ classId: 'MATH 340' }), 'math340'), true);
+    assert.equal(matchesSessionSearch(sessionFields({ classId: 'ECE 252' }), 'ece252'), true);
+  });
+
+  it('matches hyphens, underscores, and mixed case', () => {
+    assert.equal(matchesSessionSearch(sessionFields({ classId: 'CS 300' }), 'CS-300'), true);
+    assert.equal(matchesSessionSearch(sessionFields(), 'stat_240'), true);
+    assert.equal(matchesSessionSearch(sessionFields(), 'StAt240'), true);
+  });
+
+  it('matches multi-word subjects compact or spaced', () => {
+    const fields = sessionFields({ classId: 'COMP SCI 400', title: 'PS4 grind' });
+
+    assert.equal(matchesSessionSearch(fields, 'comp sci 400'), true);
+    assert.equal(matchesSessionSearch(fields, 'compsci400'), true);
+    assert.equal(matchesSessionSearch(fields, 'comp-sci 400'), true);
+  });
+
+  it('matches cross-listed courses without exact slash formatting', () => {
+    const fields = sessionFields({ classId: 'ENTOM/ENVIR ST 201', title: 'Exam review' });
+
+    assert.equal(matchesSessionSearch(fields, 'entom-envir st 201'), true);
+    assert.equal(matchesSessionSearch(fields, 'entom envir st 201'), true);
+    assert.equal(matchesSessionSearch(fields, 'entomenvirst201'), true);
+    assert.equal(matchesSessionSearch(fields, 'envir st'), true);
+  });
+
+  it('still matches titles, locations, and host names', () => {
+    assert.equal(matchesSessionSearch(sessionFields(), 'study session'), true);
+    assert.equal(matchesSessionSearch(sessionFields(), 'college library'), true);
+    assert.equal(matchesSessionSearch(sessionFields(), 'collegelibrary'), true);
+    assert.equal(matchesSessionSearch(sessionFields(), 'maya'), true);
+    assert.equal(matchesSessionSearch(sessionFields(), 'Maya P'), true);
+  });
+
+  it('keeps matching queries that span a field boundary, as before', () => {
+    // Pre-helper behavior substring-matched the space-joined fields, so
+    // "240 study" (classId into title) must keep working.
+    assert.equal(matchesSessionSearch(sessionFields({ title: 'Study Session' }), '240 study'), true);
+  });
+
+  it('matches everything on an empty or whitespace-only query', () => {
+    assert.equal(matchesSessionSearch(sessionFields(), ''), true);
+    assert.equal(matchesSessionSearch(sessionFields(), '   '), true);
+  });
+
+  it('rejects queries that appear in no field', () => {
+    assert.equal(matchesSessionSearch(sessionFields(), 'chem 103'), false);
+    assert.equal(matchesSessionSearch(sessionFields(), 'jordan'), false);
+    assert.equal(matchesSessionSearch(sessionFields(), 'stat241'), false);
+  });
+});


### PR DESCRIPTION
## Summary

Two Sessions-screen UX fixes, nothing else.

### 1. Join button can no longer overlap capacity metadata

The session-card footer previously relied on `flexShrink: 1` on the metadata block, while the texts inside `SeatPips` and the host row had no shrink constraints (RN defaults `flexShrink` to 0), so long capacity text ("1 of 8 going · 7 spots left") could run under the Join button.

New layout, applied to **full**, **hero**, and **list** variants:
- metadata container: `flex: 1` + `minWidth: 0`
- Join/Going button wrapped in a `flexShrink: 0` slot — stable width, never squeezed
- `SeatPips` row is `flexWrap: 'wrap'` and its label has `flexShrink: 1`, so long labels wrap below the pips instead of overflowing
- host-name text gets `flexShrink: 1` so it truncates with an ellipsis
- list variant body gets `minWidth: 0`

No font shrinking, no hardcoded margins. All `SessionCard` call sites covered (Sessions tab, create-session preview, dev design gallery — SeatPips is used nowhere else).

### 2. Search understands student abbreviations

New shared helper `lib/session-search.js` (+ `.d.ts`), same CommonJS-plus-declaration pattern as `lib/catalog-search.js` so mocha tests load it directly:
- `normalizeSearchValue`: lowercase + strip **every** non-alphanumeric character (spaces, hyphens, underscores, slashes, punctuation)
- `matchesSessionSearch(fields, query)`: normalizes both sides; fields are concatenated so queries spanning classId→title (e.g. "stat 240 study") keep matching as before
- Sessions screen now matches via the helper over `[classId, title, locationName, hostName]`
- **Displayed text is unchanged** — normalization is comparison-only
- Cross-listed courses: stripping slashes means `entom-envir st 201`, `entom envir st 201`, and `entomenvirst201` all match `ENTOM/ENVIR ST 201`

Now matching: `stat240`, `stat 240`, `STAT-240`, `stat_240`, `cs300`, `CS-300`, `math340`, `ece252`, `comp sci 400`, `compsci400`. Title/location/host searches behave as before; dept chips, Today, and My/All classes filters untouched.

## Tests

`tests/session-search.test.mjs` (`npm run test:search`) — 11 cases: normalization (case/whitespace/hyphen/underscore/slash/null), every abbreviation example above, title/location/host matching, boundary-spanning query back-compat, empty-query passthrough, negative cases.

## Manual QA (iPhone 16e simulator, Expo Go, temp harness with static data)

At full width **and** in a 320pt container (iPhone SE width):
- 1 of 8 going · 7 spots left + Join — no overlap
- 19 of 20 going · 1 spot left + Join — no overlap
- 120 going (unlimited legacy) + ✓ Going — no overlap
- Long host name ("Alexandra Konstantinopoulos-Vandermeer") — truncates, button intact
- Full: badge + hidden-button and disabled-Join variants — label wraps below pips cleanly
- Hero and list variants — long host truncates / body truncates, action side intact
- Search matcher run in-app against sample sessions: all abbreviation, cross-listed, location, and host queries matched; `zzz` matched nothing

## Validation

- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npm run test:map` 18 passing ✅
- `npm run test:friends` 22 passing ✅
- `npm run rules:test` 122 passing ✅
- `npm run test:notifications` 31 passing ✅
- `npm run test:deletion` 19 passing ✅
- `npm run test:search` 11 passing ✅
- `npx expo export --platform web` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)