### PR TITLE
Add Studi UI consistency foundation

### DIFF
--- a/components/dev/design-system-preview.tsx
+++ b/components/dev/design-system-preview.tsx
@@ -1,23 +1,30 @@
 import { Timestamp } from 'firebase/firestore';
+import { useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { SessionCard } from '@/components/session-card';
 import { BadgeChip } from '@/components/ui/BadgeChip';
 import { Button } from '@/components/ui/Button';
+import { Card, GroupedList, GroupedListRow } from '@/components/ui/Card';
 import { CourseChip } from '@/components/ui/CourseChip';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { LoadingState } from '@/components/ui/LoadingState';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
+import { SearchBar } from '@/components/ui/SearchBar';
 import { SeatPips } from '@/components/ui/SeatPips';
 import { Colors, Space, TypeScale } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
 /**
- * Dev-only gallery of the Direction D primitives. Not a route — to view it,
+ * Dev-only gallery of the Studi primitives. Not a route — to view it,
  * temporarily render <DesignSystemPreview /> from any screen while
  * developing. Uses static local data only; no Firestore reads.
  */
 export function DesignSystemPreview() {
   const colorScheme = useColorScheme() ?? 'light';
   const palette = Colors[colorScheme];
+  const [searchValue, setSearchValue] = useState('');
 
   const inFortyFiveMin = Timestamp.fromDate(new Date(Date.now() + 45 * 60 * 1000));
   const tonight = Timestamp.fromDate(new Date(Date.now() + 6 * 60 * 60 * 1000));
@@ -37,7 +44,19 @@ export function DesignSystemPreview() {
     <ScrollView
       style={{ backgroundColor: palette.background }}
       contentContainerStyle={styles.content}>
-      <Text style={[TypeScale.title, { color: palette.text }]}>Direction D</Text>
+      <ScreenHeader
+        title="Studi foundations"
+        subtitle="Shared building blocks for consistent product screens."
+        action={<Button label="Action" variant="ghost" size="sm" onPress={() => {}} />}
+      />
+
+      <Text style={[TypeScale.heading, { color: palette.text }]}>Search</Text>
+      <SearchBar
+        accessibilityLabel="Search design system examples"
+        onChangeText={setSearchValue}
+        placeholder="Search sessions"
+        value={searchValue}
+      />
 
       <Text style={[TypeScale.heading, { color: palette.text }]}>Buttons</Text>
       <View style={styles.row}>
@@ -63,6 +82,29 @@ export function DesignSystemPreview() {
       <SeatPips going={5} capacity={5} />
       <SeatPips going={4} />
       <SeatPips going={12} capacity={20} />
+
+      <Text style={[TypeScale.heading, { color: palette.text }]}>Surfaces</Text>
+      <Card>
+        <Text style={[TypeScale.bodyStrong, { color: palette.primaryText }]}>Standard card</Text>
+        <Text style={[TypeScale.body, { color: palette.secondaryText }]}>
+          A small composable surface with standard padding.
+        </Text>
+      </Card>
+      <GroupedList>
+        <GroupedListRow>
+          <Text style={[TypeScale.body, { color: palette.primaryText }]}>First grouped row</Text>
+        </GroupedListRow>
+        <GroupedListRow>
+          <Text style={[TypeScale.body, { color: palette.primaryText }]}>Second grouped row</Text>
+        </GroupedListRow>
+      </GroupedList>
+
+      <Text style={[TypeScale.heading, { color: palette.text }]}>Feedback states</Text>
+      <LoadingState title="Loading sessions" body="This usually takes a moment." />
+      <ErrorState
+        body="Check your connection and try again."
+        onRetry={() => {}}
+      />
 
       <Text style={[TypeScale.heading, { color: palette.text }]}>Session cards</Text>
       <SessionCard

--- a/components/dev/design-system-preview.tsx
+++ b/components/dev/design-system-preview.tsx
@@ -1,6 +1,6 @@
 import { Timestamp } from 'firebase/firestore';
 import { useState } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { SessionCard } from '@/components/session-card';
 import { BadgeChip } from '@/components/ui/BadgeChip';
@@ -9,6 +9,7 @@ import { Card, GroupedList, GroupedListRow } from '@/components/ui/Card';
 import { CourseChip } from '@/components/ui/CourseChip';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
+import { IconSymbol } from '@/components/ui/icon-symbol';
 import { LoadingState } from '@/components/ui/LoadingState';
 import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { SearchBar } from '@/components/ui/SearchBar';
@@ -48,6 +49,44 @@ export function DesignSystemPreview() {
         title="Studi foundations"
         subtitle="Shared building blocks for consistent product screens."
         action={<Button label="Action" variant="ghost" size="sm" onPress={() => {}} />}
+      />
+
+      <Text style={[TypeScale.heading, { color: palette.text }]}>Header layouts</Text>
+      <ScreenHeader
+        align="center"
+        title="Centered title"
+        subtitle="No action"
+      />
+      <ScreenHeader
+        action={
+          <Pressable
+            accessibilityLabel="Close preview"
+            accessibilityRole="button"
+            hitSlop={8}
+            onPress={() => {}}
+            style={styles.iconAction}>
+            <IconSymbol
+              color={palette.secondaryText}
+              name="xmark.circle.fill"
+              size={24}
+            />
+          </Pressable>
+        }
+        align="center"
+        title="Centered title"
+        subtitle="Icon action"
+      />
+      <ScreenHeader
+        action={<Button label="Done" variant="ghost" size="sm" onPress={() => {}} />}
+        align="center"
+        title="Centered title"
+        subtitle="Wider text action"
+      />
+      <ScreenHeader
+        action={<Button label="Done" variant="ghost" size="sm" onPress={() => {}} />}
+        align="center"
+        title="A deliberately long centered screen title that wraps safely"
+        subtitle="Increase the system text size to inspect Dynamic Type wrapping."
       />
 
       <Text style={[TypeScale.heading, { color: palette.text }]}>Search</Text>
@@ -91,10 +130,10 @@ export function DesignSystemPreview() {
         </Text>
       </Card>
       <GroupedList>
-        <GroupedListRow>
+        <GroupedListRow key="first-row">
           <Text style={[TypeScale.body, { color: palette.primaryText }]}>First grouped row</Text>
         </GroupedListRow>
-        <GroupedListRow>
+        <GroupedListRow key="second-row">
           <Text style={[TypeScale.body, { color: palette.primaryText }]}>Second grouped row</Text>
         </GroupedListRow>
       </GroupedList>
@@ -171,5 +210,11 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     gap: Space.sm,
     alignItems: 'center',
+  },
+  iconAction: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+    minWidth: 44,
   },
 });

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,4 +1,4 @@
-import { Children, Fragment, type ReactNode } from 'react';
+import { Children, Fragment, isValidElement, type ReactNode } from 'react';
 import {
   StyleSheet,
   View,
@@ -60,14 +60,18 @@ export function GroupedList({
 
   return (
     <Card tone={tone} bordered={bordered} style={[styles.groupedList, style]}>
-      {rows.map((row, index) => (
-        <Fragment key={index}>
-          {index > 0 ? (
-            <View accessibilityElementsHidden style={[styles.separator, { backgroundColor: palette.border }]} />
-          ) : null}
-          {row}
-        </Fragment>
-      ))}
+      {rows.map((row, index) => {
+        const rowKey = isValidElement(row) && row.key != null ? row.key : `row-${index}`;
+
+        return (
+          <Fragment key={rowKey}>
+            {index > 0 ? (
+              <View accessibilityElementsHidden style={[styles.separator, { backgroundColor: palette.border }]} />
+            ) : null}
+            {row}
+          </Fragment>
+        );
+      })}
     </Card>
   );
 }

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,104 @@
+import { Children, Fragment, type ReactNode } from 'react';
+import {
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewProps,
+  type ViewStyle,
+} from 'react-native';
+
+import { Colors, Radius, Space } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export type CardProps = ViewProps & {
+  tone?: 'surface' | 'muted';
+  bordered?: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function Card({
+  tone = 'surface',
+  bordered = true,
+  style,
+  ...viewProps
+}: CardProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+
+  return (
+    <View
+      {...viewProps}
+      style={[
+        styles.card,
+        {
+          backgroundColor: tone === 'muted' ? palette.mutedSurface : palette.surface,
+          borderColor: palette.border,
+          borderWidth: bordered ? StyleSheet.hairlineWidth * 2 : 0,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+export type GroupedListProps = {
+  children: ReactNode;
+  tone?: CardProps['tone'];
+  bordered?: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function GroupedList({
+  children,
+  tone = 'surface',
+  bordered = true,
+  style,
+}: GroupedListProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const rows = Children.toArray(children);
+
+  return (
+    <Card tone={tone} bordered={bordered} style={[styles.groupedList, style]}>
+      {rows.map((row, index) => (
+        <Fragment key={index}>
+          {index > 0 ? (
+            <View accessibilityElementsHidden style={[styles.separator, { backgroundColor: palette.border }]} />
+          ) : null}
+          {row}
+        </Fragment>
+      ))}
+    </Card>
+  );
+}
+
+export type GroupedListRowProps = ViewProps & {
+  style?: StyleProp<ViewStyle>;
+};
+
+export function GroupedListRow({ style, ...viewProps }: GroupedListRowProps) {
+  return <View {...viewProps} style={[styles.row, style]} />;
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: Radius.card,
+    padding: Space.lg + 4,
+  },
+  groupedList: {
+    overflow: 'hidden',
+    paddingHorizontal: Space.lg + 4,
+    paddingVertical: 0,
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+  },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: Space.md,
+    justifyContent: 'space-between',
+    minHeight: 56,
+    paddingVertical: Space.sm,
+  },
+});

--- a/components/ui/ErrorState.tsx
+++ b/components/ui/ErrorState.tsx
@@ -1,0 +1,71 @@
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+
+import { Button } from '@/components/ui/Button';
+import { Colors, Space, TypeScale } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export type ErrorStateProps = {
+  title?: string;
+  body?: string;
+  onRetry?: () => void;
+  retryLabel?: string;
+  mode?: 'compact' | 'screen';
+  style?: StyleProp<ViewStyle>;
+};
+
+export function ErrorState({
+  title = 'Something went off-script.',
+  body,
+  onRetry,
+  retryLabel = 'Try again',
+  mode = 'compact',
+  style,
+}: ErrorStateProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+
+  return (
+    <View
+      accessibilityLiveRegion="polite"
+      accessibilityRole="alert"
+      style={[styles.container, mode === 'screen' && styles.screen, style]}>
+      <View style={styles.copy}>
+        {title ? (
+          <Text style={[TypeScale.heading, styles.text, { color: palette.primaryText }]}>
+            {title}
+          </Text>
+        ) : null}
+        {body ? (
+          <Text style={[TypeScale.body, styles.text, { color: palette.secondaryText }]}>
+            {body}
+          </Text>
+        ) : null}
+      </View>
+      {onRetry ? (
+        <Button label={retryLabel} variant="secondary" onPress={onRetry} />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: Space.lg,
+    justifyContent: 'center',
+    paddingHorizontal: Space.xl,
+    paddingVertical: Space.xxl,
+  },
+  screen: {
+    flex: 1,
+    minHeight: 240,
+  },
+  copy: {
+    alignItems: 'center',
+    gap: Space.xs,
+    maxWidth: 320,
+  },
+  text: {
+    textAlign: 'center',
+  },
+});

--- a/components/ui/LoadingState.tsx
+++ b/components/ui/LoadingState.tsx
@@ -1,0 +1,65 @@
+import { ActivityIndicator, StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+
+import { Colors, Space, TypeScale } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export type LoadingStateProps = {
+  title?: string;
+  body?: string;
+  mode?: 'compact' | 'screen';
+  style?: StyleProp<ViewStyle>;
+};
+
+export function LoadingState({
+  title = 'Loading',
+  body,
+  mode = 'compact',
+  style,
+}: LoadingStateProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+
+  return (
+    <View
+      accessibilityLabel={[title, body].filter(Boolean).join('. ')}
+      accessibilityLiveRegion="polite"
+      accessibilityRole="progressbar"
+      style={[styles.container, mode === 'screen' && styles.screen, style]}>
+      <ActivityIndicator color={palette.accent} />
+      <View style={styles.copy}>
+        {title ? (
+          <Text style={[TypeScale.bodyStrong, styles.text, { color: palette.primaryText }]}>
+            {title}
+          </Text>
+        ) : null}
+        {body ? (
+          <Text style={[TypeScale.body, styles.text, { color: palette.secondaryText }]}>
+            {body}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: Space.md,
+    justifyContent: 'center',
+    paddingHorizontal: Space.xl,
+    paddingVertical: Space.xxl,
+  },
+  screen: {
+    flex: 1,
+    minHeight: 240,
+  },
+  copy: {
+    alignItems: 'center',
+    gap: Space.xs,
+    maxWidth: 320,
+  },
+  text: {
+    textAlign: 'center',
+  },
+});

--- a/components/ui/ScreenHeader.tsx
+++ b/components/ui/ScreenHeader.tsx
@@ -1,10 +1,10 @@
-import { type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import {
   StyleSheet,
   Text,
   View,
+  type LayoutChangeEvent,
   type StyleProp,
-  type TextStyle,
   type ViewStyle,
 } from 'react-native';
 
@@ -18,7 +18,6 @@ export type ScreenHeaderProps = {
   action?: ReactNode;
   align?: 'start' | 'center';
   style?: StyleProp<ViewStyle>;
-  titleStyle?: StyleProp<TextStyle>;
 };
 
 /**
@@ -32,15 +31,30 @@ export function ScreenHeader({
   action,
   align = 'start',
   style,
-  titleStyle,
 }: ScreenHeaderProps) {
   const colorScheme = useColorScheme() ?? 'light';
   const palette = Colors[colorScheme];
   const centered = align === 'center';
+  const [actionWidth, setActionWidth] = useState(0);
+
+  function handleActionLayout(event: LayoutChangeEvent) {
+    if (!centered) {
+      return;
+    }
+
+    setActionWidth(event.nativeEvent.layout.width);
+  }
 
   return (
     <View style={[styles.container, centered && styles.centered, style]}>
       <View style={[styles.headingRow, centered && styles.centeredHeadingRow]}>
+        {centered && action ? (
+          <View
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            style={[styles.actionMirror, { width: actionWidth }]}
+          />
+        ) : null}
         <View style={[styles.copy, centered && styles.centeredCopy]}>
           <Text
             accessibilityRole="header"
@@ -49,7 +63,6 @@ export function ScreenHeader({
               styles.title,
               centered && styles.centeredText,
               { color: palette.primaryText },
-              titleStyle,
             ]}>
             {title}
           </Text>
@@ -77,7 +90,11 @@ export function ScreenHeader({
             </Text>
           ) : null}
         </View>
-        {action ? <View style={styles.action}>{action}</View> : null}
+        {action ? (
+          <View onLayout={centered ? handleActionLayout : undefined} style={styles.action}>
+            {action}
+          </View>
+        ) : null}
       </View>
     </View>
   );
@@ -100,6 +117,9 @@ const styles = StyleSheet.create({
   },
   centeredHeadingRow: {
     justifyContent: 'center',
+  },
+  actionMirror: {
+    flexShrink: 0,
   },
   copy: {
     flex: 1,

--- a/components/ui/ScreenHeader.tsx
+++ b/components/ui/ScreenHeader.tsx
@@ -1,0 +1,125 @@
+import { type ReactNode } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
+
+import { Colors, Space, TypeScale } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export type ScreenHeaderProps = {
+  title: string;
+  subtitle?: string;
+  status?: string;
+  action?: ReactNode;
+  align?: 'start' | 'center';
+  style?: StyleProp<ViewStyle>;
+  titleStyle?: StyleProp<TextStyle>;
+};
+
+/**
+ * Canonical Studi top-level header. Titles always use the shared serif role;
+ * supporting copy and actions remain compact sans-serif utility UI.
+ */
+export function ScreenHeader({
+  title,
+  subtitle,
+  status,
+  action,
+  align = 'start',
+  style,
+  titleStyle,
+}: ScreenHeaderProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const centered = align === 'center';
+
+  return (
+    <View style={[styles.container, centered && styles.centered, style]}>
+      <View style={[styles.headingRow, centered && styles.centeredHeadingRow]}>
+        <View style={[styles.copy, centered && styles.centeredCopy]}>
+          <Text
+            accessibilityRole="header"
+            style={[
+              TypeScale.screenTitle,
+              styles.title,
+              centered && styles.centeredText,
+              { color: palette.primaryText },
+              titleStyle,
+            ]}>
+            {title}
+          </Text>
+          {subtitle ? (
+            <Text
+              style={[
+                TypeScale.body,
+                styles.supportingText,
+                centered && styles.centeredText,
+                { color: palette.secondaryText },
+              ]}>
+              {subtitle}
+            </Text>
+          ) : null}
+          {status ? (
+            <Text
+              accessibilityLiveRegion="polite"
+              style={[
+                TypeScale.meta,
+                styles.supportingText,
+                centered && styles.centeredText,
+                { color: palette.secondaryText },
+              ]}>
+              {status}
+            </Text>
+          ) : null}
+        </View>
+        {action ? <View style={styles.action}>{action}</View> : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: Space.xs,
+    width: '100%',
+  },
+  centered: {
+    alignItems: 'center',
+  },
+  headingRow: {
+    alignItems: 'flex-start',
+    flexDirection: 'row',
+    gap: Space.md,
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+  centeredHeadingRow: {
+    justifyContent: 'center',
+  },
+  copy: {
+    flex: 1,
+    gap: Space.xs,
+    minWidth: 0,
+  },
+  centeredCopy: {
+    alignItems: 'center',
+  },
+  title: {
+    flexShrink: 1,
+  },
+  centeredText: {
+    textAlign: 'center',
+  },
+  supportingText: {
+    flexShrink: 1,
+  },
+  action: {
+    flexShrink: 0,
+    paddingTop: Space.xs,
+  },
+});

--- a/components/ui/SearchBar.tsx
+++ b/components/ui/SearchBar.tsx
@@ -1,0 +1,116 @@
+import {
+  Pressable,
+  StyleSheet,
+  TextInput,
+  View,
+  type StyleProp,
+  type TextInputProps,
+  type ViewStyle,
+} from 'react-native';
+
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { Colors, FontFamily, Radius, Space } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export type SearchBarProps = Omit<
+  TextInputProps,
+  'onChangeText' | 'placeholder' | 'style' | 'value'
+> & {
+  value: string;
+  onChangeText: (value: string) => void;
+  placeholder: string;
+  accessibilityLabel?: string;
+  clearAccessibilityLabel?: string;
+  showSearchIcon?: boolean;
+  onClear?: () => void;
+  containerStyle?: StyleProp<ViewStyle>;
+};
+
+export function SearchBar({
+  value,
+  onChangeText,
+  placeholder,
+  accessibilityLabel = 'Search',
+  clearAccessibilityLabel = 'Clear search',
+  showSearchIcon = true,
+  onClear,
+  containerStyle,
+  editable = true,
+  ...inputProps
+}: SearchBarProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const palette = Colors[colorScheme];
+  const canClear = editable && value.length > 0;
+
+  function handleClear() {
+    onChangeText('');
+    onClear?.();
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: palette.mutedSurface,
+          borderColor: palette.border,
+          opacity: editable ? 1 : 0.6,
+        },
+        containerStyle,
+      ]}>
+      {showSearchIcon ? (
+        <IconSymbol name="magnifyingglass" size={20} color={palette.secondaryText} />
+      ) : null}
+      <TextInput
+        accessibilityLabel={accessibilityLabel}
+        autoCapitalize="none"
+        autoCorrect={false}
+        editable={editable}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={palette.secondaryText}
+        returnKeyType="search"
+        value={value}
+        {...inputProps}
+        style={[styles.input, { color: palette.primaryText }]}
+      />
+      {canClear ? (
+        <Pressable
+          accessibilityLabel={clearAccessibilityLabel}
+          accessibilityRole="button"
+          hitSlop={8}
+          onPress={handleClear}
+          style={({ pressed }) => [styles.clear, { opacity: pressed ? 0.6 : 1 }]}>
+          <IconSymbol name="xmark.circle.fill" size={20} color={palette.secondaryText} />
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    borderRadius: Radius.pill,
+    borderWidth: StyleSheet.hairlineWidth * 2,
+    flexDirection: 'row',
+    gap: Space.sm,
+    minHeight: 48,
+    paddingHorizontal: Space.lg,
+    width: '100%',
+  },
+  input: {
+    flex: 1,
+    fontFamily: FontFamily.body,
+    fontSize: 15,
+    lineHeight: 20,
+    minWidth: 0,
+    paddingVertical: Space.sm,
+  },
+  clear: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 32,
+    minWidth: 32,
+  },
+});

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -24,6 +24,8 @@ const MAPPING = {
   'chevron.right': 'chevron-right',
   eye: 'visibility',
   'eye.slash': 'visibility-off',
+  magnifyingglass: 'search',
+  'xmark.circle.fill': 'cancel',
 } as IconMapping;
 
 /**

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -5,9 +5,9 @@
  * (Kgan3039/studi-your-campus-study-hub → docs/studi-expo-handoff.md §1).
  * This supersedes the earlier Sora/dog-ear Direction D tokens.
  *
- * Serif (Cormorant Garamond) is reserved for editorial hero moments:
- * onboarding, page heroes, session-detail title, profile name, empty-state
- * headlines. Utility surfaces (Messages, settings-like screens) are sans-only.
+ * Serif (Cormorant Garamond) is reserved for major screen titles and selected
+ * editorial headings. Body copy, controls, list content, metadata, tabs, form
+ * labels, and chat content remain sans-serif.
  */
 
 import { Platform } from 'react-native';
@@ -85,6 +85,15 @@ export const Colors = {
     badge: Brand.surfaceAlt,
     border: 'rgba(31, 27, 22, 0.08)',
     outline: 'rgba(31, 27, 22, 0.16)',
+    // Semantic aliases for shared UI. Existing keys remain supported while
+    // product screens migrate incrementally.
+    accent: accentLight,
+    primaryText: Brand.text,
+    secondaryText: Brand.textMuted,
+    mutedSurface: Brand.surfaceAlt,
+    destructive: accentLight,
+    success: Brand.success,
+    warning: Brand.warning,
   },
   // Hand-converted from the handoff's .dark oklch values (src/styles.css).
   dark: {
@@ -100,6 +109,13 @@ export const Colors = {
     badge: '#2E2620',
     border: 'rgba(255, 255, 255, 0.10)',
     outline: 'rgba(255, 255, 255, 0.14)',
+    accent: accentDark,
+    primaryText: '#F7F2E9',
+    secondaryText: '#A89F92',
+    mutedSurface: '#2E2620',
+    destructive: accentDark,
+    success: '#8FBF9F',
+    warning: '#D9A45C',
   },
 };
 
@@ -120,15 +136,19 @@ export const FontFamily = {
  * Type scale (handoff §1.3). Legacy keys (title, heading, label, caption)
  * remain for existing screens; handoff-named roles added alongside.
  */
+const screenTitleType = {
+  fontFamily: FontFamily.serifItalic,
+  fontSize: 28,
+  lineHeight: 34,
+} as const;
+
 export const TypeScale = {
   /** Onboarding hero, brand moments — serif italic. */
   display: { fontFamily: FontFamily.serifItalic, fontSize: 34, lineHeight: 40 },
-  /**
-   * Page hero / h1. The Lovable boards render screen titles (Sessions,
-   * Study spots, create-session questions) in serif *italic* — the board is
-   * the pixel source of truth (handoff §0), so this is italic, not upright.
-   */
-  title: { fontFamily: FontFamily.serifItalic, fontSize: 28, lineHeight: 34 },
+  /** Legacy top-level title alias; kept compatible during migration. */
+  title: screenTitleType,
+  /** Canonical top-level screen title. Every major route uses this role. */
+  screenTitle: screenTitleType,
   /** Section titles / h2 — sans. */
   h2: { fontFamily: FontFamily.bodySemiBold, fontSize: 22, lineHeight: 28 },
   /** Card titles / h3 — sans. (Legacy name "heading".) */


### PR DESCRIPTION
## Summary

- Add semantic aliases to the existing theme without renaming compatible tokens
- Add shared `ScreenHeader`, `SearchBar`, `Card`, `GroupedList`, `LoadingState`, and `ErrorState` primitives
- Establish one canonical serif treatment for every top-level screen title
- Exercise the new APIs in the internal design-system preview

## Scope

Foundation only.

This PR does **not**:
- migrate product screens
- change navigation
- modify business logic
- add dependencies
- modify the lockfile

A generic `Screen` primitive is intentionally deferred because existing screens have different scrolling, keyboard, safe-area, and sticky-action requirements.

## Validation

- ✅ TypeScript
- ✅ Lint
- ✅ Search (11)
- ✅ Map (18)
- ✅ Friends (22)
- ✅ Rules (122)
- ✅ Notifications (31)
- ✅ Deletion (19)
- ✅ Expo web export (35 routes)

## Next PR

Migrate the Messages screen to the shared design-system primitives while preserving existing behavior.